### PR TITLE
fix: correct MCP tool schemas against Cal.com API v2 spec

### DIFF
--- a/apps/mcp-server/src/tools/bookings.ts
+++ b/apps/mcp-server/src/tools/bookings.ts
@@ -112,8 +112,8 @@ export const createBookingSchema = {
   bookingFieldsResponses: z.record(z.unknown()).optional().describe("Custom booking field responses as {slug: value} pairs"),
   metadata: z.record(z.unknown()).optional().describe("Metadata key-value pairs (max 50 keys, keys ≤40 chars, string values ≤500 chars)"),
   location: z.record(z.unknown()).optional().describe("Meeting location override as an object. Must match one of the event type's configured location types: {type:'integration',integration:'cal-video'|'google-meet'|'zoom'|...}, {type:'attendeePhone',phone:'+...'}, {type:'attendeeAddress',address:'...'}, {type:'attendeeDefined',location:'...'}, {type:'address'}, {type:'link'}, {type:'phone'}, or {type:'organizersDefaultApp'} (team events only)."),
-  allowConflicts: z.boolean().optional().describe("If true, allow booking even if it overlaps with existing calendar events. Useful for hosts who need to force-book."),
-  allowBookingOutOfBounds: z.boolean().optional().describe("If true, allow booking outside the event type's configured availability window (e.g. before minimumBookingNotice or beyond the booking window)."),
+  allowConflicts: z.boolean().optional().describe("If true and the authenticated user is a host, skip availability conflict checks. Ignored for non-hosts."),
+  allowBookingOutOfBounds: z.boolean().optional().describe("If true and the authenticated user is a host, allow booking outside the configured scheduling window (e.g. before minimumBookingNotice or beyond the booking window). Ignored for non-hosts."),
 };
 
 export async function createBooking(params: {

--- a/apps/mcp-server/src/tools/event-types.ts
+++ b/apps/mcp-server/src/tools/event-types.ts
@@ -79,7 +79,7 @@ export const createEventTypeSchema = {
   recurrence: z
     .record(z.unknown())
     .optional()
-    .describe("Recurrence settings to create a recurring event type (e.g. {frequency: 'weekly', interval: 1, count: 12})."),
+    .describe("Recurrence settings to create a recurring event type (e.g. {frequency: 'weekly', interval: 1, occurrences: 12})."),
   confirmationPolicy: z
     .record(z.unknown())
     .optional()
@@ -96,9 +96,21 @@ export const createEventTypeSchema = {
   hidden: z.boolean().optional().describe("Whether the event type is hidden from the public profile."),
   offsetStart: z.number().int().optional().describe("Offset timeslots shown to bookers by a specified number of minutes."),
   onlyShowFirstAvailableSlot: z.boolean().optional().describe("Limit availability to one slot per day (the earliest available)."),
-  bookingLimitsCount: z.record(z.number().int()).optional().describe("Limit how many times this event can be booked per period. Keys are PER_DAY, PER_WEEK, PER_MONTH, or PER_YEAR with integer values (e.g. {PER_DAY: 2, PER_WEEK: 5})."),
-  bookingWindow: z.record(z.unknown()).optional().describe("Rolling or fixed date range for when bookings can be made. Example: {type: 'calendarDays', value: 30, rolling: true} allows bookings up to 30 calendar days ahead."),
-  destinationCalendar: z.record(z.unknown()).optional().describe("Which external calendar new bookings are added to. Object with integration (e.g. 'google_calendar'), externalId (calendar ID), and optionally credentialId. Use get_connected_calendars to obtain these values."),
+  bookingLimitsCount: z.object({
+    day: z.number().int().min(1).optional().describe("Max bookings per day"),
+    week: z.number().int().min(1).optional().describe("Max bookings per week"),
+    month: z.number().int().min(1).optional().describe("Max bookings per month"),
+    year: z.number().int().min(1).optional().describe("Max bookings per year"),
+  }).optional().describe("Limit how many times this event can be booked per period (e.g. {day: 2, week: 5})."),
+  bookingWindow: z.object({
+    type: z.enum(["businessDays", "calendarDays", "range"]).describe("Window type"),
+    value: z.union([z.number(), z.array(z.string())]).describe("Number of days (for businessDays/calendarDays) or date range array ['2030-09-05', '2030-09-09'] (for range)"),
+    rolling: z.boolean().optional().describe("If true the window rolls forward keeping 'value' days available. Only for businessDays/calendarDays."),
+  }).optional().describe("Limit how far in the future this event can be booked."),
+  destinationCalendar: z.object({
+    integration: z.string().describe("Integration type (e.g. 'google_calendar'). Use get_connected_calendars to find this."),
+    externalId: z.string().describe("External calendar ID (e.g. email for Google Calendar). Use get_connected_calendars to find this."),
+  }).optional().describe("Which external calendar new bookings are added to."),
 };
 
 export async function createEventType(params: {
@@ -126,9 +138,9 @@ export async function createEventType(params: {
   hidden?: boolean;
   offsetStart?: number;
   onlyShowFirstAvailableSlot?: boolean;
-  bookingLimitsCount?: Record<string, number>;
-  bookingWindow?: Record<string, unknown>;
-  destinationCalendar?: Record<string, unknown>;
+  bookingLimitsCount?: { day?: number; week?: number; month?: number; year?: number };
+  bookingWindow?: { type: string; value: number | string[]; rolling?: boolean };
+  destinationCalendar?: { integration: string; externalId: string };
 }) {
   try {
     const body: Record<string, unknown> = {
@@ -188,7 +200,7 @@ export const updateEventTypeSchema = {
   beforeEventBuffer: z.number().int().optional().describe("Minutes blocked on calendar before the meeting."),
   afterEventBuffer: z.number().int().optional().describe("Minutes blocked on calendar after the meeting."),
   scheduleId: z.number().int().optional().describe("Schedule ID to use instead of default. Use get_schedules to find schedule IDs."),
-  recurrence: z.record(z.unknown()).optional().describe("Recurrence settings (e.g. {frequency: 'weekly', interval: 1, count: 12})."),
+  recurrence: z.record(z.unknown()).optional().describe("Recurrence settings (e.g. {frequency: 'weekly', interval: 1, occurrences: 12})."),
   confirmationPolicy: z.record(z.unknown()).optional().describe("Manual confirmation policy settings."),
   requiresBookerEmailVerification: z.boolean().optional().describe("Whether booker must verify their email."),
   hideCalendarNotes: z.boolean().optional().describe("Hide calendar notes."),
@@ -199,9 +211,21 @@ export const updateEventTypeSchema = {
   hidden: z.boolean().optional().describe("Whether the event type is hidden."),
   offsetStart: z.number().int().optional().describe("Offset timeslots by specified minutes."),
   onlyShowFirstAvailableSlot: z.boolean().optional().describe("Show only the earliest available slot per day."),
-  bookingLimitsCount: z.record(z.number().int()).optional().describe("Limit how many times this event can be booked per period. Keys are PER_DAY, PER_WEEK, PER_MONTH, or PER_YEAR with integer values (e.g. {PER_DAY: 2, PER_WEEK: 5})."),
-  bookingWindow: z.record(z.unknown()).optional().describe("Rolling or fixed date range for when bookings can be made. Example: {type: 'calendarDays', value: 30, rolling: true} allows bookings up to 30 calendar days ahead."),
-  destinationCalendar: z.record(z.unknown()).optional().describe("Which external calendar new bookings are added to. Object with integration (e.g. 'google_calendar'), externalId (calendar ID), and optionally credentialId. Use get_connected_calendars to obtain these values."),
+  bookingLimitsCount: z.object({
+    day: z.number().int().min(1).optional().describe("Max bookings per day"),
+    week: z.number().int().min(1).optional().describe("Max bookings per week"),
+    month: z.number().int().min(1).optional().describe("Max bookings per month"),
+    year: z.number().int().min(1).optional().describe("Max bookings per year"),
+  }).optional().describe("Limit how many times this event can be booked per period (e.g. {day: 2, week: 5})."),
+  bookingWindow: z.object({
+    type: z.enum(["businessDays", "calendarDays", "range"]).describe("Window type"),
+    value: z.union([z.number(), z.array(z.string())]).describe("Number of days (for businessDays/calendarDays) or date range array ['2030-09-05', '2030-09-09'] (for range)"),
+    rolling: z.boolean().optional().describe("If true the window rolls forward keeping 'value' days available. Only for businessDays/calendarDays."),
+  }).optional().describe("Limit how far in the future this event can be booked."),
+  destinationCalendar: z.object({
+    integration: z.string().describe("Integration type (e.g. 'google_calendar'). Use get_connected_calendars to find this."),
+    externalId: z.string().describe("External calendar ID (e.g. email for Google Calendar). Use get_connected_calendars to find this."),
+  }).optional().describe("Which external calendar new bookings are added to."),
 };
 
 export async function updateEventType(params: {
@@ -230,9 +254,9 @@ export async function updateEventType(params: {
   hidden?: boolean;
   offsetStart?: number;
   onlyShowFirstAvailableSlot?: boolean;
-  bookingLimitsCount?: Record<string, number>;
-  bookingWindow?: Record<string, unknown>;
-  destinationCalendar?: Record<string, unknown>;
+  bookingLimitsCount?: { day?: number; week?: number; month?: number; year?: number };
+  bookingWindow?: { type: string; value: number | string[]; rolling?: boolean };
+  destinationCalendar?: { integration: string; externalId: string };
 }) {
   try {
     const body: Record<string, unknown> = {};

--- a/apps/mcp-server/src/tools/schedules.test.ts
+++ b/apps/mcp-server/src/tools/schedules.test.ts
@@ -89,7 +89,7 @@ describe("createSchedule", () => {
       timeZone: "America/New_York",
       isDefault: true,
       availability: [
-        { day: "Monday", startTime: "09:00", endTime: "17:00" },
+        { days: ["Monday"], startTime: "09:00", endTime: "17:00" },
       ],
     });
 
@@ -99,7 +99,7 @@ describe("createSchedule", () => {
         name: "Office Hours",
         timeZone: "America/New_York",
         isDefault: true,
-        availability: [{ day: "Monday", startTime: "09:00", endTime: "17:00" }],
+        availability: [{ days: ["Monday"], startTime: "09:00", endTime: "17:00" }],
       },
     });
   });
@@ -111,7 +111,7 @@ describe("createSchedule", () => {
       name: "Holiday",
       timeZone: "UTC",
       isDefault: false,
-      overrides: [{ date: "2024-12-25" }],
+      overrides: [{ date: "2024-12-25", startTime: "00:00", endTime: "00:00" }],
     });
 
     const [, opts] = mockCalApi.mock.calls[0];
@@ -138,7 +138,7 @@ describe("updateSchedule", () => {
 
     await updateSchedule({
       scheduleId: 5,
-      availability: [{ day: "Tuesday", startTime: "10:00", endTime: "16:00" }],
+      availability: [{ days: ["Tuesday"], startTime: "10:00", endTime: "16:00" }],
     });
 
     const [, opts] = mockCalApi.mock.calls[0];

--- a/apps/mcp-server/src/tools/schedules.ts
+++ b/apps/mcp-server/src/tools/schedules.ts
@@ -3,15 +3,17 @@ import { calApi } from "../utils/api-client.js";
 import { handleError, ok } from "../utils/tool-helpers.js";
 
 const availabilitySlotSchema = z.object({
-  day: z.string().describe("Day of week (e.g. Monday)"),
+  days: z
+    .array(z.enum(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]))
+    .describe("Days of week this slot applies to (e.g. [\"Monday\", \"Tuesday\"])"),
   startTime: z.string().describe("Start time in HH:mm format (e.g. '09:00')"),
   endTime: z.string().describe("End time in HH:mm format (e.g. '17:00')"),
 });
 
 const overrideSchema = z.object({
   date: z.string().describe("Date of the override in YYYY-MM-DD format"),
-  startTime: z.string().optional().describe("Start time in HH:mm format. Omit startTime and endTime to mark the date as unavailable."),
-  endTime: z.string().optional().describe("End time in HH:mm format."),
+  startTime: z.string().describe("Start time in HH:mm format (e.g. '09:00'). To mark a date as unavailable, set both startTime and endTime to '00:00'."),
+  endTime: z.string().describe("End time in HH:mm format (e.g. '17:00'). To mark a date as unavailable, set both startTime and endTime to '00:00'."),
 });
 
 export const getSchedulesSchema = {};
@@ -56,8 +58,8 @@ export async function createSchedule(params: {
   name: string;
   timeZone: string;
   isDefault: boolean;
-  availability?: { day: string; startTime: string; endTime: string }[];
-  overrides?: { date: string; startTime?: string; endTime?: string }[];
+  availability?: { days: string[]; startTime: string; endTime: string }[];
+  overrides?: { date: string; startTime: string; endTime: string }[];
 }) {
   try {
     const body: Record<string, unknown> = {
@@ -94,8 +96,8 @@ export async function updateSchedule(params: {
   name?: string;
   timeZone?: string;
   isDefault?: boolean;
-  availability?: { day: string; startTime: string; endTime: string }[];
-  overrides?: { date: string; startTime?: string; endTime?: string }[];
+  availability?: { days: string[]; startTime: string; endTime: string }[];
+  overrides?: { date: string; startTime: string; endTime: string }[];
 }) {
   try {
     const body: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

Audited all MCP tool schemas against the Cal.com API v2 OpenAPI spec (`calcom/cal`) and fixed every confirmed mismatch:

### schedules.ts
- **`availability` slots**: Changed `day` (singular string) → `days` (array of day-name strings) to match `ScheduleAvailabilityInput_2024_06_11`. This was causing 400 errors on every schedule create/update with availability.
- **`overrides`**: Made `startTime` and `endTime` required (spec: `required: ["date", "startTime", "endTime"]`). To mark a date unavailable, set both to `"00:00"`.

### event-types.ts
- **`bookingLimitsCount`**: Replaced `z.record()` with `PER_DAY`/`PER_WEEK` description → typed `z.object({ day, week, month, year })` matching `BookingLimitsCount_2024_06_14`.
- **`bookingWindow`**: Replaced `z.record()` → typed `z.object({ type: enum["businessDays"|"calendarDays"|"range"], value, rolling })` matching `BookingWindow_2024_06_14`.
- **`destinationCalendar`**: Replaced `z.record()` → typed `z.object({ integration, externalId })` matching `DestinationCalendar_2024_06_14`.
- **`recurrence` description**: Corrected example field `count` → `occurrences` (matching `Recurrence_2024_06_14`).

### bookings.ts
- **`allowConflicts` / `allowBookingOutOfBounds` descriptions**: Clarified these are host-only and ignored for non-hosts.

## Verification
- All changes verified against `calcom/cal` source types (`packages/platform/types/`)
- Full test suite passes: 125 tests across 10 files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/companion/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
