### PR TITLE
fix: More tab page (iOS): open Apps, Routing, Workflows etc in in-app browser

### DIFF
--- a/app/(tabs)/(more)/index.ios.tsx
+++ b/app/(tabs)/(more)/index.ios.tsx
@@ -95,31 +95,31 @@ export default function More() {
       name: "Apps",
       icon: "grid-outline",
       isExternal: false,
-      onPress: () => showNotAvailableAlert(),
+      onPress: () => openInAppBrowser("https://app.cal.com/apps", "Apps page"),
     },
     {
       name: "Routing",
       icon: "git-branch-outline",
       isExternal: false,
-      onPress: () => showNotAvailableAlert(),
+      onPress: () => openInAppBrowser("https://app.cal.com/routing", "Routing page"),
     },
     {
       name: "Workflows",
       icon: "flash-outline",
       isExternal: false,
-      onPress: () => showNotAvailableAlert(),
+      onPress: () => openInAppBrowser("https://app.cal.com/workflows", "Workflows page"),
     },
     {
       name: "Insights",
       icon: "bar-chart-outline",
       isExternal: false,
-      onPress: () => showNotAvailableAlert(),
+      onPress: () => openInAppBrowser("https://app.cal.com/insights", "Insights page"),
     },
     {
       name: "Support",
       icon: "help-circle-outline",
       isExternal: false,
-      onPress: () => showNotAvailableAlert(),
+      onPress: () => openInAppBrowser("https://go.cal.com/support", "Support"),
     },
   ];
 


### PR DESCRIPTION
# Summary

Replaces the “not available” alerts on the More tab (iOS) with in-app browser links. Tapping Apps, Routing, Workflows, Insights, and Support now opens the corresponding Cal.com URLs inside the app instead of showing an alert.
More — Menu links (iOS).

# Behavior

Apps, Routing, Workflows, Insights, and Support no longer call showNotAvailableAlert(). Each item now uses openInAppBrowser() with the correct URL and title.

# Before & After

Before:

https://github.com/user-attachments/assets/7598d2e8-2f3d-40f6-8e03-75991d22678d

After:

https://github.com/user-attachments/assets/94bd34ce-2838-491b-b9be-8d2ace98f06a

# Review & testing checklist

- [x] More tab (iOS): Tap Apps — opens app.cal.com/apps in the in-app browser.
- [x] More tab (iOS): Tap Routing — opens app.cal.com/routing in the in-app browser.
- [x] More tab (iOS): Tap Workflows — opens app.cal.com/workflows in the in-app browser.
- [x] More tab (iOS): Tap Insights — opens app.cal.com/insights in the in-app browser.
- [x] More tab (iOS): Tap Support — opens go.cal.com/support in the in-app browser.
- [x] Confirm no regressions on other More items (e.g. Profile, Availability, Event Types).

# Files touched

- app/(tabs)/(more)/index.ios.tsx

# Future Work

- Building all the pages in the app so that browser dependency can be left. 
