### PR TITLE
fix: make iOS widget background transparent

### DIFF
--- a/targets/widget/widgets.swift
+++ b/targets/widget/widgets.swift
@@ -205,68 +205,56 @@ struct UpcomingBookingsWidgetEntryView: View {
     @Environment(\.widgetFamily) var family
     
     var body: some View {
-        ZStack {
-            // Subtle gradient background
-            LinearGradient(
-                gradient: Gradient(colors: [
-                    Color.accentColor.opacity(0.05),
-                    Color.clear
-                ]),
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack {
+                Image(systemName: "calendar")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.accentColor)
+                Text("Upcoming")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.primary)
+                Spacer()
+            }
+            .padding(.bottom, 8)
             
-            VStack(alignment: .leading, spacing: 0) {
-                // Header
-                HStack {
-                    Image(systemName: "calendar")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundColor(.accentColor)
-                    Text("Upcoming")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundColor(.primary)
-                    Spacer()
+            if entry.bookings.isEmpty {
+                Spacer()
+                VStack(spacing: 4) {
+                    Image(systemName: "calendar.badge.checkmark")
+                        .font(.system(size: 24))
+                        .foregroundColor(.secondary)
+                    Text("No upcoming bookings")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
                 }
-                .padding(.bottom, 8)
-                
-                if entry.bookings.isEmpty {
-                    Spacer()
-                    VStack(spacing: 4) {
-                        Image(systemName: "calendar.badge.checkmark")
-                            .font(.system(size: 24))
-                            .foregroundColor(.secondary)
-                        Text("No upcoming bookings")
-                            .font(.system(size: 12))
-                            .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity)
+                Spacer()
+            } else {
+                if family == .systemMedium {
+                    // Horizontal layout for medium widget
+                    HStack(alignment: .top, spacing: 12) {
+                        ForEach(entry.bookings.prefix(2)) { booking in
+                            MediumBookingCard(booking: booking)
+                        }
                     }
-                    .frame(maxWidth: .infinity)
-                    Spacer()
+                    Spacer(minLength: 0)
                 } else {
-                    if family == .systemMedium {
-                        // Horizontal layout for medium widget
-                        HStack(alignment: .top, spacing: 12) {
-                            ForEach(entry.bookings.prefix(2)) { booking in
-                                MediumBookingCard(booking: booking)
-                            }
+                    // Vertical layout for small and large widgets
+                    let maxBookings = family == .systemSmall ? 2 : 6
+                    ForEach(entry.bookings.prefix(maxBookings)) { booking in
+                        Link(destination: URL(string: "calcom://(tabs)/(bookings)/booking-detail?uid=\(booking.id)")!) {
+                            BookingRowView(booking: booking)
                         }
-                        Spacer(minLength: 0)
-                    } else {
-                        // Vertical layout for small and large widgets
-                        let maxBookings = family == .systemSmall ? 2 : 6
-                        ForEach(entry.bookings.prefix(maxBookings)) { booking in
-                            Link(destination: URL(string: "calcom://(tabs)/(bookings)/booking-detail?uid=\(booking.id)")!) {
-                                BookingRowView(booking: booking)
-                            }
-                            if booking.id != entry.bookings.prefix(maxBookings).last?.id {
-                                Divider()
-                            }
+                        if booking.id != entry.bookings.prefix(maxBookings).last?.id {
+                            Divider()
                         }
-                        Spacer(minLength: 0)
                     }
+                    Spacer(minLength: 0)
                 }
             }
-            .padding(12)
         }
+        .padding(12)
         .widgetURL(URL(string: "calcom://(tabs)/(bookings)"))
     }
 }
@@ -389,7 +377,7 @@ struct UpcomingBookingsWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: Provider()) { entry in
             UpcomingBookingsWidgetEntryView(entry: entry)
-                .containerBackground(.fill.tertiary, for: .widget)
+                .containerBackground(.clear, for: .widget)
         }
         .configurationDisplayName("Upcoming Bookings")
         .description("View your upcoming Cal.com bookings at a glance.")


### PR DESCRIPTION
## Summary

Makes the iOS home screen widget background transparent by:
- Removing the `ZStack` + `LinearGradient` overlay (was `Color.accentColor.opacity(0.05)` → `Color.clear`)
- Changing `.containerBackground(.fill.tertiary, for: .widget)` → `.containerBackground(.clear, for: .widget)`

Only `targets/widget/widgets.swift` is modified. No Android or web changes.

## Review & Testing Checklist for Human

- [ ] **Test on an iOS device or simulator** — these changes cannot be verified without building the widget. Confirm the widget renders with a transparent background across all three supported sizes (small, medium, large).
- [ ] **Check text readability on varied wallpapers** — with no background fill, widget text (`.primary`, `.secondary`, `.accentColor`) relies entirely on the system's vibrancy/contrast. Verify content is legible on both light and dark wallpapers.
- [ ] **Verify the empty state** ("No upcoming bookings") is still visible without the gradient behind it.

### Notes
- The indentation changes in the diff are from un-nesting the `VStack` out of the removed `ZStack` — no logic changes beyond the background removal.
- Requested by: @PeerRich
- [Link to Devin run](https://app.devin.ai/sessions/3f65313fd333476ca14ce14724e5e11f)