### PR TITLE
fix(chat): fail closed when agent credits cannot be verified

### DIFF
--- a/apps/chat/lib/agent-credits.ts
+++ b/apps/chat/lib/agent-credits.ts
@@ -15,7 +15,15 @@ interface RequireAgentCreditsParams {
   postNoCredits: (message: string) => Promise<unknown>;
 }
 
-export function agentNoCreditsMessage(platform: string): string {
+type AgentCreditsBlockReason = "no_credits" | "verification_failed";
+
+export function agentNoCreditsMessage(platform: string, reason: AgentCreditsBlockReason): string {
+  if (reason === "no_credits") {
+    return platform === "slack"
+      ? "You don't have AI credits available right now. Use `/cal help` to see the regular slash commands you can still use."
+      : "You don't have AI credits available right now. Use /help to see the regular commands you can still use.";
+  }
+
   return platform === "slack"
     ? "The AI assistant isn't available right now because we couldn't verify available AI credits for your account. Use `/cal help` to see the regular slash commands you can still use."
     : "The AI assistant isn't available right now because we couldn't verify available AI credits for your account. Use /help to see the regular commands you can still use.";
@@ -63,7 +71,7 @@ export async function requireAgentCredits({
         monthlyRemaining,
         additional,
       });
-      await postNoCredits(agentNoCreditsMessage(ctx.platform));
+      await postNoCredits(agentNoCreditsMessage(ctx.platform, "no_credits"));
       return false;
     }
 
@@ -89,7 +97,7 @@ export async function requireAgentCredits({
       statusCode: err instanceof CalcomApiError ? err.statusCode : undefined,
       code: err instanceof CalcomApiError ? err.code : undefined,
     });
-    await postNoCredits(agentNoCreditsMessage(ctx.platform));
+    await postNoCredits(agentNoCreditsMessage(ctx.platform, "verification_failed"));
     return false;
   }
 }

--- a/apps/chat/lib/agent-credits.ts
+++ b/apps/chat/lib/agent-credits.ts
@@ -1,0 +1,95 @@
+import type { Logger } from "chat";
+import { CalcomApiError, checkCredits } from "./calcom/client";
+
+export interface AgentCreditContext {
+  platform: string;
+  teamId: string;
+  userId: string;
+}
+
+interface RequireAgentCreditsParams {
+  accessToken: string;
+  ctx: AgentCreditContext;
+  logger: Logger;
+  gateName: string;
+  postNoCredits: (message: string) => Promise<unknown>;
+}
+
+export function agentNoCreditsMessage(platform: string): string {
+  return platform === "slack"
+    ? "The AI assistant isn't available right now because we couldn't verify available AI credits for your account. Use `/cal help` to see the regular slash commands you can still use."
+    : "The AI assistant isn't available right now because we couldn't verify available AI credits for your account. Use /help to see the regular commands you can still use.";
+}
+
+/**
+ * AI-cost gates must fail closed. If Cal.com cannot confirm available credits,
+ * do not start an LLM request.
+ */
+export async function requireAgentCredits({
+  accessToken,
+  ctx,
+  logger,
+  gateName,
+  postNoCredits,
+}: RequireAgentCreditsParams): Promise<boolean> {
+  logger.info("Checking agent credits", {
+    gateName,
+    platform: ctx.platform,
+    teamId: ctx.teamId,
+    userId: ctx.userId,
+  });
+
+  try {
+    const credits = await checkCredits(accessToken);
+    const monthlyRemaining = credits.balance.monthlyRemaining;
+    const additional = credits.balance.additional;
+
+    logger.info("Agent credits check result", {
+      gateName,
+      platform: ctx.platform,
+      teamId: ctx.teamId,
+      userId: ctx.userId,
+      hasCredits: credits.hasCredits,
+      monthlyRemaining,
+      additional,
+    });
+
+    if (!credits.hasCredits) {
+      logger.info("Agentic blocked - no credits", {
+        gateName,
+        platform: ctx.platform,
+        teamId: ctx.teamId,
+        userId: ctx.userId,
+        monthlyRemaining,
+        additional,
+      });
+      await postNoCredits(agentNoCreditsMessage(ctx.platform));
+      return false;
+    }
+
+    if (monthlyRemaining + additional <= 0) {
+      logger.warn("Agent credits response has no visible balance but allows usage", {
+        gateName,
+        platform: ctx.platform,
+        teamId: ctx.teamId,
+        userId: ctx.userId,
+        monthlyRemaining,
+        additional,
+      });
+    }
+
+    return true;
+  } catch (err) {
+    logger.warn("Agent credits check failed, blocking request", {
+      gateName,
+      platform: ctx.platform,
+      teamId: ctx.teamId,
+      userId: ctx.userId,
+      error: String(err),
+      statusCode: err instanceof CalcomApiError ? err.statusCode : undefined,
+      code: err instanceof CalcomApiError ? err.code : undefined,
+    });
+    await postNoCredits(agentNoCreditsMessage(ctx.platform));
+    return false;
+  }
+}

--- a/apps/chat/lib/bot.ts
+++ b/apps/chat/lib/bot.ts
@@ -28,7 +28,8 @@ import {
 import { createHash } from "node:crypto";
 import type { LookupPlatformUserFn, UserContext } from "./agent";
 import { isAIRateLimitError, isAIToolCallError, runAgentStream } from "./agent";
-import { CalcomApiError, checkCredits, chargeCredits } from "./calcom/client";
+import { requireAgentCredits } from "./agent-credits";
+import { CalcomApiError, chargeCredits } from "./calcom/client";
 import { generateAuthUrl } from "./calcom/oauth";
 import { validateRequiredEnv } from "./env";
 import { formatForTelegram } from "./format-for-telegram";
@@ -880,25 +881,17 @@ async function runAgentHandler(opts: AgentHandlerOptions): Promise<void> {
   // Re-read in case token refresh synced org fields from /v2/me
   linked = await getLinkedUser(opts.ctx.teamId, opts.ctx.userId) ?? linked;
 
-  try {
-    const credits = await checkCredits(token);
-    if (!credits.hasCredits) {
-      log.info("Agentic blocked — no credits", { userId: opts.ctx.userId });
-      const noCreditsMsg = opts.ctx.platform === "slack"
-        ? "You've run out of AI credits. Use `/cal help` to see available slash commands, or purchase more credits at <https://cal.com/pricing|cal.com/pricing>."
-        : "You've run out of AI credits. Use /help to see available commands, or purchase more credits at [cal.com/pricing](https://cal.com/pricing).";
-      if (opts.ctx.platform === "slack") {
-        await withSlackToken(opts.ctx.teamId, () => opts.thread.post(noCreditsMsg));
-      } else {
-        await opts.thread.post(noCreditsMsg);
-      }
-      return;
-    }
-  } catch (err) {
-    // If credits endpoint is unavailable, allow the request through
-    // so existing org-plan users aren't blocked during rollout.
-    log.warn("Credits check failed, allowing request", { userId: opts.ctx.userId, error: String(err) });
-  }
+  const hasAgentCredits = await requireAgentCredits({
+    accessToken: token,
+    ctx: opts.ctx,
+    logger: log,
+    gateName: opts.loggerName,
+    postNoCredits: (message) =>
+      opts.ctx.platform === "slack"
+        ? withSlackToken(opts.ctx.teamId, () => opts.thread.post(message))
+        : opts.thread.post(message),
+  });
+  if (!hasAgentCredits) return;
 
   if (await opts.shouldSubscribe()) {
     if (!(await opts.thread.isSubscribed())) {

--- a/apps/chat/lib/handlers/slack.ts
+++ b/apps/chat/lib/handlers/slack.ts
@@ -18,6 +18,7 @@ import {
 } from "chat";
 import type { LookupPlatformUserFn } from "../agent";
 import { isAIRateLimitError, isAIToolCallError, runAgentStream } from "../agent";
+import { requireAgentCredits } from "../agent-credits";
 import {
   CalcomApiError,
   cancelBooking,
@@ -740,20 +741,15 @@ export function registerSlackHandlers(
               );
               return;
             }
-            try {
-              const { checkCredits } = await import("../calcom/client");
-              const credits = await checkCredits(accessTokenForAgent);
-              if (!credits.hasCredits) {
-                await event.channel.postEphemeral(
-                  event.user,
-                  "You've run out of AI credits. Use `/cal help` to see available slash commands, or purchase more credits at <https://cal.com/pricing|cal.com/pricing>.",
-                  { fallbackToDM: true }
-                );
-                return;
-              }
-            } catch {
-              // If credits check fails, allow the request through during rollout
-            }
+            const hasAgentCredits = await requireAgentCredits({
+              accessToken: accessTokenForAgent,
+              ctx: { platform: "slack", teamId, userId },
+              logger,
+              gateName: "/cal natural query",
+              postNoCredits: (message) =>
+                event.channel.postEphemeral(event.user, message, { fallbackToDM: true }),
+            });
+            if (!hasAgentCredits) return;
 
             const result = runAgentStream({
               teamId,
@@ -1683,6 +1679,21 @@ export function registerSlackHandlers(
       async () => {
         const linked = await getLinkedUser(teamId, userId);
         if (!linked) return;
+
+        const accessToken = await getValidAccessToken(teamId, userId);
+        if (!accessToken) {
+          await thread.post(oauthLinkMessage(event.adapter.name, teamId, userId));
+          return;
+        }
+
+        const hasAgentCredits = await requireAgentCredits({
+          accessToken,
+          ctx,
+          logger,
+          gateName: "retry_response",
+          postNoCredits: (message) => thread.post(message),
+        });
+        if (!hasAgentCredits) return;
 
         const history = await buildHistory(thread);
         const lastUserMessage = [...history].reverse().find((m) => m.role === "user");

--- a/apps/chat/lib/handlers/slack.ts
+++ b/apps/chat/lib/handlers/slack.ts
@@ -83,6 +83,27 @@ function isSlackAuthError(err: unknown): boolean {
   return false;
 }
 
+function getNestedString(value: unknown, path: string[]): string | undefined {
+  let current = value;
+  for (const key of path) {
+    if (!current || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return typeof current === "string" || typeof current === "number" ? String(current) : undefined;
+}
+
+function getRetryEventId(raw: unknown): string {
+  const stableId =
+    getNestedString(raw, ["callback_query", "id"]) ??
+    getNestedString(raw, ["id"]) ??
+    getNestedString(raw, ["trigger_id"]) ??
+    getNestedString(raw, ["actions", "0", "action_ts"]) ??
+    getNestedString(raw, ["container", "message_ts"]) ??
+    getNestedString(raw, ["message", "ts"]);
+
+  return stableId ?? `ts-${Date.now()}`;
+}
+
 export interface PlatformContext {
   platform: string;
   teamId: string;
@@ -1721,7 +1742,8 @@ export function registerSlackHandlers(
 
         const messageText = lastUserMessage.content as string;
         const msgHash = createHash("sha256").update(messageText).digest("hex").slice(0, 12);
-        const externalRef = `agent-${event.adapter.name}-${thread.id}-${msgHash}`;
+        const retryEventId = createHash("sha256").update(getRetryEventId(event.raw)).digest("hex").slice(0, 12);
+        const externalRef = `agent-${event.adapter.name}-${thread.id}-${msgHash}-retry-${retryEventId}`;
         try {
           await chargeCredits(accessToken, { externalRef });
           logger.info("Credits charged for retry response", { userId, externalRef });

--- a/apps/chat/lib/handlers/slack.ts
+++ b/apps/chat/lib/handlers/slack.ts
@@ -2,6 +2,7 @@ import type { SlackAdapter } from "@chat-adapter/slack";
 import { cardToBlockKit } from "@chat-adapter/slack";
 import type { ModelMessage } from "ai";
 import type { Chat, SlashCommandEvent, Thread } from "chat";
+import { createHash } from "node:crypto";
 import {
   Actions,
   Button,
@@ -22,6 +23,7 @@ import { requireAgentCredits } from "../agent-credits";
 import {
   CalcomApiError,
   cancelBooking,
+  chargeCredits,
   createBooking,
   createBookingPublic,
   getAvailableSlotsPublic,
@@ -1716,6 +1718,21 @@ export function registerSlackHandlers(
         await postAgentStream(thread, result, ctx, {
           onErrorRef: lastStreamErrorRef,
         });
+
+        const messageText = lastUserMessage.content as string;
+        const msgHash = createHash("sha256").update(messageText).digest("hex").slice(0, 12);
+        const externalRef = `agent-${event.adapter.name}-${thread.id}-${msgHash}`;
+        try {
+          await chargeCredits(accessToken, { externalRef });
+          logger.info("Credits charged for retry response", { userId, externalRef });
+        } catch (err) {
+          // Don't fail the interaction if charging fails after a successful retry.
+          logger.warn("Failed to charge credits for retry response", {
+            userId,
+            externalRef,
+            error: String(err),
+          });
+        }
       },
       {
         postError: (msg) => thread.post(msg).catch(() => {}),


### PR DESCRIPTION
Fixes - ENG-1169

## Summary
- Add a shared fail-closed agent credit gate before starting LLM-backed chat flows.
- Apply the gate to Telegram/Slack agent handlers, Slack `/cal` natural-language fallback, and retry responses.
- Remove fail-open behavior when `/v2/credits/available` rejects third-party OAuth tokens.

## Test plan
- `pnpm --filter @calcom/chat typecheck`
- Verified Telegram freeform now blocks before `runAgentStream` when credits check returns `403 insufficient_scope`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/companion/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
