### PR TITLE
fix(companion): persist region in extension and fix iOS delete account link

### DIFF
--- a/apps/extension/entrypoints/background/index.ts
+++ b/apps/extension/entrypoints/background/index.ts
@@ -405,6 +405,7 @@ export default defineBackground(() => {
 
       if (message.action === "sync-oauth-tokens") {
         const tokens = message.tokens as OAuthTokens | null;
+        const region: "us" | "eu" = message.region === "eu" ? "eu" : "us";
 
         if (isRateLimited()) {
           devLog.warn("Token sync rate limited");
@@ -417,7 +418,13 @@ export default defineBackground(() => {
           return true;
         }
 
-        validateTokens(tokens)
+        const persistRegion = new Promise<void>((resolve) => {
+          if (!storageAPI?.local) return resolve();
+          storageAPI.local.set({ [REGION_STORAGE_KEY]: region }, () => resolve());
+        });
+
+        persistRegion
+          .then(() => validateTokens(tokens))
           .then((isValid) => {
             if (!isValid) {
               devLog.warn("Token sync rejected: invalid tokens");

--- a/apps/mobile/app/(tabs)/(more)/index.ios.tsx
+++ b/apps/mobile/app/(tabs)/(more)/index.ios.tsx
@@ -278,7 +278,7 @@ export default function More() {
         >
           <TouchableOpacity
             onPress={() =>
-              openInAppBrowser("https://app.cal.com/settings/my-account/profile", "Delete Account")
+              openInAppBrowser(`${getCalAppUrl()}/settings/my-account/profile`, "Delete Account")
             }
             style={{
               flexDirection: "row",


### PR DESCRIPTION
## Summary

Follow-up fixes for two Devin Review findings on #80:

- **Extension now persists the region**. The companion iframe already forwards the selected region alongside OAuth tokens, but the `sync-oauth-tokens` handler in `apps/extension/entrypoints/background/index.ts` was reading the tokens and ignoring `message.region`. As a result, `cal_region` was never written to `storage.local`, so `getStoredRegion()` always returned `"us"` and every extension API call (`validateTokens`, `fetchEventTypes`, `getBookingStatus`, `markAttendeeNoShow`) hit `api.cal.com` regardless of the user's selection. The handler now writes `cal_region` before validating tokens, so EU tokens are validated against `api.cal.eu`.
- **iOS "Delete Account" link is now region-aware**. The Android / web `(tabs)/(more)/index.tsx` was updated to use `getCalAppUrl()`, but `(tabs)/(more)/index.ios.tsx` still hard-coded `https://app.cal.com/settings/my-account/profile`. Fixed to match.

Both issues were real and user-visible for EU users; the first would have broken extension functionality silently on every EU session.

## Review & Testing Checklist for Human

- [ ] With an EU session active on the extension, confirm `validateTokens` succeeds after token sync and subsequent API calls (`fetch-event-types`, `getBookingStatus`) hit `api.cal.eu` (check the background service-worker logs / Network tab).
- [ ] Switch region after logout, re-login, and confirm `cal_region` in `chrome.storage.local` reflects the new region.
- [ ] On iOS, tap the "Delete Account" row in the More tab while on the EU region and confirm the in-app browser opens `app.cal.eu/settings/my-account/profile`.

### Notes

- No new env vars, no schema changes, no API surface changes.
- Lint + typecheck pass locally (`bun run typecheck`, `bun run lint:all`).

Link to Devin session: https://app.devin.ai/sessions/ed4320aeeb174166b9bd2c995f9ec364
Requested by: @PeerRich