### PR TITLE
feat(mcp-server): MCP tool annotations + OpenAI Apps domain verification

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -60,6 +60,7 @@ cp apps/mcp-server/.env.example apps/mcp-server/.env
 | `DATABASE_PATH` | No | `mcp-server.db` | SQLite database file path |
 | `RATE_LIMIT_WINDOW_MS` | No | `60000` | Rate limit window in ms (per IP) |
 | `RATE_LIMIT_MAX` | No | `30` | Max OAuth requests per window per IP |
+| `OPENAI_APPS_CHALLENGE_TOKEN` | No | — | Token served at `/.well-known/openai-apps-challenge` for OpenAI Apps domain verification. When unset, the endpoint returns 404. |
 
 ## Transport Modes
 
@@ -115,6 +116,7 @@ This starts a StreamableHTTP server with OAuth 2.1 authentication:
 
 **Other:**
 - `GET  /health` — Health check (returns `{ "status": "ok", "sessions": <count> }`)
+- `GET  /.well-known/openai-apps-challenge` — OpenAI Apps domain verification token (plain text). Returns 404 unless `OPENAI_APPS_CHALLENGE_TOKEN` is set.
 
 Each HTTP session gets its own `McpServer` instance with a unique session ID, so multiple clients can connect concurrently.
 

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -4,7 +4,7 @@ A **Model Context Protocol (MCP)** server that wraps the [Cal.com Platform API v
 
 ## Features
 
-- **34 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Routing Forms, Organizations, and User Profile
+- **35 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Routing Forms, Organizations, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
 - **Dual transport** — stdio for local dev tooling, StreamableHTTP for remote/production
 - **Dual auth** — API key for stdio (local dev), OAuth 2.1 Authorization Code + PKCE for HTTP (production)
 - **Per-user token storage** — encrypted at rest with AES-256-GCM in SQLite
@@ -176,76 +176,93 @@ The server acts as an intermediary: it issues its own access tokens to MCP clien
 - Expired tokens are cleaned up automatically every 5 minutes
 - In-process rate limiting on all OAuth endpoints (token bucket per IP, configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX`)
 
-## Tools (34)
+## Tools (35)
+
+Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specification/draft/server/tools#tool-annotations) — a human-readable `title` plus behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so MCP clients can render them appropriately and apply safety policies.
+
+| Hint preset | `readOnlyHint` | `destructiveHint` | `idempotentHint` | Used for |
+|---|---|---|---|---|
+| **Read** | `true` | — | — | All `get_*` / list endpoints |
+| **Create** | `false` | `false` | `false` | New resources (`create_*`, `add_*`, `calculate_routing_form_slots`) |
+| **Update** | `false` | `false` | `true` | Mutations (`update_*`, `reschedule_*`, `confirm_*`, `mark_*`) |
+| **Destructive** | `false` | `true` | `true` | `delete_*`, `cancel_booking` |
+
+`openWorldHint` is `true` for every tool — they all call the external Cal.com API.
 
 ### User Profile (2)
-| Tool | Description |
-|---|---|
-| `get_me` | Get authenticated user profile |
-| `update_me` | Update user profile |
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_me` | Get My Profile | Read | Get authenticated user profile |
+| `update_me` | Update My Profile | Update | Update user profile |
 
 ### Event Types (5)
-| Tool | Description |
-|---|---|
-| `get_event_types` | List all event types |
-| `get_event_type` | Get a specific event type by ID |
-| `create_event_type` | Create a new event type |
-| `update_event_type` | Update an event type |
-| `delete_event_type` | Delete an event type |
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_event_types` | List Event Types | Read | List all event types |
+| `get_event_type` | Get Event Type | Read | Get a specific event type by ID |
+| `create_event_type` | Create Event Type | Create | Create a new event type |
+| `update_event_type` | Update Event Type | Update | Update an event type |
+| `delete_event_type` | Delete Event Type | Destructive | Delete an event type |
 
 ### Bookings (10)
-| Tool | Description |
-|---|---|
-| `get_bookings` | List bookings with optional filters |
-| `get_booking` | Get a specific booking by UID |
-| `create_booking` | Create a new booking |
-| `reschedule_booking` | Reschedule a booking |
-| `cancel_booking` | Cancel a booking |
-| `confirm_booking` | Confirm a pending booking |
-| `mark_booking_absent` | Mark a booking absence |
-| `get_booking_attendees` | Get all attendees for a booking |
-| `add_booking_attendee` | Add an attendee to a booking |
-| `get_booking_attendee` | Get a specific attendee for a booking |
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_bookings` | List Bookings | Read | List bookings with optional filters |
+| `get_booking` | Get Booking | Read | Get a specific booking by UID |
+| `create_booking` | Create Booking | Create | Create a new booking |
+| `reschedule_booking` | Reschedule Booking | Update | Reschedule a booking |
+| `cancel_booking` | Cancel Booking | Destructive | Cancel a booking |
+| `confirm_booking` | Confirm Booking | Update | Confirm a pending booking |
+| `mark_booking_absent` | Mark Booking Absent | Update | Mark a booking absence |
+| `get_booking_attendees` | List Booking Attendees | Read | Get all attendees for a booking |
+| `add_booking_attendee` | Add Booking Attendee | Create | Add an attendee to a booking |
+| `get_booking_attendee` | Get Booking Attendee | Read | Get a specific attendee for a booking |
 
 ### Schedules (6)
-| Tool | Description |
-|---|---|
-| `get_schedules` | List all schedules |
-| `get_schedule` | Get a specific schedule by ID |
-| `create_schedule` | Create a new schedule |
-| `update_schedule` | Update a schedule |
-| `delete_schedule` | Delete a schedule |
-| `get_default_schedule` | Get default schedule |
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_schedules` | List Schedules | Read | List all schedules |
+| `get_schedule` | Get Schedule | Read | Get a specific schedule by ID |
+| `create_schedule` | Create Schedule | Create | Create a new schedule |
+| `update_schedule` | Update Schedule | Update | Update a schedule |
+| `delete_schedule` | Delete Schedule | Destructive | Delete a schedule |
+| `get_default_schedule` | Get Default Schedule | Read | Get default schedule |
 
-### Availability / Slots (2)
-| Tool | Description |
-|---|---|
-| `get_availability` | Get available time slots (`GET /v2/slots`). Uses `cal-api-version: 2024-09-04`. |
-| `get_busy_times` | Get busy times from calendars |
+### Availability / Slots (1)
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_availability` | Get Availability | Read | Get available time slots (`GET /v2/slots`). Uses `cal-api-version: 2024-09-04`. |
+
+### Calendars (2)
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_connected_calendars` | List Connected Calendars | Read | List calendar integrations connected to the user (returns `credentialId` + `externalId` for `get_busy_times`) |
+| `get_busy_times` | Get Busy Times | Read | Get busy/blocked time blocks from a connected calendar |
 
 ### Conferencing (1)
-| Tool | Description |
-|---|---|
-| `get_conferencing_apps` | List conferencing applications |
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_conferencing_apps` | List Conferencing Apps | Read | List conferencing applications |
 
 ### Routing Forms (1)
-| Tool | Description |
-|---|---|
-| `calculate_routing_form_slots` | Calculate slots based on routing form response |
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `calculate_routing_form_slots` | Calculate Routing Form Slots | Create | Submit a routing form response and get available slots |
 
-### Organizations: Memberships (4)
-| Tool | Description |
-|---|---|
-| `get_org_memberships` | Get all organization memberships |
-| `create_org_membership` | Create an organization membership |
-| `get_org_membership` | Get an organization membership |
-| `delete_org_membership` | Delete an organization membership |
+### Organizations: Memberships (5)
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_org_memberships` | List Org Memberships | Read | Get all organization memberships |
+| `create_org_membership` | Create Org Membership | Create | Create an organization membership |
+| `get_org_membership` | Get Org Membership | Read | Get an organization membership |
+| `update_org_membership` | Update Org Membership | Update | Update an organization membership (role, accepted, impersonation) |
+| `delete_org_membership` | Delete Org Membership | Destructive | Delete an organization membership |
 
 ### Organizations: Routing Forms (2)
-| Tool | Description |
-|---|---|
-| `get_org_routing_forms` | Get organization routing forms |
-| `get_org_routing_form_responses` | Get routing form responses |
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_org_routing_forms` | List Org Routing Forms | Read | Get organization routing forms |
+| `get_org_routing_form_responses` | List Org Routing Form Responses | Read | Get routing form responses |
 
 ### API Version Notes
 

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -70,6 +70,12 @@ const httpSchema = baseSchema.extend({
   retryMaxAttempts: z.coerce.number().int().min(0).max(5).default(2),
   retryBaseDelayMs: z.coerce.number().int().positive().default(500),
   shutdownTimeoutMs: z.coerce.number().int().positive().default(10_000),
+  /**
+   * Verification token served at `/.well-known/openai-apps-challenge` for the
+   * OpenAI Apps domain verification flow. Optional — when unset the endpoint
+   * returns 404. Rotate by updating the env var; no code change required.
+   */
+  openaiAppsChallengeToken: z.string().min(1).optional(),
 });
 
 export type StdioConfig = z.infer<typeof stdioSchema>;
@@ -102,6 +108,7 @@ function readEnv(): Record<string, unknown> {
     retryMaxAttempts: process.env.RETRY_MAX_ATTEMPTS || undefined,
     retryBaseDelayMs: process.env.RETRY_BASE_DELAY_MS || undefined,
     shutdownTimeoutMs: process.env.SHUTDOWN_TIMEOUT_MS || undefined,
+    openaiAppsChallengeToken: process.env.OPENAI_APPS_CHALLENGE_TOKEN || undefined,
   };
 }
 

--- a/apps/mcp-server/src/http-server.ts
+++ b/apps/mcp-server/src/http-server.ts
@@ -32,6 +32,12 @@ export interface HttpServerConfig {
   maxRegisteredClients?: number;
   corsOrigin?: string;
   shutdownTimeoutMs?: number;
+  /**
+   * Token served at `/.well-known/openai-apps-challenge` for the OpenAI Apps
+   * domain verification flow. Falls back to `OPENAI_APPS_CHALLENGE_TOKEN`.
+   * When unset, the endpoint returns 404.
+   */
+  openaiAppsChallengeToken?: string;
 }
 
 /**
@@ -45,6 +51,7 @@ export interface HttpServerConfig {
  *   GET  /mcp   — SSE stream for server-initiated messages
  *   DELETE /mcp — Terminate a session
  *   GET  /health — Health check
+ *   GET  /.well-known/openai-apps-challenge — OpenAI Apps domain verification token
  *   GET  /.well-known/oauth-authorization-server — OAuth AS metadata
  *   GET  /.well-known/oauth-protected-resource — Protected resource metadata
  *   POST /oauth/register — Dynamic client registration
@@ -65,6 +72,7 @@ export async function startHttpServer(
   const maxRegisteredClients = config.maxRegisteredClients ?? (Number(process.env.MAX_REGISTERED_CLIENTS) || 10_000);
   const corsOrigin = config.corsOrigin ?? process.env.CORS_ORIGIN;
   const shutdownTimeoutMs = config.shutdownTimeoutMs ?? (Number(process.env.SHUTDOWN_TIMEOUT_MS) || 10_000);
+  const openaiAppsChallengeToken = config.openaiAppsChallengeToken ?? process.env.OPENAI_APPS_CHALLENGE_TOKEN;
 
   await initDb();
 
@@ -147,6 +155,23 @@ export async function startHttpServer(
         db: dbOk ? "ok" : "error",
         uptime: Math.floor((Date.now() - startedAt) / 1000),
       }));
+      return;
+    }
+
+    // ── OpenAI Apps domain verification ──
+    // Serves a static challenge token at the well-known URL so OpenAI can verify
+    // we control this hostname. No auth — OpenAI fetches it anonymously.
+    if (url.pathname === "/.well-known/openai-apps-challenge" && req.method === "GET") {
+      if (!openaiAppsChallengeToken) {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "not_found" }));
+        return;
+      }
+      res.writeHead(200, {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "public, max-age=300",
+      });
+      res.end(openaiAppsChallengeToken);
       return;
     }
 

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -35,6 +35,7 @@ async function main(): Promise<void> {
       maxRegisteredClients: httpConfig.maxRegisteredClients,
       corsOrigin: httpConfig.corsOrigin,
       shutdownTimeoutMs: httpConfig.shutdownTimeoutMs,
+      openaiAppsChallengeToken: httpConfig.openaiAppsChallengeToken,
     });
   } else {
     const stdioConfig = config as StdioConfig;

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 
 // ── Users ──
 import { getMeSchema, getMe, updateMeSchema, updateMe } from "./tools/users.js";
@@ -95,62 +96,442 @@ import {
 } from "./tools/organizations/routing-forms.js";
 
 /**
+ * Tool annotation presets matching MCP behaviour hints.
+ *
+ * All Cal.com tools call the external Cal.com API, so `openWorldHint` is always `true`.
+ *
+ * - READ_ONLY     — does not modify state (GET endpoints).
+ * - CREATE        — creates new resources (POST). Not idempotent.
+ * - UPDATE        — updates existing resources (PATCH/PUT). Idempotent, non-destructive.
+ * - DESTRUCTIVE   — deletes/cancels resources (DELETE/cancel). Idempotent, destructive.
+ *
+ * @see https://modelcontextprotocol.io/specification/draft/server/tools#tool-annotations
+ */
+const READ_ONLY: ToolAnnotations = {
+  readOnlyHint: true,
+  openWorldHint: true,
+};
+
+const CREATE: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: false,
+  openWorldHint: true,
+};
+
+const UPDATE: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: true,
+};
+
+const DESTRUCTIVE: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: true,
+  openWorldHint: true,
+};
+
+/**
  * Register all Cal.com MCP tools on the given McpServer instance.
  * Shared between stdio and HTTP transports.
  */
 export function registerTools(server: McpServer): void {
   // ── Users (2) ──
-  server.tool("get_me", "Get the authenticated user's profile including username, email, time zone, default schedule, and organizationId. Call this first when you need the user's own details (email, username, organizationId) for other tools.", getMeSchema, getMe);
-  server.tool("update_me", "Update the authenticated user's profile. Supports name, email, bio, time zone, week start, time format, default schedule, locale, avatar URL, and custom metadata.", updateMeSchema, updateMe);
+  server.registerTool(
+    "get_me",
+    {
+      title: "Get My Profile",
+      description:
+        "Get the authenticated user's profile including username, email, time zone, default schedule, and organizationId. Call this first when you need the user's own details (email, username, organizationId) for other tools.",
+      inputSchema: getMeSchema,
+      annotations: READ_ONLY,
+    },
+    getMe,
+  );
+  server.registerTool(
+    "update_me",
+    {
+      title: "Update My Profile",
+      description:
+        "Update the authenticated user's profile. Supports name, email, bio, time zone, week start, time format, default schedule, locale, avatar URL, and custom metadata.",
+      inputSchema: updateMeSchema,
+      annotations: UPDATE,
+    },
+    updateMe,
+  );
 
   // ── Event Types (5) ──
-  server.tool("get_event_types", "List event types. Without parameters returns all event types for the authenticated user. Pass 'username' to list another user's event types, or username + eventSlug for a specific one. Use usernames (comma-separated) for dynamic group event types.", getEventTypesSchema, getEventTypes);
-  server.tool("get_event_type", "Get a specific event type by its numeric ID (use get_event_types to find IDs). Returns full details including locations, booking fields, and schedule.", getEventTypeSchema, getEventType);
-  server.tool("create_event_type", "Create a new event type. Required: title, slug, lengthInMinutes. Supports locations, booking fields, buffers, recurrence, confirmation policy, seats, and more.", createEventTypeSchema, createEventType);
-  server.tool("update_event_type", "Update an existing event type by ID (use get_event_types to find IDs). Any provided field replaces the current value. Array fields (locations, bookingFields) replace entirely — fetch the current event type first with get_event_type to avoid losing existing values.", updateEventTypeSchema, updateEventType);
-  server.tool("delete_event_type", "Permanently delete an event type by ID. This action is irreversible — confirm with the user before proceeding.", deleteEventTypeSchema, deleteEventType);
+  server.registerTool(
+    "get_event_types",
+    {
+      title: "List Event Types",
+      description:
+        "List event types. Without parameters returns all event types for the authenticated user. Pass 'username' to list another user's event types, or username + eventSlug for a specific one. Use usernames (comma-separated) for dynamic group event types.",
+      inputSchema: getEventTypesSchema,
+      annotations: READ_ONLY,
+    },
+    getEventTypes,
+  );
+  server.registerTool(
+    "get_event_type",
+    {
+      title: "Get Event Type",
+      description:
+        "Get a specific event type by its numeric ID (use get_event_types to find IDs). Returns full details including locations, booking fields, and schedule.",
+      inputSchema: getEventTypeSchema,
+      annotations: READ_ONLY,
+    },
+    getEventType,
+  );
+  server.registerTool(
+    "create_event_type",
+    {
+      title: "Create Event Type",
+      description:
+        "Create a new event type. Required: title, slug, lengthInMinutes. Supports locations, booking fields, buffers, recurrence, confirmation policy, seats, and more.",
+      inputSchema: createEventTypeSchema,
+      annotations: CREATE,
+    },
+    createEventType,
+  );
+  server.registerTool(
+    "update_event_type",
+    {
+      title: "Update Event Type",
+      description:
+        "Update an existing event type by ID (use get_event_types to find IDs). Any provided field replaces the current value. Array fields (locations, bookingFields) replace entirely — fetch the current event type first with get_event_type to avoid losing existing values.",
+      inputSchema: updateEventTypeSchema,
+      annotations: UPDATE,
+    },
+    updateEventType,
+  );
+  server.registerTool(
+    "delete_event_type",
+    {
+      title: "Delete Event Type",
+      description:
+        "Permanently delete an event type by ID. This action is irreversible — confirm with the user before proceeding.",
+      inputSchema: deleteEventTypeSchema,
+      annotations: DESTRUCTIVE,
+    },
+    deleteEventType,
+  );
 
   // ── Bookings (10) ──
-  server.tool("get_bookings", "List bookings with pagination (default 100, max 250 per page — use take/skip for more). Supports filtering by status (upcoming, recurring, past, cancelled, unconfirmed), attendee email/name, event type, team, date ranges (afterStart, beforeEnd), and sorting (sortStart, sortEnd, sortCreated).", getBookingsSchema, getBookings);
-  server.tool("get_booking", "Get a specific booking by its UID (use get_bookings to find UIDs). Returns full details including attendees, location, and metadata.", getBookingSchema, getBooking);
-  server.tool("create_booking", "Create a booking. WORKFLOW: (1) Use get_event_types to find the event type ID/slug. (2) Call get_availability to find open slots — NEVER pick a time without checking availability first. (3) If using bookingFieldsResponses, call get_event_type first to discover required custom fields. (4) For attendee details (name, email, timeZone), use get_me if booking for yourself, otherwise ASK THE USER — never guess or fabricate attendee info. Identify the event type by: eventTypeId, OR eventTypeSlug + username (individual), OR eventTypeSlug + teamSlug (team). The 'start' time MUST be in UTC ISO 8601. 'username' is the HOST whose calendar you are booking. 'attendee' is the GUEST (the caller).", createBookingSchema, createBooking);
-  server.tool("reschedule_booking", "Reschedule a booking to a new time. WORKFLOW: (1) Call get_availability to find open slots — NEVER pick a new time without checking availability first. (2) The new start time must be in UTC ISO 8601. rescheduledBy is only needed for confirmation-required bookings — use the event owner's email (from get_me) for auto-confirmation. Never fabricate emails.", rescheduleBookingSchema, rescheduleBooking);
-  server.tool("cancel_booking", "Cancel a booking by UID. For recurring non-seated bookings, set cancelSubsequentBookings=true to cancel future recurrences. For seated bookings, pass seatUid to cancel a specific seat instead of the entire booking. Confirm with the user before cancelling.", cancelBookingSchema, cancelBooking);
-  server.tool("confirm_booking", "Confirm a pending booking that requires manual confirmation. Only the host can confirm.", confirmBookingSchema, confirmBooking);
-  server.tool("mark_booking_absent", "Mark host or attendees as absent for a past booking. Set host=true if the host was absent. Use get_booking_attendees to look up real attendee emails before calling this.", markBookingAbsentSchema, markBookingAbsent);
-  server.tool("get_booking_attendees", "Get all attendees for a booking by its UID.", getBookingAttendeesSchema, getBookingAttendees);
-  server.tool("add_booking_attendee", "Add a new attendee to an existing booking. Required: name, email, timeZone. ASK THE USER for all attendee details — never guess or fabricate names, emails, or time zones.", addBookingAttendeeSchema, addBookingAttendee);
-  server.tool("get_booking_attendee", "Get a specific attendee by their numeric ID within a booking. Use get_booking_attendees to find attendee IDs.", getBookingAttendeeSchema, getBookingAttendee);
+  server.registerTool(
+    "get_bookings",
+    {
+      title: "List Bookings",
+      description:
+        "List bookings with pagination (default 100, max 250 per page — use take/skip for more). Supports filtering by status (upcoming, recurring, past, cancelled, unconfirmed), attendee email/name, event type, team, date ranges (afterStart, beforeEnd), and sorting (sortStart, sortEnd, sortCreated).",
+      inputSchema: getBookingsSchema,
+      annotations: READ_ONLY,
+    },
+    getBookings,
+  );
+  server.registerTool(
+    "get_booking",
+    {
+      title: "Get Booking",
+      description:
+        "Get a specific booking by its UID (use get_bookings to find UIDs). Returns full details including attendees, location, and metadata.",
+      inputSchema: getBookingSchema,
+      annotations: READ_ONLY,
+    },
+    getBooking,
+  );
+  server.registerTool(
+    "create_booking",
+    {
+      title: "Create Booking",
+      description:
+        "Create a booking. WORKFLOW: (1) Use get_event_types to find the event type ID/slug. (2) Call get_availability to find open slots — NEVER pick a time without checking availability first. (3) If using bookingFieldsResponses, call get_event_type first to discover required custom fields. (4) For attendee details (name, email, timeZone), use get_me if booking for yourself, otherwise ASK THE USER — never guess or fabricate attendee info. Identify the event type by: eventTypeId, OR eventTypeSlug + username (individual), OR eventTypeSlug + teamSlug (team). The 'start' time MUST be in UTC ISO 8601. 'username' is the HOST whose calendar you are booking. 'attendee' is the GUEST (the caller).",
+      inputSchema: createBookingSchema,
+      annotations: CREATE,
+    },
+    createBooking,
+  );
+  server.registerTool(
+    "reschedule_booking",
+    {
+      title: "Reschedule Booking",
+      description:
+        "Reschedule a booking to a new time. WORKFLOW: (1) Call get_availability to find open slots — NEVER pick a new time without checking availability first. (2) The new start time must be in UTC ISO 8601. rescheduledBy is only needed for confirmation-required bookings — use the event owner's email (from get_me) for auto-confirmation. Never fabricate emails.",
+      inputSchema: rescheduleBookingSchema,
+      annotations: UPDATE,
+    },
+    rescheduleBooking,
+  );
+  server.registerTool(
+    "cancel_booking",
+    {
+      title: "Cancel Booking",
+      description:
+        "Cancel a booking by UID. For recurring non-seated bookings, set cancelSubsequentBookings=true to cancel future recurrences. For seated bookings, pass seatUid to cancel a specific seat instead of the entire booking. Confirm with the user before cancelling.",
+      inputSchema: cancelBookingSchema,
+      annotations: DESTRUCTIVE,
+    },
+    cancelBooking,
+  );
+  server.registerTool(
+    "confirm_booking",
+    {
+      title: "Confirm Booking",
+      description: "Confirm a pending booking that requires manual confirmation. Only the host can confirm.",
+      inputSchema: confirmBookingSchema,
+      annotations: UPDATE,
+    },
+    confirmBooking,
+  );
+  server.registerTool(
+    "mark_booking_absent",
+    {
+      title: "Mark Booking Absent",
+      description:
+        "Mark host or attendees as absent for a past booking. Set host=true if the host was absent. Use get_booking_attendees to look up real attendee emails before calling this.",
+      inputSchema: markBookingAbsentSchema,
+      annotations: UPDATE,
+    },
+    markBookingAbsent,
+  );
+  server.registerTool(
+    "get_booking_attendees",
+    {
+      title: "List Booking Attendees",
+      description: "Get all attendees for a booking by its UID.",
+      inputSchema: getBookingAttendeesSchema,
+      annotations: READ_ONLY,
+    },
+    getBookingAttendees,
+  );
+  server.registerTool(
+    "add_booking_attendee",
+    {
+      title: "Add Booking Attendee",
+      description:
+        "Add a new attendee to an existing booking. Required: name, email, timeZone. ASK THE USER for all attendee details — never guess or fabricate names, emails, or time zones.",
+      inputSchema: addBookingAttendeeSchema,
+      annotations: CREATE,
+    },
+    addBookingAttendee,
+  );
+  server.registerTool(
+    "get_booking_attendee",
+    {
+      title: "Get Booking Attendee",
+      description:
+        "Get a specific attendee by their numeric ID within a booking. Use get_booking_attendees to find attendee IDs.",
+      inputSchema: getBookingAttendeeSchema,
+      annotations: READ_ONLY,
+    },
+    getBookingAttendee,
+  );
 
   // ── Schedules (6) ──
-  server.tool("get_schedules", "List all schedules for the authenticated user.", getSchedulesSchema, getSchedules);
-  server.tool("get_schedule", "Get a specific schedule by its numeric ID. Returns availability slots and overrides.", getScheduleSchema, getSchedule);
-  server.tool("create_schedule", "Create a new schedule. Required: name, timeZone, isDefault. Each user should have exactly one default schedule. Supports availability slots and date-specific overrides.", createScheduleSchema, createSchedule);
-  server.tool("update_schedule", "Update an existing schedule. Array fields (availability, overrides) replace all existing entries.", updateScheduleSchema, updateSchedule);
-  server.tool("delete_schedule", "Delete a schedule by its numeric ID. This action is irreversible — confirm with the user before proceeding.", deleteScheduleSchema, deleteSchedule);
-  server.tool("get_default_schedule", "Get the authenticated user's default schedule.", getDefaultScheduleSchema, getDefaultSchedule);
+  server.registerTool(
+    "get_schedules",
+    {
+      title: "List Schedules",
+      description: "List all schedules for the authenticated user.",
+      inputSchema: getSchedulesSchema,
+      annotations: READ_ONLY,
+    },
+    getSchedules,
+  );
+  server.registerTool(
+    "get_schedule",
+    {
+      title: "Get Schedule",
+      description: "Get a specific schedule by its numeric ID. Returns availability slots and overrides.",
+      inputSchema: getScheduleSchema,
+      annotations: READ_ONLY,
+    },
+    getSchedule,
+  );
+  server.registerTool(
+    "create_schedule",
+    {
+      title: "Create Schedule",
+      description:
+        "Create a new schedule. Required: name, timeZone, isDefault. Each user should have exactly one default schedule. Supports availability slots and date-specific overrides.",
+      inputSchema: createScheduleSchema,
+      annotations: CREATE,
+    },
+    createSchedule,
+  );
+  server.registerTool(
+    "update_schedule",
+    {
+      title: "Update Schedule",
+      description: "Update an existing schedule. Array fields (availability, overrides) replace all existing entries.",
+      inputSchema: updateScheduleSchema,
+      annotations: UPDATE,
+    },
+    updateSchedule,
+  );
+  server.registerTool(
+    "delete_schedule",
+    {
+      title: "Delete Schedule",
+      description:
+        "Delete a schedule by its numeric ID. This action is irreversible — confirm with the user before proceeding.",
+      inputSchema: deleteScheduleSchema,
+      annotations: DESTRUCTIVE,
+    },
+    deleteSchedule,
+  );
+  server.registerTool(
+    "get_default_schedule",
+    {
+      title: "Get Default Schedule",
+      description: "Get the authenticated user's default schedule.",
+      inputSchema: getDefaultScheduleSchema,
+      annotations: READ_ONLY,
+    },
+    getDefaultSchedule,
+  );
 
-  // ── Availability / Slots (2) ──
-  server.tool("get_availability", "Get available time slots for a host. You MUST provide at least one identifier: (1) eventTypeId, (2) eventTypeSlug + username, (3) eventTypeSlug + teamSlug, or (4) usernames (comma-separated, min 2, for dynamic events). 'username' is the host whose availability you are checking. Start/end must be in UTC ISO 8601.", getAvailabilitySchema, getAvailability);
+  // ── Availability / Slots (1) ──
+  server.registerTool(
+    "get_availability",
+    {
+      title: "Get Availability",
+      description:
+        "Get available time slots for a host. You MUST provide at least one identifier: (1) eventTypeId, (2) eventTypeSlug + username, (3) eventTypeSlug + teamSlug, or (4) usernames (comma-separated, min 2, for dynamic events). 'username' is the host whose availability you are checking. Start/end must be in UTC ISO 8601.",
+      inputSchema: getAvailabilitySchema,
+      annotations: READ_ONLY,
+    },
+    getAvailability,
+  );
 
   // ── Calendars (2) ──
-  server.tool("get_connected_calendars", "List all calendar integrations connected to the authenticated user's account. Returns each calendar's credentialId and externalId, which are required by get_busy_times. Also shows the user's destination calendar.", getConnectedCalendarsSchema, getConnectedCalendars);
-  server.tool("get_busy_times", "Get busy/blocked time blocks from a connected calendar (e.g. Google Calendar) between two dates. Returns a list of time ranges when the user is unavailable. Required: dateFrom, dateTo (YYYY-MM-DD), credentialId, and externalId. WORKFLOW: (1) Call get_connected_calendars first to get the real credentialId (number) and externalId (e.g. email) for the calendar — NEVER guess or fabricate these. (2) Provide dateFrom and dateTo as YYYY-MM-DD strings. (3) Optionally pass timeZone (IANA, e.g. 'America/New_York') to localise the results.", getBusyTimesSchema, getBusyTimes);
+  server.registerTool(
+    "get_connected_calendars",
+    {
+      title: "List Connected Calendars",
+      description:
+        "List all calendar integrations connected to the authenticated user's account. Returns each calendar's credentialId and externalId, which are required by get_busy_times. Also shows the user's destination calendar.",
+      inputSchema: getConnectedCalendarsSchema,
+      annotations: READ_ONLY,
+    },
+    getConnectedCalendars,
+  );
+  server.registerTool(
+    "get_busy_times",
+    {
+      title: "Get Busy Times",
+      description:
+        "Get busy/blocked time blocks from a connected calendar (e.g. Google Calendar) between two dates. Returns a list of time ranges when the user is unavailable. Required: dateFrom, dateTo (YYYY-MM-DD), credentialId, and externalId. WORKFLOW: (1) Call get_connected_calendars first to get the real credentialId (number) and externalId (e.g. email) for the calendar — NEVER guess or fabricate these. (2) Provide dateFrom and dateTo as YYYY-MM-DD strings. (3) Optionally pass timeZone (IANA, e.g. 'America/New_York') to localise the results.",
+      inputSchema: getBusyTimesSchema,
+      annotations: READ_ONLY,
+    },
+    getBusyTimes,
+  );
 
   // ── Conferencing (1) ──
-  server.tool("get_conferencing_apps", "List all conferencing applications connected to the authenticated user's account (e.g. Zoom, Google Meet, Cal Video).", getConferencingAppsSchema, getConferencingApps);
+  server.registerTool(
+    "get_conferencing_apps",
+    {
+      title: "List Conferencing Apps",
+      description:
+        "List all conferencing applications connected to the authenticated user's account (e.g. Zoom, Google Meet, Cal Video).",
+      inputSchema: getConferencingAppsSchema,
+      annotations: READ_ONLY,
+    },
+    getConferencingApps,
+  );
 
   // ── Routing Forms (1) ──
-  server.tool("calculate_routing_form_slots", "Submit a routing form response and get available slots. The response object contains the user's answers (keys are routing form field slugs/IDs). Use get_org_routing_forms to find routingFormId. Start/end must be in UTC ISO 8601.", calculateRoutingFormSlotsSchema, calculateRoutingFormSlots);
+  server.registerTool(
+    "calculate_routing_form_slots",
+    {
+      title: "Calculate Routing Form Slots",
+      description:
+        "Submit a routing form response and get available slots. The response object contains the user's answers (keys are routing form field slugs/IDs). Use get_org_routing_forms to find routingFormId. Start/end must be in UTC ISO 8601.",
+      inputSchema: calculateRoutingFormSlotsSchema,
+      annotations: CREATE,
+    },
+    calculateRoutingFormSlots,
+  );
 
   // ── Organizations: Memberships (5) ──
-  server.tool("get_org_memberships", "List all memberships in an organization. Supports pagination with take/skip.", getOrgMembershipsSchema, getOrgMemberships);
-  server.tool("create_org_membership", "Add a user to an organization. Required: userId (must be a real user ID from the system) and role (MEMBER, ADMIN, or OWNER). Platform managed users should only have MEMBER role.", createOrgMembershipSchema, createOrgMembership);
-  server.tool("get_org_membership", "Get a specific organization membership by its numeric ID.", getOrgMembershipSchema, getOrgMembership);
-  server.tool("delete_org_membership", "Remove a membership from an organization. This action is irreversible — confirm with the user before proceeding.", deleteOrgMembershipSchema, deleteOrgMembership);
-  server.tool("update_org_membership", "Update an organization membership. Can change role, accepted status, or impersonation settings.", updateOrgMembershipSchema, updateOrgMembership);
+  server.registerTool(
+    "get_org_memberships",
+    {
+      title: "List Org Memberships",
+      description: "List all memberships in an organization. Supports pagination with take/skip.",
+      inputSchema: getOrgMembershipsSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgMemberships,
+  );
+  server.registerTool(
+    "create_org_membership",
+    {
+      title: "Create Org Membership",
+      description:
+        "Add a user to an organization. Required: userId (must be a real user ID from the system) and role (MEMBER, ADMIN, or OWNER). Platform managed users should only have MEMBER role.",
+      inputSchema: createOrgMembershipSchema,
+      annotations: CREATE,
+    },
+    createOrgMembership,
+  );
+  server.registerTool(
+    "get_org_membership",
+    {
+      title: "Get Org Membership",
+      description: "Get a specific organization membership by its numeric ID.",
+      inputSchema: getOrgMembershipSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgMembership,
+  );
+  server.registerTool(
+    "delete_org_membership",
+    {
+      title: "Delete Org Membership",
+      description:
+        "Remove a membership from an organization. This action is irreversible — confirm with the user before proceeding.",
+      inputSchema: deleteOrgMembershipSchema,
+      annotations: DESTRUCTIVE,
+    },
+    deleteOrgMembership,
+  );
+  server.registerTool(
+    "update_org_membership",
+    {
+      title: "Update Org Membership",
+      description:
+        "Update an organization membership. Can change role, accepted status, or impersonation settings.",
+      inputSchema: updateOrgMembershipSchema,
+      annotations: UPDATE,
+    },
+    updateOrgMembership,
+  );
 
   // ── Organizations: Routing Forms (2) ──
-  server.tool("get_org_routing_forms", "List routing forms for an organization. Supports filtering by team IDs, date ranges, routed booking UID, and sorting.", getOrgRoutingFormsSchema, getOrgRoutingForms);
-  server.tool("get_org_routing_form_responses", "Get responses for a specific routing form. Supports filtering by date ranges, routed booking UID, and sorting.", getOrgRoutingFormResponsesSchema, getOrgRoutingFormResponses);
+  server.registerTool(
+    "get_org_routing_forms",
+    {
+      title: "List Org Routing Forms",
+      description:
+        "List routing forms for an organization. Supports filtering by team IDs, date ranges, routed booking UID, and sorting.",
+      inputSchema: getOrgRoutingFormsSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgRoutingForms,
+  );
+  server.registerTool(
+    "get_org_routing_form_responses",
+    {
+      title: "List Org Routing Form Responses",
+      description:
+        "Get responses for a specific routing form. Supports filtering by date ranges, routed booking UID, and sorting.",
+      inputSchema: getOrgRoutingFormResponsesSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgRoutingFormResponses,
+  );
 }

--- a/apps/mcp-server/src/vercel-handler.ts
+++ b/apps/mcp-server/src/vercel-handler.ts
@@ -126,6 +126,24 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
     return;
   }
 
+  // ── OpenAI Apps domain verification ──
+  // Serves a static challenge token at the well-known URL so OpenAI can verify
+  // we control this hostname. No auth — OpenAI fetches it anonymously.
+  // The token is provided via the OPENAI_APPS_CHALLENGE_TOKEN env var.
+  if (url.pathname === "/.well-known/openai-apps-challenge" && req.method === "GET") {
+    const token = config.openaiAppsChallengeToken;
+    if (!token) {
+      jsonError(res, 404, "not_found");
+      return;
+    }
+    res.writeHead(200, {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+    });
+    res.end(token);
+    return;
+  }
+
   // ── OAuth metadata ──
   if (url.pathname === "/.well-known/oauth-authorization-server" && req.method === "GET") {
     res.writeHead(200, { "Content-Type": "application/json" });


### PR DESCRIPTION
## Summary
Two related changes to make mcp.cal.com pass external directory submission flows:

1. **MCP tool annotations** — adds `title` + behavior hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) to all 35 tools, migrating from the deprecated `server.tool()` to the recommended `server.registerTool()` API.
2. **OpenAI Apps domain verification** — serves a static challenge token at `/.well-known/openai-apps-challenge` so OpenAI can verify ownership of `mcp.cal.com`.

README brought up to date alongside.

## Why

### Annotations
MCP clients (Claude Desktop / Cursor / VS Code, plus the public MCP directory submission flow) flag missing annotations — e.g. `get_me did not include an annotation for readOnlyHint`. Adding them lets clients render tools properly (read vs. write vs. destructive) and apply safety policies before invoking destructive operations.

### Domain verification
The OpenAI Apps listing flow asks us to expose a token at a fixed well-known URL on the MCP hostname. Without it the listing is rejected with `Domain not verified`.

## What changed

### `apps/mcp-server/src/register-tools.ts`
- All 35 tools now go through `server.registerTool(name, { title, description, inputSchema, annotations }, cb)`.
- Four hint presets keep the file readable:
  | Preset | `readOnly` | `destructive` | `idempotent` | Used for |
  |---|---|---|---|---|
  | `READ_ONLY` | `true` | — | — | All `get_*` |
  | `CREATE` | `false` | `false` | `false` | `create_*`, `add_*`, `calculate_routing_form_slots` |
  | `UPDATE` | `false` | `false` | `true` | `update_*`, `reschedule_*`, `confirm_*`, `mark_*` |
  | `DESTRUCTIVE` | `false` | `true` | `true` | `delete_*`, `cancel_booking` |
- `openWorldHint: true` is set everywhere — every tool calls the external Cal.com API.
- No behavior changes to handlers/schemas.

### Domain verification (`vercel-handler.ts`, `http-server.ts`, `config.ts`, `index.ts`)
- New endpoint `GET /.well-known/openai-apps-challenge` returns the token as `text/plain`.
- Token comes from the optional `OPENAI_APPS_CHALLENGE_TOKEN` env var. When unset → 404 (no partial-config leakage).
- Unauthenticated by design (OpenAI fetches anonymously).
- `Cache-Control: public, max-age=300` to spare the Vercel function on repeat fetches.
- Wired into both transports (Vercel handler for prod, `http-server.ts` for self-hosted).

### `apps/mcp-server/README.md`
- Tool count `34` → `35`.
- Added the missing `get_connected_calendars` row and a dedicated **Calendars** section.
- Added the missing `update_org_membership` row (Memberships count `4` → `5`).
- Moved `get_busy_times` from Availability/Slots → Calendars to match the code.
- New **Title** and **Hint** columns per tool, plus a preset legend at the top of the section.
- Documented `OPENAI_APPS_CHALLENGE_TOKEN` env var and the new well-known endpoint.

## Deployment note
After this merges, set `OPENAI_APPS_CHALLENGE_TOKEN` in the Vercel project environment for `mcp.cal.com` to the value provided by the OpenAI Apps console, then click **Verify Domain**. The token can be rotated by updating the env var — no code change required.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 203/203 pass
- [x] `bun run lint` — clean
- [ ] After deploy: `curl -s https://mcp.cal.com/.well-known/openai-apps-challenge` returns the configured token
- [ ] After deploy: `tools/list` from an MCP client confirms `annotations.readOnlyHint` and `title` on every tool
- [ ] OpenAI Apps "Verify Domain" succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)