### PR TITLE
feat(mcp-server): replace SQLite with Vercel Postgres

### DIFF
--- a/apps/mcp-server/.env.example
+++ b/apps/mcp-server/.env.example
@@ -28,9 +28,8 @@ CAL_API_KEY=cal_live_xxxx
 # Optional: override the Cal.com app base URL (for authorize redirect)
 # CAL_APP_BASE_URL=https://app.cal.com
 
-# Vercel Postgres connection string (required for HTTP mode)
-# Automatically set by Vercel when Vercel Postgres is added to a project
-# POSTGRES_URL=postgres://user:pass@host:5432/dbname
+# Postgres connection string (required for HTTP mode)
+# DATABASE_URL=postgres://user:pass@host:5432/dbname
 
 # Rate limiting for OAuth endpoints (token bucket per IP)
 # RATE_LIMIT_WINDOW_MS=60000

--- a/apps/mcp-server/.env.example
+++ b/apps/mcp-server/.env.example
@@ -28,8 +28,9 @@ CAL_API_KEY=cal_live_xxxx
 # Optional: override the Cal.com app base URL (for authorize redirect)
 # CAL_APP_BASE_URL=https://app.cal.com
 
-# SQLite database path (default: mcp-server.db in the working directory)
-# DATABASE_PATH=mcp-server.db
+# Vercel Postgres connection string (required for HTTP mode)
+# Automatically set by Vercel when Vercel Postgres is added to a project
+# POSTGRES_URL=postgres://user:pass@host:5432/dbname
 
 # Rate limiting for OAuth endpoints (token bucket per IP)
 # RATE_LIMIT_WINDOW_MS=60000

--- a/apps/mcp-server/docker-compose.yml
+++ b/apps/mcp-server/docker-compose.yml
@@ -1,6 +1,23 @@
 version: "3.8"
 
 services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: mcp
+      POSTGRES_USER: mcp
+      POSTGRES_PASSWORD: mcp
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mcp"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
   mcp-server:
     build:
       context: .
@@ -15,14 +32,15 @@ services:
       - TOKEN_ENCRYPTION_KEY=${TOKEN_ENCRYPTION_KEY}
       - CAL_API_BASE_URL=${CAL_API_BASE_URL:-https://api.cal.com}
       - CAL_APP_BASE_URL=${CAL_APP_BASE_URL:-https://app.cal.com}
-      - DATABASE_PATH=/data/mcp-server.db
+      - POSTGRES_URL=postgres://mcp:mcp@postgres:5432/mcp
       - TRUST_PROXY=true
       - CORS_ORIGIN=${CORS_ORIGIN:-*}
       - LOG_LEVEL=${LOG_LEVEL:-info}
-    volumes:
-      - ./data:/data
     expose:
       - "3100"
+    depends_on:
+      postgres:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3100/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
       interval: 30s
@@ -45,5 +63,6 @@ services:
         condition: service_healthy
 
 volumes:
+  pgdata:
   caddy_data:
   caddy_config:

--- a/apps/mcp-server/docker-compose.yml
+++ b/apps/mcp-server/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - TOKEN_ENCRYPTION_KEY=${TOKEN_ENCRYPTION_KEY}
       - CAL_API_BASE_URL=${CAL_API_BASE_URL:-https://api.cal.com}
       - CAL_APP_BASE_URL=${CAL_APP_BASE_URL:-https://app.cal.com}
-      - POSTGRES_URL=postgres://mcp:mcp@postgres:5432/mcp
+      - DATABASE_URL=postgres://mcp:mcp@postgres:5432/mcp
       - TRUST_PROXY=true
       - CORS_ORIGIN=${CORS_ORIGIN:-*}
       - LOG_LEVEL=${LOG_LEVEL:-info}

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -29,12 +29,11 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "better-sqlite3": "^12.8.0",
+    "@vercel/postgres": "^0.10.0",
     "zod": "^3.24.4"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.10",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "22.19.6",
     "tsx": "^4.19.4",
     "typescript": "5.9.3",

--- a/apps/mcp-server/src/auth/oauth-handlers.ts
+++ b/apps/mcp-server/src/auth/oauth-handlers.ts
@@ -15,6 +15,7 @@ import {
   deleteAccessToken,
   deleteAccessTokenByRefresh,
   getAccessToken,
+  updateCalTokens,
 } from "../storage/token-store.js";
 
 export interface OAuthConfig {
@@ -105,7 +106,7 @@ export async function handleRegister(
   }
   const clientName = typeof body.client_name === "string" ? body.client_name : undefined;
 
-  const client = createRegisteredClient(redirectUris, clientName);
+  const client = await createRegisteredClient(redirectUris, clientName);
 
   jsonResponse(res, 201, {
     client_id: client.clientId,
@@ -116,11 +117,11 @@ export async function handleRegister(
 
 // ── Authorization (GET /oauth/authorize) ──
 
-export function handleAuthorize(
+export async function handleAuthorize(
   req: IncomingMessage,
   res: ServerResponse,
   config: OAuthConfig,
-): void {
+): Promise<void> {
   const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
 
   const responseType = url.searchParams.get("response_type");
@@ -146,7 +147,7 @@ export function handleAuthorize(
     return;
   }
 
-  const client = getRegisteredClient(clientId);
+  const client = await getRegisteredClient(clientId);
   if (!client) {
     jsonResponse(res, 400, { error: "invalid_client", error_description: "Unknown client_id" });
     return;
@@ -165,7 +166,7 @@ export function handleAuthorize(
   const calCodeVerifier = useCalPkce ? generateCodeVerifier() : undefined;
   const calCodeChallenge = calCodeVerifier ? generateCodeChallenge(calCodeVerifier) : undefined;
 
-  createPendingAuth({
+  await createPendingAuth({
     state: internalState,
     clientId,
     clientRedirectUri: redirectUri,
@@ -216,7 +217,7 @@ export async function handleCallback(
     return;
   }
 
-  const pending = getPendingAuth(state);
+  const pending = await getPendingAuth(state);
   if (!pending) {
     jsonResponse(res, 400, { error: "invalid_request", error_description: "Unknown or expired state parameter" });
     return;
@@ -247,7 +248,7 @@ export async function handleCallback(
   if (!exchangeRes.ok) {
     // Do not log response body — it may contain sensitive Cal.com error details
     logger.error("Cal.com token exchange failed", { status: exchangeRes.status });
-    deletePendingAuth(state);
+    await deletePendingAuth(state);
     jsonResponse(res, 502, { error: "server_error", error_description: "Token exchange with Cal.com failed" });
     return;
   }
@@ -264,7 +265,7 @@ export async function handleCallback(
   const calRefreshToken = tokens.refresh_token;
   const calTokenExpiresAt = Math.floor(Date.now() / 1000) + (tokens.expires_in ?? 3600);
 
-  const authCode = createAuthCode({
+  const authCode = await createAuthCode({
     clientId: pending.clientId,
     redirectUri: pending.clientRedirectUri,
     codeChallenge: pending.clientCodeChallenge,
@@ -309,7 +310,7 @@ export async function handleToken(
   jsonResponse(res, 400, { error: "unsupported_grant_type" });
 }
 
-function handleAuthorizationCodeGrant(params: URLSearchParams, res: ServerResponse): void {
+async function handleAuthorizationCodeGrant(params: URLSearchParams, res: ServerResponse): Promise<void> {
   const code = params.get("code");
   const redirectUri = params.get("redirect_uri");
   const codeVerifier = params.get("code_verifier");
@@ -323,7 +324,7 @@ function handleAuthorizationCodeGrant(params: URLSearchParams, res: ServerRespon
     return;
   }
 
-  const authCode = consumeAuthCode(code);
+  const authCode = await consumeAuthCode(code);
   if (!authCode) {
     jsonResponse(res, 400, { error: "invalid_grant", error_description: "Invalid, expired, or already-used authorization code" });
     return;
@@ -339,7 +340,7 @@ function handleAuthorizationCodeGrant(params: URLSearchParams, res: ServerRespon
     return;
   }
 
-  const result = createAccessToken({
+  const result = await createAccessToken({
     clientId: authCode.clientId,
     calAccessToken: authCode.calAccessToken,
     calRefreshToken: authCode.calRefreshToken,
@@ -354,14 +355,14 @@ function handleAuthorizationCodeGrant(params: URLSearchParams, res: ServerRespon
   });
 }
 
-function handleRefreshTokenGrant(params: URLSearchParams, res: ServerResponse): void {
+async function handleRefreshTokenGrant(params: URLSearchParams, res: ServerResponse): Promise<void> {
   const refreshToken = params.get("refresh_token");
   if (!refreshToken) {
     jsonResponse(res, 400, { error: "invalid_request", error_description: "Missing refresh_token" });
     return;
   }
 
-  const result = rotateAccessToken(refreshToken);
+  const result = await rotateAccessToken(refreshToken);
   if (!result) {
     jsonResponse(res, 400, { error: "invalid_grant", error_description: "Invalid refresh token" });
     return;
@@ -391,8 +392,8 @@ export async function handleRevoke(
   const token = params.get("token");
 
   if (token) {
-    deleteAccessToken(token);
-    deleteAccessTokenByRefresh(token);
+    await deleteAccessToken(token);
+    await deleteAccessTokenByRefresh(token);
   }
 
   jsonResponse(res, 200, {});
@@ -437,13 +438,11 @@ export async function refreshCalTokens(
     scope?: string;
   };
 
-  const { updateCalTokens } = await import("../storage/token-store.js");
-
   const newCalAccessToken = data.access_token;
   const newCalRefreshToken = data.refresh_token;
   const newCalTokenExpiresAt = Math.floor(Date.now() / 1000) + (data.expires_in ?? 3600);
 
-  updateCalTokens(accessTokenValue, newCalAccessToken, newCalRefreshToken, newCalTokenExpiresAt);
+  await updateCalTokens(accessTokenValue, newCalAccessToken, newCalRefreshToken, newCalTokenExpiresAt);
 
   return {
     calAccessToken: newCalAccessToken,
@@ -461,7 +460,7 @@ export async function resolveCalAuthHeaders(
   bearerToken: string,
   config: OAuthConfig,
 ): Promise<Record<string, string> | undefined> {
-  const record = getAccessToken(bearerToken);
+  const record = await getAccessToken(bearerToken);
   if (!record) return undefined;
 
   let { calAccessToken } = record;

--- a/apps/mcp-server/src/auth/oauth-handlers.ts
+++ b/apps/mcp-server/src/auth/oauth-handlers.ts
@@ -274,7 +274,7 @@ export async function handleCallback(
     calTokenExpiresAt,
   });
 
-  deletePendingAuth(state);
+  await deletePendingAuth(state);
 
   const clientRedirect = new URL(pending.clientRedirectUri);
   clientRedirect.searchParams.set("code", authCode);

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -49,7 +49,7 @@ const httpSchema = baseSchema.extend({
     .length(64, "TOKEN_ENCRYPTION_KEY must be a 64-character hex string (32 bytes)")
     .regex(/^[0-9a-fA-F]+$/, "TOKEN_ENCRYPTION_KEY must be valid hex"),
   serverUrl: z.string().url("MCP_SERVER_URL must be a valid URL"),
-  databasePath: z.string().default("mcp-server.db"),
+  postgresUrl: z.string().min(1, "POSTGRES_URL is required for HTTP mode"),
   rateLimitWindowMs: z.coerce.number().int().positive().default(60_000),
   rateLimitMax: z.coerce.number().int().positive().default(30),
   maxSessions: z.coerce.number().int().positive().default(10_000),
@@ -83,7 +83,7 @@ function readEnv(): Record<string, unknown> {
     calOAuthClientSecret: process.env.CAL_OAUTH_CLIENT_SECRET || undefined,
     tokenEncryptionKey: process.env.TOKEN_ENCRYPTION_KEY || undefined,
     serverUrl: process.env.MCP_SERVER_URL || undefined,
-    databasePath: process.env.DATABASE_PATH || undefined,
+    postgresUrl: process.env.POSTGRES_URL || undefined,
     rateLimitWindowMs: process.env.RATE_LIMIT_WINDOW_MS || undefined,
     rateLimitMax: process.env.RATE_LIMIT_MAX || undefined,
     maxSessions: process.env.MAX_SESSIONS || undefined,

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -49,7 +49,7 @@ const httpSchema = baseSchema.extend({
     .length(64, "TOKEN_ENCRYPTION_KEY must be a 64-character hex string (32 bytes)")
     .regex(/^[0-9a-fA-F]+$/, "TOKEN_ENCRYPTION_KEY must be valid hex"),
   serverUrl: z.string().url("MCP_SERVER_URL must be a valid URL"),
-  postgresUrl: z.string().min(1, "POSTGRES_URL is required for HTTP mode"),
+  databaseUrl: z.string().min(1, "DATABASE_URL is required for HTTP mode"),
   rateLimitWindowMs: z.coerce.number().int().positive().default(60_000),
   rateLimitMax: z.coerce.number().int().positive().default(30),
   maxSessions: z.coerce.number().int().positive().default(10_000),
@@ -83,7 +83,7 @@ function readEnv(): Record<string, unknown> {
     calOAuthClientSecret: process.env.CAL_OAUTH_CLIENT_SECRET || undefined,
     tokenEncryptionKey: process.env.TOKEN_ENCRYPTION_KEY || undefined,
     serverUrl: process.env.MCP_SERVER_URL || undefined,
-    postgresUrl: process.env.POSTGRES_URL || undefined,
+    databaseUrl: process.env.DATABASE_URL || undefined,
     rateLimitWindowMs: process.env.RATE_LIMIT_WINDOW_MS || undefined,
     rateLimitMax: process.env.RATE_LIMIT_MAX || undefined,
     maxSessions: process.env.MAX_SESSIONS || undefined,

--- a/apps/mcp-server/src/http-server.ts
+++ b/apps/mcp-server/src/http-server.ts
@@ -17,7 +17,7 @@ import {
   resolveCalAuthHeaders,
 } from "./auth/oauth-handlers.js";
 import type { OAuthConfig } from "./auth/oauth-handlers.js";
-import { getDb, closeDb } from "./storage/db.js";
+import { initDb, endPool, sql } from "./storage/db.js";
 import { cleanupExpired, countRegisteredClients } from "./storage/token-store.js";
 import { logger, withLogContext } from "./utils/logger.js";
 import { RateLimiter, getClientIp, sendRateLimited } from "./utils/rate-limiter.js";
@@ -55,10 +55,10 @@ export interface HttpServerConfig {
  */
 const startedAt = Date.now();
 
-export function startHttpServer(
+export async function startHttpServer(
   registerTools: (server: McpServer) => void,
   config: HttpServerConfig,
-): void {
+): Promise<void> {
   const { port, oauthConfig } = config;
   const maxSessions = config.maxSessions ?? (Number(process.env.MAX_SESSIONS) || 10_000);
   const sessionIdleTimeoutMs = config.sessionIdleTimeoutMs ?? (Number(process.env.SESSION_IDLE_TIMEOUT_MS) || 30 * 60 * 1000);
@@ -66,7 +66,7 @@ export function startHttpServer(
   const corsOrigin = config.corsOrigin ?? process.env.CORS_ORIGIN;
   const shutdownTimeoutMs = config.shutdownTimeoutMs ?? (Number(process.env.SHUTDOWN_TIMEOUT_MS) || 10_000);
 
-  getDb();
+  await initDb();
 
   const rateLimitWindowMs = config.rateLimitWindowMs ?? (Number(process.env.RATE_LIMIT_WINDOW_MS) || 60_000);
   const rateLimitMax = config.rateLimitMax ?? (Number(process.env.RATE_LIMIT_MAX) || 30);
@@ -76,11 +76,9 @@ export function startHttpServer(
   mcpRateLimiter.startGc();
 
   const cleanupInterval = setInterval(() => {
-    try {
-      cleanupExpired();
-    } catch (err) {
+    cleanupExpired().catch((err) => {
       logger.error("Cleanup error", { error: String(err) });
-    }
+    });
   }, 5 * 60 * 1000);
 
   const sessions = new Map<
@@ -137,8 +135,7 @@ export function startHttpServer(
     if (url.pathname === "/health") {
       let dbOk = false;
       try {
-        const db = getDb();
-        db.prepare("SELECT 1").get();
+        await sql`SELECT 1`;
         dbOk = true;
       } catch { /* db not healthy */ }
       const status = dbOk ? "ok" : "degraded";
@@ -176,7 +173,7 @@ export function startHttpServer(
 
       if (url.pathname === "/oauth/register") {
         // Enforce max registered clients limit
-        const currentCount = countRegisteredClients();
+        const currentCount = await countRegisteredClients();
         if (currentCount >= maxRegisteredClients) {
           res.writeHead(503, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "server_error", error_description: "Maximum number of registered clients reached" }));
@@ -186,7 +183,7 @@ export function startHttpServer(
         return;
       }
       if (url.pathname === "/oauth/authorize" && req.method === "GET") {
-        handleAuthorize(req, res, oauthConfig);
+        await handleAuthorize(req, res, oauthConfig);
         return;
       }
       if (url.pathname === "/oauth/callback" && req.method === "GET") {
@@ -378,8 +375,8 @@ export function startHttpServer(
     const timeout = new Promise<void>((resolve) => setTimeout(resolve, shutdownTimeoutMs));
     await Promise.race([drainPromise, timeout]);
 
-    // 4. Close database
-    closeDb();
+    // 4. Close database pool
+    await endPool();
     logger.info("Shutdown complete");
   };
 

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -18,7 +18,7 @@ async function main(): Promise<void> {
 
   if (config.transport === "http") {
     const httpConfig = config as HttpConfig;
-    startHttpServer(registerTools, {
+    await startHttpServer(registerTools, {
       port: httpConfig.port,
       oauthConfig: {
         serverUrl: httpConfig.serverUrl,

--- a/apps/mcp-server/src/storage/db.ts
+++ b/apps/mcp-server/src/storage/db.ts
@@ -1,28 +1,26 @@
-import Database from "better-sqlite3";
+import { sql, db as pool } from "@vercel/postgres";
 
-let db: Database.Database | null = null;
+export { sql };
+
+let initialized = false;
 
 /**
- * Get or initialize the SQLite database for OAuth token storage.
- * Uses WAL mode for better concurrent read performance.
+ * Initialize the Postgres database schema.
+ * Creates tables if they do not already exist. Safe to call multiple times.
  */
-export function getDb(): Database.Database {
-  if (db) return db;
+export async function initDb(): Promise<void> {
+  if (initialized) return;
 
-  const dbPath = process.env.DATABASE_PATH || "mcp-server.db";
-  const instance = new Database(dbPath);
-
-  instance.pragma("journal_mode = WAL");
-  instance.pragma("foreign_keys = ON");
-
-  instance.exec(`
+  await sql`
     CREATE TABLE IF NOT EXISTS registered_clients (
       client_id TEXT PRIMARY KEY,
       redirect_uris TEXT NOT NULL,
       client_name TEXT,
-      created_at INTEGER NOT NULL DEFAULT (unixepoch())
-    );
+      created_at INTEGER NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::INTEGER
+    )
+  `;
 
+  await sql`
     CREATE TABLE IF NOT EXISTS pending_auths (
       state TEXT PRIMARY KEY,
       client_id TEXT NOT NULL,
@@ -30,10 +28,12 @@ export function getDb(): Database.Database {
       client_state TEXT NOT NULL,
       client_code_challenge TEXT NOT NULL,
       cal_code_verifier TEXT,
-      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      created_at INTEGER NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::INTEGER,
       expires_at INTEGER NOT NULL
-    );
+    )
+  `;
 
+  await sql`
     CREATE TABLE IF NOT EXISTS auth_codes (
       code TEXT PRIMARY KEY,
       client_id TEXT NOT NULL,
@@ -42,11 +42,13 @@ export function getDb(): Database.Database {
       cal_access_token_enc TEXT NOT NULL,
       cal_refresh_token_enc TEXT NOT NULL,
       cal_token_expires_at INTEGER NOT NULL,
-      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      created_at INTEGER NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::INTEGER,
       expires_at INTEGER NOT NULL,
       used INTEGER NOT NULL DEFAULT 0
-    );
+    )
+  `;
 
+  await sql`
     CREATE TABLE IF NOT EXISTS access_tokens (
       token TEXT PRIMARY KEY,
       refresh_token TEXT NOT NULL UNIQUE,
@@ -54,21 +56,18 @@ export function getDb(): Database.Database {
       cal_access_token_enc TEXT NOT NULL,
       cal_refresh_token_enc TEXT NOT NULL,
       cal_token_expires_at INTEGER NOT NULL,
-      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      created_at INTEGER NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::INTEGER,
       expires_at INTEGER NOT NULL
-    );
-  `);
+    )
+  `;
 
-  db = instance;
-  return db;
+  initialized = true;
 }
 
 /**
- * Close the database connection (for graceful shutdown).
+ * End the connection pool (for graceful shutdown).
  */
-export function closeDb(): void {
-  if (db) {
-    db.close();
-    db = null;
-  }
+export async function endPool(): Promise<void> {
+  await pool.end();
+  initialized = false;
 }

--- a/apps/mcp-server/src/storage/db.ts
+++ b/apps/mcp-server/src/storage/db.ts
@@ -10,60 +10,65 @@ let initialized = false;
 
 /**
  * Initialize the Postgres database schema.
- * Creates tables if they do not already exist. Safe to call multiple times.
+ * Creates tables and indexes if they do not already exist. Safe to call
+ * multiple times. Identifiers are double-quoted so Postgres preserves case
+ * (PascalCase tables, camelCase columns).
  */
 export async function initDb(): Promise<void> {
   if (initialized) return;
 
   await sql`
-    CREATE TABLE IF NOT EXISTS registered_clients (
-      client_id TEXT PRIMARY KEY,
-      redirect_uris TEXT NOT NULL,
-      client_name TEXT,
-      created_at INTEGER NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::INTEGER
+    CREATE TABLE IF NOT EXISTS "RegisteredClient" (
+      "clientId" TEXT PRIMARY KEY,
+      "redirectUris" TEXT NOT NULL,
+      "clientName" TEXT,
+      "createdAt" INTEGER NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::INTEGER
     )
   `;
 
   await sql`
-    CREATE TABLE IF NOT EXISTS pending_auths (
-      state TEXT PRIMARY KEY,
-      client_id TEXT NOT NULL,
-      client_redirect_uri TEXT NOT NULL,
-      client_state TEXT NOT NULL,
-      client_code_challenge TEXT NOT NULL,
-      cal_code_verifier TEXT,
-      created_at INTEGER NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::INTEGER,
-      expires_at INTEGER NOT NULL
+    CREATE TABLE IF NOT EXISTS "PendingAuth" (
+      "state" TEXT PRIMARY KEY,
+      "clientId" TEXT NOT NULL,
+      "clientRedirectUri" TEXT NOT NULL,
+      "clientState" TEXT NOT NULL,
+      "clientCodeChallenge" TEXT NOT NULL,
+      "calCodeVerifier" TEXT,
+      "createdAt" INTEGER NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::INTEGER,
+      "expiresAt" INTEGER NOT NULL
     )
   `;
+  await sql`CREATE INDEX IF NOT EXISTS "PendingAuth_expiresAt_idx" ON "PendingAuth" ("expiresAt")`;
 
   await sql`
-    CREATE TABLE IF NOT EXISTS auth_codes (
-      code TEXT PRIMARY KEY,
-      client_id TEXT NOT NULL,
-      redirect_uri TEXT NOT NULL,
-      code_challenge TEXT NOT NULL,
-      cal_access_token_enc TEXT NOT NULL,
-      cal_refresh_token_enc TEXT NOT NULL,
-      cal_token_expires_at INTEGER NOT NULL,
-      created_at INTEGER NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::INTEGER,
-      expires_at INTEGER NOT NULL,
-      used INTEGER NOT NULL DEFAULT 0
+    CREATE TABLE IF NOT EXISTS "AuthCode" (
+      "code" TEXT PRIMARY KEY,
+      "clientId" TEXT NOT NULL,
+      "redirectUri" TEXT NOT NULL,
+      "codeChallenge" TEXT NOT NULL,
+      "calAccessTokenEnc" TEXT NOT NULL,
+      "calRefreshTokenEnc" TEXT NOT NULL,
+      "calTokenExpiresAt" INTEGER NOT NULL,
+      "createdAt" INTEGER NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::INTEGER,
+      "expiresAt" INTEGER NOT NULL,
+      "used" INTEGER NOT NULL DEFAULT 0
     )
   `;
+  await sql`CREATE INDEX IF NOT EXISTS "AuthCode_expiresAt_idx" ON "AuthCode" ("expiresAt")`;
 
   await sql`
-    CREATE TABLE IF NOT EXISTS access_tokens (
-      token TEXT PRIMARY KEY,
-      refresh_token TEXT NOT NULL UNIQUE,
-      client_id TEXT NOT NULL,
-      cal_access_token_enc TEXT NOT NULL,
-      cal_refresh_token_enc TEXT NOT NULL,
-      cal_token_expires_at INTEGER NOT NULL,
-      created_at INTEGER NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::INTEGER,
-      expires_at INTEGER NOT NULL
+    CREATE TABLE IF NOT EXISTS "AccessToken" (
+      "token" TEXT PRIMARY KEY,
+      "refreshToken" TEXT NOT NULL UNIQUE,
+      "clientId" TEXT NOT NULL,
+      "calAccessTokenEnc" TEXT NOT NULL,
+      "calRefreshTokenEnc" TEXT NOT NULL,
+      "calTokenExpiresAt" INTEGER NOT NULL,
+      "createdAt" INTEGER NOT NULL DEFAULT EXTRACT(EPOCH FROM CURRENT_TIMESTAMP)::INTEGER,
+      "expiresAt" INTEGER NOT NULL
     )
   `;
+  await sql`CREATE INDEX IF NOT EXISTS "AccessToken_expiresAt_idx" ON "AccessToken" ("expiresAt")`;
 
   initialized = true;
 }

--- a/apps/mcp-server/src/storage/db.ts
+++ b/apps/mcp-server/src/storage/db.ts
@@ -1,6 +1,10 @@
-import { sql, db as pool } from "@vercel/postgres";
+import { createPool } from "@vercel/postgres";
 
-export { sql };
+const pool = createPool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export const sql = pool.sql;
 
 let initialized = false;
 

--- a/apps/mcp-server/src/storage/db.ts
+++ b/apps/mcp-server/src/storage/db.ts
@@ -1,6 +1,6 @@
 import { createPool } from "@vercel/postgres";
 
-const pool = createPool({
+export const pool = createPool({
   connectionString: process.env.DATABASE_URL,
 });
 

--- a/apps/mcp-server/src/storage/token-store.test.ts
+++ b/apps/mcp-server/src/storage/token-store.test.ts
@@ -8,9 +8,11 @@ let mockSql: ReturnType<typeof vi.fn>;
 
 vi.mock("@vercel/postgres", () => {
   mockSql = vi.fn(async () => ({ rows: mockRows, rowCount: mockRows.length }));
+  const pool = { sql: mockSql, end: vi.fn() };
   return {
+    createPool: () => pool,
     sql: mockSql,
-    db: { end: vi.fn() },
+    db: pool,
   };
 });
 

--- a/apps/mcp-server/src/storage/token-store.test.ts
+++ b/apps/mcp-server/src/storage/token-store.test.ts
@@ -8,7 +8,12 @@ let mockSql: ReturnType<typeof vi.fn>;
 
 vi.mock("@vercel/postgres", () => {
   mockSql = vi.fn(async () => ({ rows: mockRows, rowCount: mockRows.length }));
-  const pool = { sql: mockSql, end: vi.fn() };
+  const client = { sql: mockSql, release: vi.fn() };
+  const pool = {
+    sql: mockSql,
+    connect: vi.fn(async () => client),
+    end: vi.fn(),
+  };
   return {
     createPool: () => pool,
     sql: mockSql,

--- a/apps/mcp-server/src/storage/token-store.test.ts
+++ b/apps/mcp-server/src/storage/token-store.test.ts
@@ -155,14 +155,13 @@ describe("auth codes", () => {
     expect(consumed?.clientId).toBe("client-1");
     expect(consumed?.calAccessToken).toBe("cal-access-token");
     expect(consumed?.calRefreshToken).toBe("cal-refresh-token");
-    // SELECT + UPDATE
-    expect(mockSql).toHaveBeenCalledTimes(2);
+    // Single atomic UPDATE...RETURNING
+    expect(mockSql).toHaveBeenCalledTimes(1);
   });
 
   it("returns undefined when code not found", async () => {
     const result = await tokenStore.consumeAuthCode("nonexistent");
     expect(result).toBeUndefined();
-    // Only the SELECT query
     expect(mockSql).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mcp-server/src/storage/token-store.test.ts
+++ b/apps/mcp-server/src/storage/token-store.test.ts
@@ -49,9 +49,9 @@ describe("registered clients", () => {
 
   it("retrieves a client when rows are returned", async () => {
     mockRows.push({
-      client_id: "test-id",
-      redirect_uris: JSON.stringify(["http://localhost/cb"]),
-      client_name: "Test",
+      clientId: "test-id",
+      redirectUris: JSON.stringify(["http://localhost/cb"]),
+      clientName: "Test",
     });
 
     const result = await tokenStore.getRegisteredClient("test-id");
@@ -86,12 +86,12 @@ describe("pending auths", () => {
   it("retrieves a pending auth", async () => {
     mockRows.push({
       state: "test-state",
-      client_id: "client-1",
-      client_redirect_uri: "http://localhost/cb",
-      client_state: "client-state-abc",
-      client_code_challenge: "challenge-xyz",
-      cal_code_verifier: "verifier-123",
-      expires_at: Math.floor(Date.now() / 1000) + 600,
+      clientId: "client-1",
+      clientRedirectUri: "http://localhost/cb",
+      clientState: "client-state-abc",
+      clientCodeChallenge: "challenge-xyz",
+      calCodeVerifier: "verifier-123",
+      expiresAt: Math.floor(Date.now() / 1000) + 600,
     });
 
     const auth = await tokenStore.getPendingAuth("test-state");
@@ -109,12 +109,12 @@ describe("pending auths", () => {
   it("handles null calCodeVerifier", async () => {
     mockRows.push({
       state: "s",
-      client_id: "c",
-      client_redirect_uri: "http://localhost/cb",
-      client_state: "cs",
-      client_code_challenge: "cc",
-      cal_code_verifier: null,
-      expires_at: Math.floor(Date.now() / 1000) + 600,
+      clientId: "c",
+      clientRedirectUri: "http://localhost/cb",
+      clientState: "cs",
+      clientCodeChallenge: "cc",
+      calCodeVerifier: null,
+      expiresAt: Math.floor(Date.now() / 1000) + 600,
     });
 
     const auth = await tokenStore.getPendingAuth("s");
@@ -146,13 +146,13 @@ describe("auth codes", () => {
     const { encrypt } = await import("./encryption.js");
     mockRows.push({
       code: "test-code",
-      client_id: "client-1",
-      redirect_uri: "http://localhost/cb",
-      code_challenge: "cc",
-      cal_access_token_enc: encrypt("cal-access-token"),
-      cal_refresh_token_enc: encrypt("cal-refresh-token"),
-      cal_token_expires_at: Math.floor(Date.now() / 1000) + 3600,
-      expires_at: Math.floor(Date.now() / 1000) + 300,
+      clientId: "client-1",
+      redirectUri: "http://localhost/cb",
+      codeChallenge: "cc",
+      calAccessTokenEnc: encrypt("cal-access-token"),
+      calRefreshTokenEnc: encrypt("cal-refresh-token"),
+      calTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+      expiresAt: Math.floor(Date.now() / 1000) + 300,
     });
 
     const consumed = await tokenStore.consumeAuthCode("test-code");
@@ -189,12 +189,12 @@ describe("access tokens", () => {
     const { encrypt } = await import("./encryption.js");
     mockRows.push({
       token: "test-token",
-      refresh_token: "test-refresh",
-      client_id: "client-1",
-      cal_access_token_enc: encrypt("cal-at"),
-      cal_refresh_token_enc: encrypt("cal-rt"),
-      cal_token_expires_at: Math.floor(Date.now() / 1000) + 3600,
-      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      refreshToken: "test-refresh",
+      clientId: "client-1",
+      calAccessTokenEnc: encrypt("cal-at"),
+      calRefreshTokenEnc: encrypt("cal-rt"),
+      calTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
     });
 
     const record = await tokenStore.getAccessToken("test-token");
@@ -207,12 +207,12 @@ describe("access tokens", () => {
     const { encrypt } = await import("./encryption.js");
     mockRows.push({
       token: "test-token",
-      refresh_token: "test-refresh",
-      client_id: "client-1",
-      cal_access_token_enc: encrypt("cal-at"),
-      cal_refresh_token_enc: encrypt("cal-rt"),
-      cal_token_expires_at: Math.floor(Date.now() / 1000) + 3600,
-      expires_at: Math.floor(Date.now() / 1000) + 3600,
+      refreshToken: "test-refresh",
+      clientId: "client-1",
+      calAccessTokenEnc: encrypt("cal-at"),
+      calRefreshTokenEnc: encrypt("cal-rt"),
+      calTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
     });
 
     const record = await tokenStore.getAccessTokenByRefresh("test-refresh");
@@ -232,12 +232,12 @@ describe("access tokens", () => {
     mockSql.mockResolvedValueOnce({
       rows: [{
         token: "old-token",
-        refresh_token: "old-refresh",
-        client_id: "client-1",
-        cal_access_token_enc: encrypt("cal-at"),
-        cal_refresh_token_enc: encrypt("cal-rt"),
-        cal_token_expires_at: Math.floor(Date.now() / 1000) + 3600,
-        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        refreshToken: "old-refresh",
+        clientId: "client-1",
+        calAccessTokenEnc: encrypt("cal-at"),
+        calRefreshTokenEnc: encrypt("cal-rt"),
+        calTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
       }],
       rowCount: 1,
     });
@@ -272,7 +272,7 @@ describe("access tokens", () => {
 describe("cleanupExpired", () => {
   it("runs cleanup queries without error", async () => {
     await tokenStore.cleanupExpired();
-    // 3 DELETE queries (pending_auths, auth_codes, access_tokens)
+    // 3 DELETE queries (PendingAuth, AuthCode, AccessToken)
     expect(mockSql).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/mcp-server/src/storage/token-store.test.ts
+++ b/apps/mcp-server/src/storage/token-store.test.ts
@@ -1,62 +1,70 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import * as dbModule from "./db.js";
-import {
-  createRegisteredClient,
-  getRegisteredClient,
-  createPendingAuth,
-  getPendingAuth,
-  deletePendingAuth,
-  createAuthCode,
-  consumeAuthCode,
-  createAccessToken,
-  getAccessToken,
-  getAccessTokenByRefresh,
-  rotateAccessToken,
-  deleteAccessToken,
-  cleanupExpired,
-} from "./token-store.js";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
 const TEST_KEY = "a".repeat(64);
-const originalEnv = process.env;
 
-beforeEach(() => {
-  process.env = { ...originalEnv };
-  process.env.TOKEN_ENCRYPTION_KEY = TEST_KEY;
-  // Use in-memory SQLite for tests
-  process.env.DATABASE_PATH = ":memory:";
-  // Reset the db singleton by re-initializing
-  const db = dbModule.getDb();
-  // Clean all tables
-  db.exec("DELETE FROM registered_clients");
-  db.exec("DELETE FROM pending_auths");
-  db.exec("DELETE FROM auth_codes");
-  db.exec("DELETE FROM access_tokens");
+// Mock @vercel/postgres before importing modules that use it
+const mockRows: Record<string, unknown>[] = [];
+let mockSql: ReturnType<typeof vi.fn>;
+
+vi.mock("@vercel/postgres", () => {
+  mockSql = vi.fn(async () => ({ rows: mockRows, rowCount: mockRows.length }));
+  return {
+    sql: mockSql,
+    db: { end: vi.fn() },
+  };
 });
 
-afterEach(() => {
-  dbModule.closeDb();
-  process.env = originalEnv;
+// Set encryption key before imports
+process.env.TOKEN_ENCRYPTION_KEY = TEST_KEY;
+
+const tokenStore = await import("./token-store.js");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRows.length = 0;
 });
 
 describe("registered clients", () => {
-  it("creates and retrieves a client", () => {
-    const client = createRegisteredClient(["http://localhost:3000/callback"], "Test Client");
+  it("creates a client with correct SQL", async () => {
+    const client = await tokenStore.createRegisteredClient(["http://localhost:3000/callback"], "Test Client");
+
     expect(client.clientId).toBeTruthy();
     expect(client.redirectUris).toEqual(["http://localhost:3000/callback"]);
     expect(client.clientName).toBe("Test Client");
-
-    const retrieved = getRegisteredClient(client.clientId);
-    expect(retrieved).toEqual(client);
+    expect(mockSql).toHaveBeenCalledTimes(1);
   });
 
-  it("returns undefined for unknown client", () => {
-    expect(getRegisteredClient("nonexistent")).toBeUndefined();
+  it("returns undefined for unknown client", async () => {
+    // mockRows is empty by default
+    const result = await tokenStore.getRegisteredClient("nonexistent");
+    expect(result).toBeUndefined();
+  });
+
+  it("retrieves a client when rows are returned", async () => {
+    mockRows.push({
+      client_id: "test-id",
+      redirect_uris: JSON.stringify(["http://localhost/cb"]),
+      client_name: "Test",
+    });
+
+    const result = await tokenStore.getRegisteredClient("test-id");
+    expect(result).toEqual({
+      clientId: "test-id",
+      redirectUris: ["http://localhost/cb"],
+      clientName: "Test",
+    });
+  });
+
+  it("counts registered clients", async () => {
+    mockRows.push({ count: 5 });
+    const count = await tokenStore.countRegisteredClients();
+    expect(count).toBe(5);
   });
 });
 
 describe("pending auths", () => {
-  it("creates and retrieves a pending auth", () => {
-    createPendingAuth({
+  it("creates a pending auth", async () => {
+    await tokenStore.createPendingAuth({
       state: "test-state",
       clientId: "client-1",
       clientRedirectUri: "http://localhost/cb",
@@ -65,45 +73,56 @@ describe("pending auths", () => {
       calCodeVerifier: "verifier-123",
     });
 
-    const auth = getPendingAuth("test-state");
+    expect(mockSql).toHaveBeenCalledTimes(1);
+  });
+
+  it("retrieves a pending auth", async () => {
+    mockRows.push({
+      state: "test-state",
+      client_id: "client-1",
+      client_redirect_uri: "http://localhost/cb",
+      client_state: "client-state-abc",
+      client_code_challenge: "challenge-xyz",
+      cal_code_verifier: "verifier-123",
+      expires_at: Math.floor(Date.now() / 1000) + 600,
+    });
+
+    const auth = await tokenStore.getPendingAuth("test-state");
     expect(auth).toBeDefined();
     expect(auth?.clientId).toBe("client-1");
     expect(auth?.clientState).toBe("client-state-abc");
     expect(auth?.calCodeVerifier).toBe("verifier-123");
   });
 
-  it("returns undefined for expired pending auth", () => {
-    createPendingAuth({
-      state: "expired-state",
-      clientId: "client-1",
-      clientRedirectUri: "http://localhost/cb",
-      clientState: "cs",
-      clientCodeChallenge: "cc",
-      calCodeVerifier: "cv",
-      ttlSeconds: -1, // Already expired
-    });
-
-    expect(getPendingAuth("expired-state")).toBeUndefined();
+  it("returns undefined when no rows", async () => {
+    const result = await tokenStore.getPendingAuth("nonexistent");
+    expect(result).toBeUndefined();
   });
 
-  it("deletes a pending auth", () => {
-    createPendingAuth({
-      state: "delete-me",
-      clientId: "client-1",
-      clientRedirectUri: "http://localhost/cb",
-      clientState: "cs",
-      clientCodeChallenge: "cc",
-      calCodeVerifier: "cv",
+  it("handles null calCodeVerifier", async () => {
+    mockRows.push({
+      state: "s",
+      client_id: "c",
+      client_redirect_uri: "http://localhost/cb",
+      client_state: "cs",
+      client_code_challenge: "cc",
+      cal_code_verifier: null,
+      expires_at: Math.floor(Date.now() / 1000) + 600,
     });
 
-    deletePendingAuth("delete-me");
-    expect(getPendingAuth("delete-me")).toBeUndefined();
+    const auth = await tokenStore.getPendingAuth("s");
+    expect(auth?.calCodeVerifier).toBeUndefined();
+  });
+
+  it("deletes a pending auth", async () => {
+    await tokenStore.deletePendingAuth("delete-me");
+    expect(mockSql).toHaveBeenCalledTimes(1);
   });
 });
 
 describe("auth codes", () => {
-  it("creates and consumes an auth code", () => {
-    const code = createAuthCode({
+  it("creates an auth code", async () => {
+    const code = await tokenStore.createAuthCode({
       clientId: "client-1",
       redirectUri: "http://localhost/cb",
       codeChallenge: "challenge-xyz",
@@ -113,32 +132,42 @@ describe("auth codes", () => {
     });
 
     expect(code).toBeTruthy();
+    expect(mockSql).toHaveBeenCalledTimes(1);
+  });
 
-    const consumed = consumeAuthCode(code);
+  it("consumes an auth code", async () => {
+    const { encrypt } = await import("./encryption.js");
+    mockRows.push({
+      code: "test-code",
+      client_id: "client-1",
+      redirect_uri: "http://localhost/cb",
+      code_challenge: "cc",
+      cal_access_token_enc: encrypt("cal-access-token"),
+      cal_refresh_token_enc: encrypt("cal-refresh-token"),
+      cal_token_expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_at: Math.floor(Date.now() / 1000) + 300,
+    });
+
+    const consumed = await tokenStore.consumeAuthCode("test-code");
     expect(consumed).toBeDefined();
     expect(consumed?.clientId).toBe("client-1");
     expect(consumed?.calAccessToken).toBe("cal-access-token");
     expect(consumed?.calRefreshToken).toBe("cal-refresh-token");
+    // SELECT + UPDATE
+    expect(mockSql).toHaveBeenCalledTimes(2);
   });
 
-  it("cannot consume the same code twice", () => {
-    const code = createAuthCode({
-      clientId: "client-1",
-      redirectUri: "http://localhost/cb",
-      codeChallenge: "cc",
-      calAccessToken: "at",
-      calRefreshToken: "rt",
-      calTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
-    });
-
-    expect(consumeAuthCode(code)).toBeDefined();
-    expect(consumeAuthCode(code)).toBeUndefined();
+  it("returns undefined when code not found", async () => {
+    const result = await tokenStore.consumeAuthCode("nonexistent");
+    expect(result).toBeUndefined();
+    // Only the SELECT query
+    expect(mockSql).toHaveBeenCalledTimes(1);
   });
 });
 
 describe("access tokens", () => {
-  it("creates and retrieves an access token", () => {
-    const result = createAccessToken({
+  it("creates an access token", async () => {
+    const result = await tokenStore.createAccessToken({
       clientId: "client-1",
       calAccessToken: "cal-at",
       calRefreshToken: "cal-rt",
@@ -148,79 +177,96 @@ describe("access tokens", () => {
     expect(result.accessToken).toBeTruthy();
     expect(result.refreshToken).toBeTruthy();
     expect(result.expiresIn).toBe(3600);
+  });
 
-    const record = getAccessToken(result.accessToken);
+  it("retrieves an access token", async () => {
+    const { encrypt } = await import("./encryption.js");
+    mockRows.push({
+      token: "test-token",
+      refresh_token: "test-refresh",
+      client_id: "client-1",
+      cal_access_token_enc: encrypt("cal-at"),
+      cal_refresh_token_enc: encrypt("cal-rt"),
+      cal_token_expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    const record = await tokenStore.getAccessToken("test-token");
     expect(record).toBeDefined();
     expect(record?.calAccessToken).toBe("cal-at");
     expect(record?.calRefreshToken).toBe("cal-rt");
   });
 
-  it("retrieves by refresh token", () => {
-    const result = createAccessToken({
-      clientId: "client-1",
-      calAccessToken: "cal-at",
-      calRefreshToken: "cal-rt",
-      calTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+  it("retrieves by refresh token", async () => {
+    const { encrypt } = await import("./encryption.js");
+    mockRows.push({
+      token: "test-token",
+      refresh_token: "test-refresh",
+      client_id: "client-1",
+      cal_access_token_enc: encrypt("cal-at"),
+      cal_refresh_token_enc: encrypt("cal-rt"),
+      cal_token_expires_at: Math.floor(Date.now() / 1000) + 3600,
+      expires_at: Math.floor(Date.now() / 1000) + 3600,
     });
 
-    const record = getAccessTokenByRefresh(result.refreshToken);
+    const record = await tokenStore.getAccessTokenByRefresh("test-refresh");
     expect(record).toBeDefined();
-    expect(record?.token).toBe(result.accessToken);
+    expect(record?.token).toBe("test-token");
   });
 
-  it("deletes an access token", () => {
-    const result = createAccessToken({
-      clientId: "client-1",
-      calAccessToken: "cal-at",
-      calRefreshToken: "cal-rt",
-      calTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
-    });
-
-    deleteAccessToken(result.accessToken);
-    expect(getAccessToken(result.accessToken)).toBeUndefined();
+  it("deletes an access token", async () => {
+    await tokenStore.deleteAccessToken("test-token");
+    expect(mockSql).toHaveBeenCalledTimes(1);
   });
 
-  it("rotates an access token", () => {
-    const original = createAccessToken({
-      clientId: "client-1",
-      calAccessToken: "cal-at",
-      calRefreshToken: "cal-rt",
-      calTokenExpiresAt: Math.floor(Date.now() / 1000) + 3600,
-    });
+  it("rotates an access token", async () => {
+    const { encrypt } = await import("./encryption.js");
 
-    const rotated = rotateAccessToken(original.refreshToken);
+    // First call: getAccessTokenByRefresh SELECT
+    mockSql.mockResolvedValueOnce({
+      rows: [{
+        token: "old-token",
+        refresh_token: "old-refresh",
+        client_id: "client-1",
+        cal_access_token_enc: encrypt("cal-at"),
+        cal_refresh_token_enc: encrypt("cal-rt"),
+        cal_token_expires_at: Math.floor(Date.now() / 1000) + 3600,
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      }],
+      rowCount: 1,
+    });
+    // BEGIN
+    mockSql.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    // DELETE
+    mockSql.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    // INSERT
+    mockSql.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    // COMMIT
+    mockSql.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    const rotated = await tokenStore.rotateAccessToken("old-refresh");
     expect(rotated).toBeDefined();
-    expect(rotated?.accessToken).not.toBe(original.accessToken);
-    expect(rotated?.refreshToken).not.toBe(original.refreshToken);
-
-    // Old token should be gone
-    expect(getAccessToken(original.accessToken)).toBeUndefined();
-
-    // New token should work and have same Cal.com creds
-    const record = getAccessToken(rotated?.accessToken ?? "");
-    expect(record?.calAccessToken).toBe("cal-at");
+    expect(rotated?.accessToken).toBeTruthy();
+    expect(rotated?.refreshToken).toBeTruthy();
+    // getAccessTokenByRefresh + BEGIN + DELETE + INSERT + COMMIT
+    expect(mockSql).toHaveBeenCalledTimes(5);
   });
 
-  it("returns undefined when rotating unknown refresh token", () => {
-    expect(rotateAccessToken("nonexistent")).toBeUndefined();
+  it("returns undefined when rotating unknown refresh token", async () => {
+    const result = await tokenStore.rotateAccessToken("nonexistent");
+    expect(result).toBeUndefined();
+  });
+
+  it("updates Cal.com tokens", async () => {
+    await tokenStore.updateCalTokens("token", "new-cal-at", "new-cal-rt", 999);
+    expect(mockSql).toHaveBeenCalledTimes(1);
   });
 });
 
 describe("cleanupExpired", () => {
-  it("removes expired rows without error", () => {
-    // Create some records that are not expired
-    createPendingAuth({
-      state: "valid-state",
-      clientId: "client-1",
-      clientRedirectUri: "http://localhost/cb",
-      clientState: "cs",
-      clientCodeChallenge: "cc",
-      calCodeVerifier: "cv",
-    });
-
-    expect(() => cleanupExpired()).not.toThrow();
-
-    // Valid record should still exist
-    expect(getPendingAuth("valid-state")).toBeDefined();
+  it("runs cleanup queries without error", async () => {
+    await tokenStore.cleanupExpired();
+    // 3 DELETE queries (pending_auths, auth_codes, access_tokens)
+    expect(mockSql).toHaveBeenCalledTimes(3);
   });
 });

--- a/apps/mcp-server/src/storage/token-store.ts
+++ b/apps/mcp-server/src/storage/token-store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { sql } from "./db.js";
+import { sql, pool } from "./db.js";
 import { encrypt, decrypt } from "./encryption.js";
 
 // ── Registered Clients ──
@@ -252,17 +252,23 @@ export async function rotateAccessToken(oldRefreshToken: string): Promise<{
   const ttl = 3600;
   const expiresAt = Math.floor(Date.now() / 1000) + ttl;
 
-  await sql`BEGIN`;
+  // Dedicated client so BEGIN/DELETE/INSERT/COMMIT share one connection.
+  // The `sql` tagged template pulls a fresh pooled connection per call, which
+  // would make the transaction a no-op.
+  const client = await pool.connect();
   try {
-    await sql`DELETE FROM access_tokens WHERE token = ${existing.token}`;
-    await sql`
+    await client.sql`BEGIN`;
+    await client.sql`DELETE FROM access_tokens WHERE token = ${existing.token}`;
+    await client.sql`
       INSERT INTO access_tokens (token, refresh_token, client_id, cal_access_token_enc, cal_refresh_token_enc, cal_token_expires_at, expires_at)
       VALUES (${token}, ${refreshToken}, ${existing.clientId}, ${encrypt(existing.calAccessToken)}, ${encrypt(existing.calRefreshToken)}, ${existing.calTokenExpiresAt}, ${expiresAt})
     `;
-    await sql`COMMIT`;
+    await client.sql`COMMIT`;
   } catch (err) {
-    await sql`ROLLBACK`;
+    await client.sql`ROLLBACK`;
     throw err;
+  } finally {
+    client.release();
   }
 
   return { accessToken: token, refreshToken, expiresIn: ttl };

--- a/apps/mcp-server/src/storage/token-store.ts
+++ b/apps/mcp-server/src/storage/token-store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { getDb } from "./db.js";
+import { sql } from "./db.js";
 import { encrypt, decrypt } from "./encryption.js";
 
 // ── Registered Clients ──
@@ -10,27 +10,29 @@ export interface RegisteredClient {
   clientName: string | null;
 }
 
-export function createRegisteredClient(redirectUris: string[], clientName?: string): RegisteredClient {
+export async function createRegisteredClient(redirectUris: string[], clientName?: string): Promise<RegisteredClient> {
   const clientId = randomUUID();
-  const db = getDb();
-  db.prepare(
-    "INSERT INTO registered_clients (client_id, redirect_uris, client_name) VALUES (?, ?, ?)",
-  ).run(clientId, JSON.stringify(redirectUris), clientName ?? null);
-  return { clientId, redirectUris, clientName: clientName ?? null };
+  const name = clientName ?? null;
+  await sql`
+    INSERT INTO registered_clients (client_id, redirect_uris, client_name)
+    VALUES (${clientId}, ${JSON.stringify(redirectUris)}, ${name})
+  `;
+  return { clientId, redirectUris, clientName: name };
 }
 
-export function countRegisteredClients(): number {
-  const db = getDb();
-  const row = db.prepare("SELECT COUNT(*) as count FROM registered_clients").get() as { count: number };
-  return row.count;
+export async function countRegisteredClients(): Promise<number> {
+  const { rows } = await sql`SELECT COUNT(*) as count FROM registered_clients`;
+  return Number(rows[0].count);
 }
 
-export function getRegisteredClient(clientId: string): RegisteredClient | undefined {
-  const db = getDb();
-  const row = db
-    .prepare("SELECT client_id, redirect_uris, client_name FROM registered_clients WHERE client_id = ?")
-    .get(clientId) as { client_id: string; redirect_uris: string; client_name: string | null } | undefined;
-  if (!row) return undefined;
+export async function getRegisteredClient(clientId: string): Promise<RegisteredClient | undefined> {
+  const { rows } = await sql`
+    SELECT client_id, redirect_uris, client_name
+    FROM registered_clients
+    WHERE client_id = ${clientId}
+  `;
+  if (rows.length === 0) return undefined;
+  const row = rows[0];
   return {
     clientId: row.client_id,
     redirectUris: JSON.parse(row.redirect_uris) as string[],
@@ -50,37 +52,22 @@ export interface PendingAuth {
   expiresAt: number;
 }
 
-export function createPendingAuth(params: Omit<PendingAuth, "expiresAt"> & { ttlSeconds?: number }): void {
-  const db = getDb();
+export async function createPendingAuth(params: Omit<PendingAuth, "expiresAt"> & { ttlSeconds?: number }): Promise<void> {
   const expiresAt = Math.floor(Date.now() / 1000) + (params.ttlSeconds ?? 600); // 10 min default
-  db.prepare(
-    `INSERT INTO pending_auths (state, client_id, client_redirect_uri, client_state, client_code_challenge, cal_code_verifier, expires_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    params.state,
-    params.clientId,
-    params.clientRedirectUri,
-    params.clientState,
-    params.clientCodeChallenge,
-    params.calCodeVerifier,
-    expiresAt,
-  );
+  const calCodeVerifier = params.calCodeVerifier ?? null;
+  await sql`
+    INSERT INTO pending_auths (state, client_id, client_redirect_uri, client_state, client_code_challenge, cal_code_verifier, expires_at)
+    VALUES (${params.state}, ${params.clientId}, ${params.clientRedirectUri}, ${params.clientState}, ${params.clientCodeChallenge}, ${calCodeVerifier}, ${expiresAt})
+  `;
 }
 
-export function getPendingAuth(state: string): PendingAuth | undefined {
-  const db = getDb();
-  const row = db
-    .prepare("SELECT * FROM pending_auths WHERE state = ? AND expires_at > unixepoch()")
-    .get(state) as {
-    state: string;
-    client_id: string;
-    client_redirect_uri: string;
-    client_state: string;
-    client_code_challenge: string;
-    cal_code_verifier: string | null;
-    expires_at: number;
-  } | undefined;
-  if (!row) return undefined;
+export async function getPendingAuth(state: string): Promise<PendingAuth | undefined> {
+  const { rows } = await sql`
+    SELECT * FROM pending_auths
+    WHERE state = ${state} AND expires_at > EXTRACT(EPOCH FROM NOW())::INTEGER
+  `;
+  if (rows.length === 0) return undefined;
+  const row = rows[0];
   return {
     state: row.state,
     clientId: row.client_id,
@@ -92,9 +79,8 @@ export function getPendingAuth(state: string): PendingAuth | undefined {
   };
 }
 
-export function deletePendingAuth(state: string): void {
-  const db = getDb();
-  db.prepare("DELETE FROM pending_auths WHERE state = ?").run(state);
+export async function deletePendingAuth(state: string): Promise<void> {
+  await sql`DELETE FROM pending_auths WHERE state = ${state}`;
 }
 
 // ── Auth Codes ──
@@ -111,51 +97,33 @@ export interface AuthCode {
   used: boolean;
 }
 
-export function createAuthCode(params: {
+export async function createAuthCode(params: {
   clientId: string;
   redirectUri: string;
   codeChallenge: string;
   calAccessToken: string;
   calRefreshToken: string;
   calTokenExpiresAt: number;
-}): string {
+}): Promise<string> {
   const code = randomUUID();
-  const db = getDb();
   const expiresAt = Math.floor(Date.now() / 1000) + 300; // 5 min
-  db.prepare(
-    `INSERT INTO auth_codes (code, client_id, redirect_uri, code_challenge, cal_access_token_enc, cal_refresh_token_enc, cal_token_expires_at, expires_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    code,
-    params.clientId,
-    params.redirectUri,
-    params.codeChallenge,
-    encrypt(params.calAccessToken),
-    encrypt(params.calRefreshToken),
-    params.calTokenExpiresAt,
-    expiresAt,
-  );
+  await sql`
+    INSERT INTO auth_codes (code, client_id, redirect_uri, code_challenge, cal_access_token_enc, cal_refresh_token_enc, cal_token_expires_at, expires_at)
+    VALUES (${code}, ${params.clientId}, ${params.redirectUri}, ${params.codeChallenge}, ${encrypt(params.calAccessToken)}, ${encrypt(params.calRefreshToken)}, ${params.calTokenExpiresAt}, ${expiresAt})
+  `;
   return code;
 }
 
-export function consumeAuthCode(code: string): AuthCode | undefined {
-  const db = getDb();
-  const row = db
-    .prepare("SELECT * FROM auth_codes WHERE code = ? AND expires_at > unixepoch() AND used = 0")
-    .get(code) as {
-    code: string;
-    client_id: string;
-    redirect_uri: string;
-    code_challenge: string;
-    cal_access_token_enc: string;
-    cal_refresh_token_enc: string;
-    cal_token_expires_at: number;
-    expires_at: number;
-  } | undefined;
-  if (!row) return undefined;
+export async function consumeAuthCode(code: string): Promise<AuthCode | undefined> {
+  const { rows } = await sql`
+    SELECT * FROM auth_codes
+    WHERE code = ${code} AND expires_at > EXTRACT(EPOCH FROM NOW())::INTEGER AND used = 0
+  `;
+  if (rows.length === 0) return undefined;
 
-  db.prepare("UPDATE auth_codes SET used = 1 WHERE code = ?").run(code);
+  await sql`UPDATE auth_codes SET used = 1 WHERE code = ${code}`;
 
+  const row = rows[0];
   return {
     code: row.code,
     clientId: row.client_id,
@@ -181,47 +149,31 @@ export interface AccessTokenRecord {
   expiresAt: number;
 }
 
-export function createAccessToken(params: {
+export async function createAccessToken(params: {
   clientId: string;
   calAccessToken: string;
   calRefreshToken: string;
   calTokenExpiresAt: number;
   ttlSeconds?: number;
-}): { accessToken: string; refreshToken: string; expiresIn: number } {
+}): Promise<{ accessToken: string; refreshToken: string; expiresIn: number }> {
   const token = randomUUID();
   const refreshToken = randomUUID();
   const ttl = params.ttlSeconds ?? 3600; // 1 hour default
   const expiresAt = Math.floor(Date.now() / 1000) + ttl;
-  const db = getDb();
-  db.prepare(
-    `INSERT INTO access_tokens (token, refresh_token, client_id, cal_access_token_enc, cal_refresh_token_enc, cal_token_expires_at, expires_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    token,
-    refreshToken,
-    params.clientId,
-    encrypt(params.calAccessToken),
-    encrypt(params.calRefreshToken),
-    params.calTokenExpiresAt,
-    expiresAt,
-  );
+  await sql`
+    INSERT INTO access_tokens (token, refresh_token, client_id, cal_access_token_enc, cal_refresh_token_enc, cal_token_expires_at, expires_at)
+    VALUES (${token}, ${refreshToken}, ${params.clientId}, ${encrypt(params.calAccessToken)}, ${encrypt(params.calRefreshToken)}, ${params.calTokenExpiresAt}, ${expiresAt})
+  `;
   return { accessToken: token, refreshToken, expiresIn: ttl };
 }
 
-export function getAccessToken(token: string): AccessTokenRecord | undefined {
-  const db = getDb();
-  const row = db
-    .prepare("SELECT * FROM access_tokens WHERE token = ? AND expires_at > unixepoch()")
-    .get(token) as {
-    token: string;
-    refresh_token: string;
-    client_id: string;
-    cal_access_token_enc: string;
-    cal_refresh_token_enc: string;
-    cal_token_expires_at: number;
-    expires_at: number;
-  } | undefined;
-  if (!row) return undefined;
+export async function getAccessToken(token: string): Promise<AccessTokenRecord | undefined> {
+  const { rows } = await sql`
+    SELECT * FROM access_tokens
+    WHERE token = ${token} AND expires_at > EXTRACT(EPOCH FROM NOW())::INTEGER
+  `;
+  if (rows.length === 0) return undefined;
+  const row = rows[0];
   return {
     token: row.token,
     refreshToken: row.refresh_token,
@@ -233,20 +185,12 @@ export function getAccessToken(token: string): AccessTokenRecord | undefined {
   };
 }
 
-export function getAccessTokenByRefresh(refreshToken: string): AccessTokenRecord | undefined {
-  const db = getDb();
-  const row = db
-    .prepare("SELECT * FROM access_tokens WHERE refresh_token = ?")
-    .get(refreshToken) as {
-    token: string;
-    refresh_token: string;
-    client_id: string;
-    cal_access_token_enc: string;
-    cal_refresh_token_enc: string;
-    cal_token_expires_at: number;
-    expires_at: number;
-  } | undefined;
-  if (!row) return undefined;
+export async function getAccessTokenByRefresh(refreshToken: string): Promise<AccessTokenRecord | undefined> {
+  const { rows } = await sql`
+    SELECT * FROM access_tokens WHERE refresh_token = ${refreshToken}
+  `;
+  if (rows.length === 0) return undefined;
+  const row = rows[0];
   return {
     token: row.token,
     refreshToken: row.refresh_token,
@@ -261,59 +205,66 @@ export function getAccessTokenByRefresh(refreshToken: string): AccessTokenRecord
 /**
  * Update the Cal.com tokens for an existing access token (e.g. after refresh).
  */
-export function updateCalTokens(
+export async function updateCalTokens(
   token: string,
   calAccessToken: string,
   calRefreshToken: string,
   calTokenExpiresAt: number,
-): void {
-  const db = getDb();
-  db.prepare(
-    `UPDATE access_tokens SET cal_access_token_enc = ?, cal_refresh_token_enc = ?, cal_token_expires_at = ?
-     WHERE token = ?`,
-  ).run(encrypt(calAccessToken), encrypt(calRefreshToken), calTokenExpiresAt, token);
+): Promise<void> {
+  await sql`
+    UPDATE access_tokens
+    SET cal_access_token_enc = ${encrypt(calAccessToken)},
+        cal_refresh_token_enc = ${encrypt(calRefreshToken)},
+        cal_token_expires_at = ${calTokenExpiresAt}
+    WHERE token = ${token}
+  `;
 }
 
 /**
  * Delete an access token (revocation).
  */
-export function deleteAccessToken(token: string): void {
-  const db = getDb();
-  db.prepare("DELETE FROM access_tokens WHERE token = ?").run(token);
+export async function deleteAccessToken(token: string): Promise<void> {
+  await sql`DELETE FROM access_tokens WHERE token = ${token}`;
 }
 
 /**
  * Delete an access token by its refresh token (for RFC 7009 revocation).
  */
-export function deleteAccessTokenByRefresh(refreshToken: string): void {
-  const db = getDb();
-  db.prepare("DELETE FROM access_tokens WHERE refresh_token = ?").run(refreshToken);
+export async function deleteAccessTokenByRefresh(refreshToken: string): Promise<void> {
+  await sql`DELETE FROM access_tokens WHERE refresh_token = ${refreshToken}`;
 }
 
 /**
  * Rotate: delete old token, issue new one with same Cal.com creds.
- * Wrapped in a transaction so that if createAccessToken fails, the old token is not lost.
+ * Wrapped in a transaction so that if the insert fails, the old token is not lost.
  */
-export function rotateAccessToken(oldRefreshToken: string): {
+export async function rotateAccessToken(oldRefreshToken: string): Promise<{
   accessToken: string;
   refreshToken: string;
   expiresIn: number;
-} | undefined {
-  const existing = getAccessTokenByRefresh(oldRefreshToken);
+} | undefined> {
+  const existing = await getAccessTokenByRefresh(oldRefreshToken);
   if (!existing) return undefined;
 
-  const db = getDb();
-  const rotate = db.transaction(() => {
-    deleteAccessToken(existing.token);
-    return createAccessToken({
-      clientId: existing.clientId,
-      calAccessToken: existing.calAccessToken,
-      calRefreshToken: existing.calRefreshToken,
-      calTokenExpiresAt: existing.calTokenExpiresAt,
-    });
-  });
+  const token = randomUUID();
+  const refreshToken = randomUUID();
+  const ttl = 3600;
+  const expiresAt = Math.floor(Date.now() / 1000) + ttl;
 
-  return rotate();
+  await sql`BEGIN`;
+  try {
+    await sql`DELETE FROM access_tokens WHERE token = ${existing.token}`;
+    await sql`
+      INSERT INTO access_tokens (token, refresh_token, client_id, cal_access_token_enc, cal_refresh_token_enc, cal_token_expires_at, expires_at)
+      VALUES (${token}, ${refreshToken}, ${existing.clientId}, ${encrypt(existing.calAccessToken)}, ${encrypt(existing.calRefreshToken)}, ${existing.calTokenExpiresAt}, ${expiresAt})
+    `;
+    await sql`COMMIT`;
+  } catch (err) {
+    await sql`ROLLBACK`;
+    throw err;
+  }
+
+  return { accessToken: token, refreshToken, expiresIn: ttl };
 }
 
 // ── Cleanup ──
@@ -321,9 +272,8 @@ export function rotateAccessToken(oldRefreshToken: string): {
 /**
  * Remove expired rows from all tables.
  */
-export function cleanupExpired(): void {
-  const db = getDb();
-  db.prepare("DELETE FROM pending_auths WHERE expires_at <= unixepoch()").run();
-  db.prepare("DELETE FROM auth_codes WHERE expires_at <= unixepoch()").run();
-  db.prepare("DELETE FROM access_tokens WHERE expires_at <= unixepoch()").run();
+export async function cleanupExpired(): Promise<void> {
+  await sql`DELETE FROM pending_auths WHERE expires_at <= EXTRACT(EPOCH FROM NOW())::INTEGER`;
+  await sql`DELETE FROM auth_codes WHERE expires_at <= EXTRACT(EPOCH FROM NOW())::INTEGER`;
+  await sql`DELETE FROM access_tokens WHERE expires_at <= EXTRACT(EPOCH FROM NOW())::INTEGER`;
 }

--- a/apps/mcp-server/src/storage/token-store.ts
+++ b/apps/mcp-server/src/storage/token-store.ts
@@ -115,13 +115,14 @@ export async function createAuthCode(params: {
 }
 
 export async function consumeAuthCode(code: string): Promise<AuthCode | undefined> {
+  // Atomic single-use consumption: UPDATE...RETURNING ensures only one concurrent
+  // caller can successfully consume the code (RFC 6749 §10.5).
   const { rows } = await sql`
-    SELECT * FROM auth_codes
+    UPDATE auth_codes SET used = 1
     WHERE code = ${code} AND expires_at > EXTRACT(EPOCH FROM NOW())::INTEGER AND used = 0
+    RETURNING *
   `;
   if (rows.length === 0) return undefined;
-
-  await sql`UPDATE auth_codes SET used = 1 WHERE code = ${code}`;
 
   const row = rows[0];
   return {

--- a/apps/mcp-server/src/storage/token-store.ts
+++ b/apps/mcp-server/src/storage/token-store.ts
@@ -14,29 +14,29 @@ export async function createRegisteredClient(redirectUris: string[], clientName?
   const clientId = randomUUID();
   const name = clientName ?? null;
   await sql`
-    INSERT INTO registered_clients (client_id, redirect_uris, client_name)
+    INSERT INTO "RegisteredClient" ("clientId", "redirectUris", "clientName")
     VALUES (${clientId}, ${JSON.stringify(redirectUris)}, ${name})
   `;
   return { clientId, redirectUris, clientName: name };
 }
 
 export async function countRegisteredClients(): Promise<number> {
-  const { rows } = await sql`SELECT COUNT(*) as count FROM registered_clients`;
+  const { rows } = await sql`SELECT COUNT(*) as count FROM "RegisteredClient"`;
   return Number(rows[0].count);
 }
 
 export async function getRegisteredClient(clientId: string): Promise<RegisteredClient | undefined> {
   const { rows } = await sql`
-    SELECT client_id, redirect_uris, client_name
-    FROM registered_clients
-    WHERE client_id = ${clientId}
+    SELECT "clientId", "redirectUris", "clientName"
+    FROM "RegisteredClient"
+    WHERE "clientId" = ${clientId}
   `;
   if (rows.length === 0) return undefined;
   const row = rows[0];
   return {
-    clientId: row.client_id,
-    redirectUris: JSON.parse(row.redirect_uris) as string[],
-    clientName: row.client_name,
+    clientId: row.clientId,
+    redirectUris: JSON.parse(row.redirectUris) as string[],
+    clientName: row.clientName,
   };
 }
 
@@ -56,31 +56,31 @@ export async function createPendingAuth(params: Omit<PendingAuth, "expiresAt"> &
   const expiresAt = Math.floor(Date.now() / 1000) + (params.ttlSeconds ?? 600); // 10 min default
   const calCodeVerifier = params.calCodeVerifier ?? null;
   await sql`
-    INSERT INTO pending_auths (state, client_id, client_redirect_uri, client_state, client_code_challenge, cal_code_verifier, expires_at)
+    INSERT INTO "PendingAuth" ("state", "clientId", "clientRedirectUri", "clientState", "clientCodeChallenge", "calCodeVerifier", "expiresAt")
     VALUES (${params.state}, ${params.clientId}, ${params.clientRedirectUri}, ${params.clientState}, ${params.clientCodeChallenge}, ${calCodeVerifier}, ${expiresAt})
   `;
 }
 
 export async function getPendingAuth(state: string): Promise<PendingAuth | undefined> {
   const { rows } = await sql`
-    SELECT * FROM pending_auths
-    WHERE state = ${state} AND expires_at > EXTRACT(EPOCH FROM NOW())::INTEGER
+    SELECT * FROM "PendingAuth"
+    WHERE "state" = ${state} AND "expiresAt" > EXTRACT(EPOCH FROM NOW())::INTEGER
   `;
   if (rows.length === 0) return undefined;
   const row = rows[0];
   return {
     state: row.state,
-    clientId: row.client_id,
-    clientRedirectUri: row.client_redirect_uri,
-    clientState: row.client_state,
-    clientCodeChallenge: row.client_code_challenge,
-    calCodeVerifier: row.cal_code_verifier ?? undefined,
-    expiresAt: row.expires_at,
+    clientId: row.clientId,
+    clientRedirectUri: row.clientRedirectUri,
+    clientState: row.clientState,
+    clientCodeChallenge: row.clientCodeChallenge,
+    calCodeVerifier: row.calCodeVerifier ?? undefined,
+    expiresAt: row.expiresAt,
   };
 }
 
 export async function deletePendingAuth(state: string): Promise<void> {
-  await sql`DELETE FROM pending_auths WHERE state = ${state}`;
+  await sql`DELETE FROM "PendingAuth" WHERE "state" = ${state}`;
 }
 
 // ── Auth Codes ──
@@ -108,7 +108,7 @@ export async function createAuthCode(params: {
   const code = randomUUID();
   const expiresAt = Math.floor(Date.now() / 1000) + 300; // 5 min
   await sql`
-    INSERT INTO auth_codes (code, client_id, redirect_uri, code_challenge, cal_access_token_enc, cal_refresh_token_enc, cal_token_expires_at, expires_at)
+    INSERT INTO "AuthCode" ("code", "clientId", "redirectUri", "codeChallenge", "calAccessTokenEnc", "calRefreshTokenEnc", "calTokenExpiresAt", "expiresAt")
     VALUES (${code}, ${params.clientId}, ${params.redirectUri}, ${params.codeChallenge}, ${encrypt(params.calAccessToken)}, ${encrypt(params.calRefreshToken)}, ${params.calTokenExpiresAt}, ${expiresAt})
   `;
   return code;
@@ -118,8 +118,8 @@ export async function consumeAuthCode(code: string): Promise<AuthCode | undefine
   // Atomic single-use consumption: UPDATE...RETURNING ensures only one concurrent
   // caller can successfully consume the code (RFC 6749 §10.5).
   const { rows } = await sql`
-    UPDATE auth_codes SET used = 1
-    WHERE code = ${code} AND expires_at > EXTRACT(EPOCH FROM NOW())::INTEGER AND used = 0
+    UPDATE "AuthCode" SET "used" = 1
+    WHERE "code" = ${code} AND "expiresAt" > EXTRACT(EPOCH FROM NOW())::INTEGER AND "used" = 0
     RETURNING *
   `;
   if (rows.length === 0) return undefined;
@@ -127,13 +127,13 @@ export async function consumeAuthCode(code: string): Promise<AuthCode | undefine
   const row = rows[0];
   return {
     code: row.code,
-    clientId: row.client_id,
-    redirectUri: row.redirect_uri,
-    codeChallenge: row.code_challenge,
-    calAccessToken: decrypt(row.cal_access_token_enc),
-    calRefreshToken: decrypt(row.cal_refresh_token_enc),
-    calTokenExpiresAt: row.cal_token_expires_at,
-    expiresAt: row.expires_at,
+    clientId: row.clientId,
+    redirectUri: row.redirectUri,
+    codeChallenge: row.codeChallenge,
+    calAccessToken: decrypt(row.calAccessTokenEnc),
+    calRefreshToken: decrypt(row.calRefreshTokenEnc),
+    calTokenExpiresAt: row.calTokenExpiresAt,
+    expiresAt: row.expiresAt,
     used: true,
   };
 }
@@ -162,7 +162,7 @@ export async function createAccessToken(params: {
   const ttl = params.ttlSeconds ?? 3600; // 1 hour default
   const expiresAt = Math.floor(Date.now() / 1000) + ttl;
   await sql`
-    INSERT INTO access_tokens (token, refresh_token, client_id, cal_access_token_enc, cal_refresh_token_enc, cal_token_expires_at, expires_at)
+    INSERT INTO "AccessToken" ("token", "refreshToken", "clientId", "calAccessTokenEnc", "calRefreshTokenEnc", "calTokenExpiresAt", "expiresAt")
     VALUES (${token}, ${refreshToken}, ${params.clientId}, ${encrypt(params.calAccessToken)}, ${encrypt(params.calRefreshToken)}, ${params.calTokenExpiresAt}, ${expiresAt})
   `;
   return { accessToken: token, refreshToken, expiresIn: ttl };
@@ -170,36 +170,36 @@ export async function createAccessToken(params: {
 
 export async function getAccessToken(token: string): Promise<AccessTokenRecord | undefined> {
   const { rows } = await sql`
-    SELECT * FROM access_tokens
-    WHERE token = ${token} AND expires_at > EXTRACT(EPOCH FROM NOW())::INTEGER
+    SELECT * FROM "AccessToken"
+    WHERE "token" = ${token} AND "expiresAt" > EXTRACT(EPOCH FROM NOW())::INTEGER
   `;
   if (rows.length === 0) return undefined;
   const row = rows[0];
   return {
     token: row.token,
-    refreshToken: row.refresh_token,
-    clientId: row.client_id,
-    calAccessToken: decrypt(row.cal_access_token_enc),
-    calRefreshToken: decrypt(row.cal_refresh_token_enc),
-    calTokenExpiresAt: row.cal_token_expires_at,
-    expiresAt: row.expires_at,
+    refreshToken: row.refreshToken,
+    clientId: row.clientId,
+    calAccessToken: decrypt(row.calAccessTokenEnc),
+    calRefreshToken: decrypt(row.calRefreshTokenEnc),
+    calTokenExpiresAt: row.calTokenExpiresAt,
+    expiresAt: row.expiresAt,
   };
 }
 
 export async function getAccessTokenByRefresh(refreshToken: string): Promise<AccessTokenRecord | undefined> {
   const { rows } = await sql`
-    SELECT * FROM access_tokens WHERE refresh_token = ${refreshToken}
+    SELECT * FROM "AccessToken" WHERE "refreshToken" = ${refreshToken}
   `;
   if (rows.length === 0) return undefined;
   const row = rows[0];
   return {
     token: row.token,
-    refreshToken: row.refresh_token,
-    clientId: row.client_id,
-    calAccessToken: decrypt(row.cal_access_token_enc),
-    calRefreshToken: decrypt(row.cal_refresh_token_enc),
-    calTokenExpiresAt: row.cal_token_expires_at,
-    expiresAt: row.expires_at,
+    refreshToken: row.refreshToken,
+    clientId: row.clientId,
+    calAccessToken: decrypt(row.calAccessTokenEnc),
+    calRefreshToken: decrypt(row.calRefreshTokenEnc),
+    calTokenExpiresAt: row.calTokenExpiresAt,
+    expiresAt: row.expiresAt,
   };
 }
 
@@ -213,11 +213,11 @@ export async function updateCalTokens(
   calTokenExpiresAt: number,
 ): Promise<void> {
   await sql`
-    UPDATE access_tokens
-    SET cal_access_token_enc = ${encrypt(calAccessToken)},
-        cal_refresh_token_enc = ${encrypt(calRefreshToken)},
-        cal_token_expires_at = ${calTokenExpiresAt}
-    WHERE token = ${token}
+    UPDATE "AccessToken"
+    SET "calAccessTokenEnc" = ${encrypt(calAccessToken)},
+        "calRefreshTokenEnc" = ${encrypt(calRefreshToken)},
+        "calTokenExpiresAt" = ${calTokenExpiresAt}
+    WHERE "token" = ${token}
   `;
 }
 
@@ -225,14 +225,14 @@ export async function updateCalTokens(
  * Delete an access token (revocation).
  */
 export async function deleteAccessToken(token: string): Promise<void> {
-  await sql`DELETE FROM access_tokens WHERE token = ${token}`;
+  await sql`DELETE FROM "AccessToken" WHERE "token" = ${token}`;
 }
 
 /**
  * Delete an access token by its refresh token (for RFC 7009 revocation).
  */
 export async function deleteAccessTokenByRefresh(refreshToken: string): Promise<void> {
-  await sql`DELETE FROM access_tokens WHERE refresh_token = ${refreshToken}`;
+  await sql`DELETE FROM "AccessToken" WHERE "refreshToken" = ${refreshToken}`;
 }
 
 /**
@@ -258,9 +258,9 @@ export async function rotateAccessToken(oldRefreshToken: string): Promise<{
   const client = await pool.connect();
   try {
     await client.sql`BEGIN`;
-    await client.sql`DELETE FROM access_tokens WHERE token = ${existing.token}`;
+    await client.sql`DELETE FROM "AccessToken" WHERE "token" = ${existing.token}`;
     await client.sql`
-      INSERT INTO access_tokens (token, refresh_token, client_id, cal_access_token_enc, cal_refresh_token_enc, cal_token_expires_at, expires_at)
+      INSERT INTO "AccessToken" ("token", "refreshToken", "clientId", "calAccessTokenEnc", "calRefreshTokenEnc", "calTokenExpiresAt", "expiresAt")
       VALUES (${token}, ${refreshToken}, ${existing.clientId}, ${encrypt(existing.calAccessToken)}, ${encrypt(existing.calRefreshToken)}, ${existing.calTokenExpiresAt}, ${expiresAt})
     `;
     await client.sql`COMMIT`;
@@ -280,7 +280,7 @@ export async function rotateAccessToken(oldRefreshToken: string): Promise<{
  * Remove expired rows from all tables.
  */
 export async function cleanupExpired(): Promise<void> {
-  await sql`DELETE FROM pending_auths WHERE expires_at <= EXTRACT(EPOCH FROM NOW())::INTEGER`;
-  await sql`DELETE FROM auth_codes WHERE expires_at <= EXTRACT(EPOCH FROM NOW())::INTEGER`;
-  await sql`DELETE FROM access_tokens WHERE expires_at <= EXTRACT(EPOCH FROM NOW())::INTEGER`;
+  await sql`DELETE FROM "PendingAuth" WHERE "expiresAt" <= EXTRACT(EPOCH FROM NOW())::INTEGER`;
+  await sql`DELETE FROM "AuthCode" WHERE "expiresAt" <= EXTRACT(EPOCH FROM NOW())::INTEGER`;
+  await sql`DELETE FROM "AccessToken" WHERE "expiresAt" <= EXTRACT(EPOCH FROM NOW())::INTEGER`;
 }

--- a/bun.lock
+++ b/bun.lock
@@ -56,12 +56,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "better-sqlite3": "^12.8.0",
+        "@vercel/postgres": "^0.10.0",
         "zod": "^3.24.4",
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.10",
-        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "22.19.6",
         "tsx": "^4.19.4",
         "typescript": "5.9.3",
@@ -666,6 +665,8 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
+    "@neondatabase/serverless": ["@neondatabase/serverless@0.9.5", "", { "dependencies": { "@types/pg": "8.11.6" } }, "sha512-siFas6gItqv6wD/pZnvdu34wEqgG3nSE6zWZdq5j2DEsa+VvX8i/5HXJOo06qrw5axPXn+lGCxeR+NLaSPIXug=="],
+
     "@next/env": ["@next/env@16.1.6", "", {}, "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ=="],
 
     "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.1.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw=="],
@@ -916,8 +917,6 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
-
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/chrome": ["@types/chrome@0.1.31", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-8fC9t02LRdqlSQ9bktaiLjP0NKujPNPaCKPfXxfIjZ35A9u831XY0pt0UEf2oup2SjcUEAaIYOB8mzJ51jhjmA=="],
@@ -953,6 +952,8 @@
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@22.19.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ=="],
+
+    "@types/pg": ["@types/pg@8.11.6", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^4.0.1" } }, "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ=="],
 
     "@types/react": ["@types/react@19.2.10", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw=="],
 
@@ -997,6 +998,8 @@
     "@vercel/functions": ["@vercel/functions@3.4.3", "", { "dependencies": { "@vercel/oidc": "3.2.0" }, "peerDependencies": { "@aws-sdk/credential-provider-web-identity": "*" }, "optionalPeers": ["@aws-sdk/credential-provider-web-identity"] }, "sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
+    "@vercel/postgres": ["@vercel/postgres@0.10.0", "", { "dependencies": { "@neondatabase/serverless": "^0.9.3", "bufferutil": "^4.0.8", "ws": "^8.17.1" } }, "sha512-fSD23DxGND40IzSkXjcFcxr53t3Tiym59Is0jSYIFpG4/0f0KO9SGtcp1sXiebvPaGe7N/tU05cH4yt2S6/IPg=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
@@ -1126,15 +1129,9 @@
 
     "better-opn": ["better-opn@3.0.2", "", { "dependencies": { "open": "^8.0.4" } }, "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ=="],
 
-    "better-sqlite3": ["better-sqlite3@12.8.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ=="],
-
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
-
-    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
-
-    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 
@@ -1159,6 +1156,8 @@
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -1194,7 +1193,7 @@
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
-    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "chrome-launcher": ["chrome-launcher@1.2.0", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^2.0.1" }, "bin": { "print-chrome-path": "bin/print-chrome-path.cjs" } }, "sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q=="],
 
@@ -1306,8 +1305,6 @@
 
     "decode-uri-component": ["decode-uri-component@0.2.2", "", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
-    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
-
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
@@ -1376,8 +1373,6 @@
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
-    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
-
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-editor": ["env-editor@0.4.2", "", {}, "sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA=="],
@@ -1445,8 +1440,6 @@
     "exec-async": ["exec-async@2.2.0", "", {}, "sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw=="],
 
     "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
-
-    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
@@ -1552,8 +1545,6 @@
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
-    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
-
     "filesize": ["filesize@11.0.13", "", {}, "sha512-mYJ/qXKvREuO0uH8LTQJ6v7GsUvVOguqxg2VTwQUkyTPXXRRWPdjuUPVqdBrJQhvci48OHlNGRnux+Slr2Rnvw=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
@@ -1590,8 +1581,6 @@
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
-    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
-
     "fs-extra": ["fs-extra@11.3.4", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
@@ -1625,8 +1614,6 @@
     "getenv": ["getenv@2.0.0", "", {}, "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ=="],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
-
-    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
@@ -1704,7 +1691,7 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+    "ini": ["ini@4.1.3", "", {}, "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg=="],
 
     "inline-style-prefixer": ["inline-style-prefixer@7.0.1", "", { "dependencies": { "css-in-js-utils": "^3.1.0" } }, "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw=="],
 
@@ -2058,8 +2045,6 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
-
     "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
@@ -2069,8 +2054,6 @@
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
-
-    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "mlly": ["mlly@1.8.1", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ=="],
 
@@ -2086,8 +2069,6 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
-
     "nativewind": ["nativewind@4.2.1", "", { "dependencies": { "comment-json": "^4.2.5", "debug": "^4.3.7", "react-native-css-interop": "0.2.1" }, "peerDependencies": { "tailwindcss": ">3.3.0" } }, "sha512-10uUB2Dlli3MH3NDL5nMHqJHz1A3e/E6mzjTj6cl7hHECClJ7HpE6v+xZL+GXdbwQSnWE+UWMIMsNz7yOQkAJQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
@@ -2098,13 +2079,13 @@
 
     "next": ["next@16.1.6", "", { "dependencies": { "@next/env": "16.1.6", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.6", "@next/swc-darwin-x64": "16.1.6", "@next/swc-linux-arm64-gnu": "16.1.6", "@next/swc-linux-arm64-musl": "16.1.6", "@next/swc-linux-x64-gnu": "16.1.6", "@next/swc-linux-x64-musl": "16.1.6", "@next/swc-win32-arm64-msvc": "16.1.6", "@next/swc-win32-x64-msvc": "16.1.6", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw=="],
 
-    "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
-
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
     "node-forge": ["node-forge@1.3.3", "", {}, "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
 
@@ -2131,6 +2112,8 @@
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "obuf": ["obuf@1.1.2", "", {}, "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="],
 
     "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
 
@@ -2200,6 +2183,14 @@
 
     "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
 
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-numeric": ["pg-numeric@1.0.2", "", {}, "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw=="],
+
+    "pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
+
+    "pg-types": ["pg-types@4.1.0", "", { "dependencies": { "pg-int8": "1.0.1", "pg-numeric": "1.0.2", "postgres-array": "~3.0.1", "postgres-bytea": "~3.0.0", "postgres-date": "~2.1.0", "postgres-interval": "^3.0.0", "postgres-range": "^1.1.1" } }, "sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -2238,9 +2229,17 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
-    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+    "postgres-array": ["postgres-array@3.0.4", "", {}, "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ=="],
 
-    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+    "postgres-bytea": ["postgres-bytea@3.0.0", "", { "dependencies": { "obuf": "~1.1.2" } }, "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw=="],
+
+    "postgres-date": ["postgres-date@2.1.0", "", {}, "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA=="],
+
+    "postgres-interval": ["postgres-interval@3.0.0", "", {}, "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw=="],
+
+    "postgres-range": ["postgres-range@1.1.4", "", {}, "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w=="],
+
+    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -2269,8 +2268,6 @@
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "publish-browser-extension": ["publish-browser-extension@3.0.3", "", { "dependencies": { "cac": "^6.7.14", "consola": "^3.4.2", "dotenv": "^17.2.3", "form-data-encoder": "^4.1.0", "formdata-node": "^6.0.3", "listr2": "^8.3.3", "ofetch": "^1.4.1", "zod": "^3.25.76 || ^4.0.0" }, "bin": { "publish-extension": "bin/publish-extension.cjs" } }, "sha512-cBINZCkLo7YQaGoUvEHthZ0sDzgJQht28IS+SFMT2omSNhGsPiVNRkWir3qLiTrhGhW9Ci2KVHpA1QAMoBdL2g=="],
-
-    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -2412,7 +2409,7 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
@@ -2465,10 +2462,6 @@
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
-
-    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
     "simple-plist": ["simple-plist@1.3.1", "", { "dependencies": { "bplist-creator": "0.1.0", "bplist-parser": "0.3.1", "plist": "^3.0.5" } }, "sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw=="],
 
@@ -2566,10 +2559,6 @@
 
     "tar": ["tar@7.5.10", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw=="],
 
-    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
-
-    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
-
     "temp-dir": ["temp-dir@2.0.0", "", {}, "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="],
 
     "terminal-link": ["terminal-link@2.1.1", "", { "dependencies": { "ansi-escapes": "^4.2.1", "supports-hyperlinks": "^2.0.0" } }, "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ=="],
@@ -2621,8 +2610,6 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
-
-    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
@@ -2762,7 +2749,7 @@
 
     "write-file-atomic": ["write-file-atomic@4.0.2", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^3.0.7" } }, "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg=="],
 
-    "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
@@ -2887,8 +2874,6 @@
     "@expo/cli/send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
 
     "@expo/cli/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "@expo/cli/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "@expo/cli/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -3028,6 +3013,8 @@
 
     "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
+    "@react-native/dev-middleware/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
     "@slack/web-api/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
@@ -3056,8 +3043,6 @@
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
-    "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
     "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "boxen/chalk": ["chalk@5.3.0", "", {}, "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="],
@@ -3083,6 +3068,10 @@
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "compression/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
+
+    "compression/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "config-chain/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
@@ -3120,8 +3109,6 @@
 
     "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "firefox-profile/ini": ["ini@4.1.3", "", {}, "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg=="],
-
     "firefox-profile/xml2js": ["xml2js@0.6.2", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -3135,6 +3122,8 @@
     "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "global-directory/ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
+
+    "global-dirs/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
@@ -3200,6 +3189,8 @@
 
     "metro/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
 
+    "metro/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
     "metro-babel-transformer/hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
 
     "metro-config/metro-runtime": ["metro-runtime@0.83.3", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-JHCJb9ebr9rfJ+LcssFYA2x1qPYuSD/bbePupIGhpMrsla7RCwC/VL3yJ9cSU+nUhU4c9Ixxy8tBta+JbDeZWw=="],
@@ -3231,8 +3222,6 @@
     "multimatch/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "nativewind/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "node-abi/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "node-notifier/is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
 
@@ -3272,7 +3261,11 @@
 
     "publish-browser-extension/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "react-native/@react-native/normalize-colors": ["@react-native/normalize-colors@0.83.1", "", {}, "sha512-84feABbmeWo1kg81726UOlMKAhcQyFXYz2SjRKYkS78QmfhVDhJ2o/ps1VjhFfBz0i/scDwT1XNv9GwmRIghkg=="],
 
@@ -3284,6 +3277,8 @@
 
     "react-native/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "react-native/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
     "react-native-css-interop/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "react-native-css-interop/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
@@ -3293,8 +3288,6 @@
     "react-native-worklets/@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
 
     "react-native-worklets/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
-
-    "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "requireg/resolve": ["resolve@1.7.1", "", { "dependencies": { "path-parse": "^1.0.5" } }, "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw=="],
 
@@ -3326,8 +3319,6 @@
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "string_decoder/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
-
     "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
@@ -3341,10 +3332,6 @@
     "tailwindcss/micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "tailwindcss/postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
-
-    "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
-
-    "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "terminal-link/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
@@ -3569,6 +3556,8 @@
     "@react-native/community-cli-plugin/metro/metro-transform-worker": ["metro-transform-worker@0.83.5", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/generator": "^7.29.1", "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "flow-enums-runtime": "^0.0.6", "metro": "0.83.5", "metro-babel-transformer": "0.83.5", "metro-cache": "0.83.5", "metro-cache-key": "0.83.5", "metro-minify-terser": "0.83.5", "metro-source-map": "0.83.5", "metro-transform-plugins": "0.83.5", "nullthrows": "^1.1.1" } }, "sha512-8N4pjkNXc6ytlP9oAM6MwqkvUepNSW39LKYl9NjUMpRDazBQ7oBpQDc8Sz4aI8jnH6AGhF7s1m/ayxkN1t04yA=="],
 
     "@react-native/community-cli-plugin/metro/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
+
+    "@react-native/community-cli-plugin/metro/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "@react-native/community-cli-plugin/metro-config/metro-cache": ["metro-cache@0.83.5", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.5" } }, "sha512-oH+s4U+IfZyg8J42bne2Skc90rcuESIYf86dYittcdWQtPfcaFXWpByPyTuWk3rR1Zz3Eh5HOrcVImfEhhJLng=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -158,6 +158,9 @@
       },
     },
   },
+  "overrides": {
+    "axios": "^1.15.0",
+  },
   "packages": {
     "@0no-co/graphql.web": ["@0no-co/graphql.web@1.2.0", "", { "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0" }, "optionalPeers": ["graphql"] }, "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw=="],
 
@@ -1091,7 +1094,7 @@
 
     "atomically": ["atomically@2.1.1", "", { "dependencies": { "stubborn-fs": "^2.0.0", "when-exit": "^2.1.4" } }, "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ=="],
 
-    "axios": ["axios@1.13.6", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ=="],
+    "axios": ["axios@1.15.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q=="],
 
     "babel-jest": ["babel-jest@29.7.0", "", { "dependencies": { "@jest/transform": "^29.7.0", "@types/babel__core": "^7.1.14", "babel-plugin-istanbul": "^6.1.1", "babel-preset-jest": "^29.6.3", "chalk": "^4.0.0", "graceful-fs": "^4.2.9", "slash": "^3.0.0" }, "peerDependencies": { "@babel/core": "^7.8.0" } }, "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg=="],
 
@@ -2265,7 +2268,7 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
-    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "publish-browser-extension": ["publish-browser-extension@3.0.3", "", { "dependencies": { "cac": "^6.7.14", "consola": "^3.4.2", "dotenv": "^17.2.3", "form-data-encoder": "^4.1.0", "formdata-node": "^6.0.3", "listr2": "^8.3.3", "ofetch": "^1.4.1", "zod": "^3.25.76 || ^4.0.0" }, "bin": { "publish-extension": "bin/publish-extension.cjs" } }, "sha512-cBINZCkLo7YQaGoUvEHthZ0sDzgJQht28IS+SFMT2omSNhGsPiVNRkWir3qLiTrhGhW9Ci2KVHpA1QAMoBdL2g=="],
 

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "**/*.{js,jsx,ts,tsx,json,css,md}": [
       "biome format --write"
     ]
+  },
+  "overrides": {
+    "axios": "^1.15.0"
   }
 }


### PR DESCRIPTION
## Summary
- Migrate OAuth 2.1 storage layer from `better-sqlite3` (synchronous SQLite) to `@vercel/postgres` (async Postgres), enabling serverless deployment on Vercel
- Convert all 16 token-store functions from sync to async, update all call sites with `await`
- Add Postgres service to `docker-compose.yml` for local development, replace `DATABASE_PATH` with `POSTGRES_URL`

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun run test` — 203 tests passing
- [x] `bun run build` — builds successfully
- [ ] Deploy to Vercel with Vercel Postgres addon and test OAuth flow end-to-end
- [ ] Test `docker-compose up` with local Postgres service

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/companion/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
