### PR TITLE
fix: persist region in secureStorage alongside OAuth tokens to prevent cross-instance auth

### DIFF
--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -17,7 +17,13 @@ import {
 import type { UserProfile } from "@/services/types/users.types";
 import { WebAuthService } from "@/services/webAuth";
 import { clearQueryCache } from "@/utils/queryPersister";
-import { clearRegion, getRegion, preloadRegion, subscribeRegion } from "@/utils/region";
+import {
+  clearRegion,
+  getRegion,
+  preloadRegion,
+  setRegion,
+  subscribeRegion,
+} from "@/utils/region";
 import { generalStorage, secureStorage } from "@/utils/storage";
 
 /**
@@ -49,6 +55,14 @@ const ACCESS_TOKEN_KEY = "cal_access_token";
 const REFRESH_TOKEN_KEY = "cal_refresh_token";
 const OAUTH_TOKENS_KEY = "cal_oauth_tokens";
 const AUTH_TYPE_KEY = "cal_auth_type";
+/**
+ * Region stored in secureStorage alongside OAuth tokens so the two can never
+ * get out of sync.  On iOS, SecureStore (Keychain) persists across app
+ * reinstalls whereas AsyncStorage does not — if the region were only in
+ * AsyncStorage, a reinstall would lose the region while keeping the tokens,
+ * defaulting to "us" and routing API calls to the wrong instance.
+ */
+const AUTH_REGION_KEY = "cal_auth_region";
 
 type AuthType = "oauth" | "web_session";
 
@@ -127,6 +141,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   ) => {
     await storage.set(OAUTH_TOKENS_KEY, JSON.stringify(tokens));
     await storage.set(AUTH_TYPE_KEY, "oauth");
+    await storage.set(AUTH_REGION_KEY, getRegion());
 
     if (service) {
       try {
@@ -138,7 +153,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
   };
 
   const clearAuth = useCallback(async () => {
-    await storage.removeAll([ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY, OAUTH_TOKENS_KEY, AUTH_TYPE_KEY]);
+    await storage.removeAll([
+      ACCESS_TOKEN_KEY,
+      REFRESH_TOKEN_KEY,
+      OAUTH_TOKENS_KEY,
+      AUTH_TYPE_KEY,
+      AUTH_REGION_KEY,
+    ]);
 
     if (oauthService) {
       try {
@@ -337,6 +358,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
     CalComAPIService.setAuthFailureCallback(() => logoutRef.current());
 
     (async () => {
+      // Restore the region from secureStorage first.  This is the
+      // authoritative source when tokens exist because secureStorage
+      // (iOS Keychain) persists across app reinstalls whereas
+      // generalStorage (AsyncStorage) does not.  Without this, a
+      // reinstall drops the region while keeping the tokens, defaulting
+      // to "us" and routing API calls to the wrong instance.
+      try {
+        const authRegion = await storage.get(AUTH_REGION_KEY);
+        if (authRegion === "us" || authRegion === "eu") {
+          await setRegion(authRegion);
+        }
+      } catch {
+        // Best-effort; fall through to preloadRegion.
+      }
+
       const initialRegion = getRegion();
       const region = await preloadRegion();
       if (cancelled) return;
@@ -388,6 +424,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setIsAuthenticated(true);
       setIsWebSession(true);
       await storage.set(AUTH_TYPE_KEY, "web_session");
+      await storage.set(AUTH_REGION_KEY, getRegion());
 
       // Try to get tokens from web session
       const tokens = await WebAuthService.getTokensFromWebSession();

--- a/apps/mobile/contexts/QueryContext.tsx
+++ b/apps/mobile/contexts/QueryContext.tsx
@@ -10,10 +10,11 @@
 
 import { onlineManager, QueryClient } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
-import React, { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import React, { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Platform } from "react-native";
 import { CACHE_CONFIG } from "@/config/cache.config";
 import { clearQueryCache, createQueryPersister } from "@/utils/queryPersister";
+import { getRegion, subscribeRegion } from "@/utils/region";
 
 /**
  * Create and configure the QueryClient instance
@@ -121,6 +122,18 @@ export function QueryProvider({ children }: QueryProviderProps) {
     // For now, assume online on mobile (React Query handles network errors gracefully)
     return undefined;
   }, []);
+
+  // Clear in-memory query cache when the data region changes so stale data
+  // from a different region is never served to the user.
+  const regionRef = useRef(getRegion());
+  useEffect(() => {
+    return subscribeRegion((newRegion) => {
+      if (newRegion !== regionRef.current) {
+        regionRef.current = newRegion;
+        queryClient.clear();
+      }
+    });
+  }, [queryClient]);
 
   // Listen for reload messages from extension
   useEffect(() => {

--- a/apps/mobile/utils/queryPersister.ts
+++ b/apps/mobile/utils/queryPersister.ts
@@ -2,15 +2,28 @@
  * React Query Cache Persister
  *
  * Uses the shared storage adapter from utils/storage.ts for cross-platform support.
+ * Cache is scoped by region (US/EU) to prevent data leakage between instances
+ * that share numeric user IDs.
  */
 
 import type { PersistedClient, Persister } from "@tanstack/react-query-persist-client";
 import { CACHE_CONFIG } from "@/config/cache.config";
+import { getRegion } from "./region";
 import { safeLogWarn } from "./safeLogger";
 import { generalStorage } from "./storage";
 
 // Use the shared general storage adapter for cache persistence
 const storage = generalStorage;
+
+/**
+ * Returns the region-scoped storage key for the query cache.
+ * This ensures caches from different regions (US/EU) are completely
+ * isolated, preventing data leakage when users with the same numeric
+ * ID exist across regions.
+ */
+function getRegionScopedStorageKey(): string {
+  return `${CACHE_CONFIG.persistence.storageKey}-${getRegion()}`;
+}
 
 /**
  * Create a React Query persister that works across all platforms
@@ -20,9 +33,9 @@ const storage = generalStorage;
  * - Restores cache on app launch for instant data display
  * - Handles serialization/deserialization of cache data
  * - Respects cache expiration (maxAge)
+ * - Scopes cache by region to prevent cross-region data leakage
  */
 export const createQueryPersister = (): Persister => {
-  const storageKey = CACHE_CONFIG.persistence.storageKey;
   const maxAge = CACHE_CONFIG.persistence.maxAge;
 
   return {
@@ -32,7 +45,7 @@ export const createQueryPersister = (): Persister => {
     persistClient: async (client: PersistedClient): Promise<void> => {
       try {
         const serialized = JSON.stringify(client);
-        await storage.setItem(storageKey, serialized);
+        await storage.setItem(getRegionScopedStorageKey(), serialized);
       } catch (error) {
         safeLogWarn("[QueryPersister] Failed to persist client:", error);
         // Fail silently - persistence is a nice-to-have, not critical
@@ -44,7 +57,8 @@ export const createQueryPersister = (): Persister => {
      */
     restoreClient: async (): Promise<PersistedClient | undefined> => {
       try {
-        const serialized = await storage.getItem(storageKey);
+        const key = getRegionScopedStorageKey();
+        const serialized = await storage.getItem(key);
         if (!serialized) {
           return undefined;
         }
@@ -54,7 +68,7 @@ export const createQueryPersister = (): Persister => {
         // Validate timestamp exists and is a valid number
         if (typeof client.timestamp !== "number" || Number.isNaN(client.timestamp)) {
           safeLogWarn("[QueryPersister] Invalid or missing timestamp, discarding cache");
-          await storage.removeItem(storageKey);
+          await storage.removeItem(key);
           return undefined;
         }
 
@@ -63,7 +77,7 @@ export const createQueryPersister = (): Persister => {
         const now = Date.now();
         if (now - persistedAt > maxAge) {
           // Cache is too old, discard it
-          await storage.removeItem(storageKey);
+          await storage.removeItem(key);
           return undefined;
         }
 
@@ -80,7 +94,7 @@ export const createQueryPersister = (): Persister => {
      */
     removeClient: async (): Promise<void> => {
       try {
-        await storage.removeItem(storageKey);
+        await storage.removeItem(getRegionScopedStorageKey());
       } catch (error) {
         safeLogWarn("[QueryPersister] Failed to remove client:", error);
       }
@@ -95,10 +109,13 @@ export { storage };
 
 /**
  * Utility to clear all query cache from storage
- * Useful for logout or cache reset scenarios
+ * Useful for logout or cache reset scenarios.
+ * Clears both the region-scoped key and the legacy unscoped key.
  */
 export const clearQueryCache = async (): Promise<void> => {
   try {
+    await storage.removeItem(getRegionScopedStorageKey());
+    // Also remove the legacy unscoped key to clean up old caches
     await storage.removeItem(CACHE_CONFIG.persistence.storageKey);
   } catch (error) {
     safeLogWarn("[QueryPersister] Failed to clear cache:", error);
@@ -115,7 +132,7 @@ export const getCacheMetadata = async (): Promise<{
   isExpired?: boolean;
 } | null> => {
   try {
-    const serialized = await storage.getItem(CACHE_CONFIG.persistence.storageKey);
+    const serialized = await storage.getItem(getRegionScopedStorageKey());
     if (!serialized) {
       return { exists: false };
     }


### PR DESCRIPTION
## Summary

Fixes a critical security vulnerability where a cal.eu user could accidentally see another user's data from cal.com when both users share the same numeric user ID (82126).

**Root cause:** On iOS, OAuth tokens are stored in `SecureStore` (Keychain), which persists across app reinstalls, but the region (US/EU) is stored in `AsyncStorage`, which does **not** persist across reinstalls. After a reinstall or AsyncStorage corruption, the tokens survive while the region defaults to "us", routing all API calls to `api.cal.com` instead of `api.cal.eu` — returning a completely different user's data.

**Primary fix:** Store the region in `secureStorage` alongside the OAuth tokens (`cal_auth_region` key). On boot, restore the region from secureStorage before `preloadRegion()` so the authoritative region is never lost, regardless of AsyncStorage state.

**Defense-in-depth:** Scope the persisted query cache key by region (`cal-companion-query-cache-us` / `cal-companion-query-cache-eu`) and clear the in-memory query cache on region change.

### Changes

- **`AuthContext.tsx`**: 
  - New `AUTH_REGION_KEY` stored in secureStorage alongside tokens on login (both OAuth and web session)
  - On boot, restore region from secureStorage before `preloadRegion()` 
  - Clear `AUTH_REGION_KEY` on logout alongside other auth state
- **`queryPersister.ts`**: Scope persisted cache storage key by region; clear legacy unscoped key on cache clear
- **`QueryContext.tsx`**: Subscribe to region changes and clear in-memory query cache when region changes

## Review & Testing Checklist for Human

- [ ] **Verify on iOS**: Install the app → select EU → log in via cal.eu → delete and reinstall the app → confirm the app restores the EU region and routes API calls to `api.cal.eu` (not `api.cal.com`)
- [ ] **Verify region stored on login**: After OAuth login, check that `cal_auth_region` is written to SecureStore with the correct value ("us" or "eu")
- [ ] **Verify logout clears auth region**: After logout, confirm `cal_auth_region` is removed from SecureStore and the login screen region picker appears
- [ ] **Verify query cache isolation**: Log in as a US user → check cached data → switch to EU account → confirm no US cached data is served
- [ ] **Verify web/extension still works**: The extension stores both region and tokens in `chrome.storage.local` (same persistence), so no change in behavior expected — but verify the sidebar still loads correctly

### Notes

- This bug is limited to the same device — it requires tokens from a previous session to still be in SecureStore while AsyncStorage has been cleared
- The query cache scoping is defense-in-depth; the primary fix is the secureStorage region persistence
- Existing users who already have tokens but no `cal_auth_region` in secureStorage will fall through to the existing `preloadRegion()` path (backward compatible)

Link to Devin session: https://app.devin.ai/sessions/0e094b9d77cc4b6ebf523ce7ef4ef1f4
Requested by: @anikdhabal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-instance auth on iOS by persisting the region (US/EU) in secure storage with OAuth tokens and scoping query caches by region. Prevents users from being routed to the wrong API after app reinstalls or storage corruption.

- **Bug Fixes**
  - Save region in `secureStorage` (`cal_auth_region`) when storing OAuth or web-session auth; restore it on boot before `preloadRegion()`.
  - Clear `cal_auth_region` on logout with other auth keys.
  - Scope React Query persisted cache key by region and remove the legacy unscoped key.
  - Clear in-memory query cache when the region changes to avoid cross-region stale data.

<sup>Written for commit 1be585b2fd6db2f68012dd6277a5e0427bb42ec2. Summary will update on new commits. <a href="https://cubic.dev/pr/calcom/companion/pull/90?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

