### PR TITLE
fix: ensure Continue button text is visible in dark mode (AlertDialog)

### DIFF
--- a/app/(tabs)/(event-types)/index.tsx
+++ b/app/(tabs)/(event-types)/index.tsx
@@ -696,7 +696,7 @@ export default function EventTypes() {
                 <AlertDialogText>Cancel</AlertDialogText>
               </AlertDialogCancel>
               <AlertDialogAction onPress={handleCreateEventType} disabled={creating}>
-                <AlertDialogText className="text-white">Continue</AlertDialogText>
+                <AlertDialogText className="text-white dark:text-black">Continue</AlertDialogText>
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/components/screens/AvailabilityListScreen.tsx
+++ b/components/screens/AvailabilityListScreen.tsx
@@ -476,7 +476,7 @@ export function AvailabilityListScreen({
                 <AlertDialogText>Cancel</AlertDialogText>
               </AlertDialogCancel>
               <AlertDialogAction onPress={handleCreateSchedule} disabled={creating}>
-                <AlertDialogText className="text-white">Continue</AlertDialogText>
+                <AlertDialogText className="text-white dark:text-black">Continue</AlertDialogText>
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>


### PR DESCRIPTION
# Summary

1. Fixes the Continue button label in dark mode so it stays visible in AlertDialogs. In Event Types and Availability, the primary action button was inheriting light text on a light dialog background in dark mode. This adds dark:text-black so the label is readable.

2. Event Types — Continue button in the “Create event type” AlertDialog
Availability — Continue button in the “Add schedule” AlertDialog

# Before and After

Before:

https://github.com/user-attachments/assets/5d286110-62d4-466d-ad72-94bbcf586624

After:

https://github.com/user-attachments/assets/43787b00-e4c0-4f9f-b550-9a736ce55d20

# Review & Testing Checklist for Human

- [x] Event Types — In dark mode, open “Create event type” and confirm the Continue button text is clearly visible (dark text on light dialog)
- [x] Availability — In dark mode, open “Add schedule” and confirm the Continue button  text is clearly visible 
- [x] Light mode — Confirm both dialogs still look correct in light mode (no regressions) 



# Notes
1. Only styling changes (dark:text-black on the Continue button in two AlertDialogs); no logic or API changes.
2. Files touched: app/(tabs)/(event-types)/index.tsx, components/screens/AvailabilityListScreen.tsx.

@dhairyashiil 