### PR TITLE
fix(auth): additional logout/cache hardening on top of #91

### DIFF
--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import {
   createContext,
   type ReactNode,
@@ -7,6 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { queryKeys } from "@/config/cache.config";
 import { USER_PREFERENCES_KEY } from "@/hooks/useUserPreferences";
 import { CalComAPIService } from "@/services/calcom";
 import {
@@ -17,9 +19,10 @@ import {
 import type { UserProfile } from "@/services/types/users.types";
 import { WebAuthService } from "@/services/webAuth";
 import { clearQueryCache } from "@/utils/queryPersister";
-import { safeLogWarn } from "@/utils/safeLogger";
 import { clearRegion, getRegion, preloadRegion, subscribeRegion } from "@/utils/region";
+import { safeLogWarn } from "@/utils/safeLogger";
 import { generalStorage, secureStorage } from "@/utils/storage";
+import { clearWidgetBookings } from "@/utils/widgetStorage";
 
 /**
  * Simplified user info stored in auth context
@@ -72,6 +75,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [userInfo, setUserInfo] = useState<AuthUserInfo | null>(null);
   const [isWebSession, setIsWebSession] = useState(false);
   const [loading, setLoading] = useState(true);
+  // AuthProvider is mounted inside QueryProvider (see app/_layout.tsx), so
+  // useQueryClient() resolves the live client we need to wipe on logout and
+  // on cross-user cache rehydration.
+  const queryClient = useQueryClient();
   // Construct synchronously on first render so downstream hooks can rely on a
   // non-null service immediately and mount-time configuration failures are
   // logged right away. The effect below rebuilds only if `preloadRegion()`
@@ -99,33 +106,57 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   // Common post-login setup: configure API service and fetch user profile
-  const setupAfterLogin = useCallback(async (token: string, refreshToken?: string) => {
-    CalComAPIService.setAccessToken(token, refreshToken);
+  const setupAfterLogin = useCallback(
+    async (token: string, refreshToken?: string) => {
+      CalComAPIService.setAccessToken(token, refreshToken);
 
-    try {
-      const profile = await CalComAPIService.getUserProfile();
-      // Store user info for use in the app (e.g., to display "You" in bookings)
-      if (profile) {
-        setUserInfo({
-          email: profile.email,
-          name: profile.name,
-          id: profile.id,
-          username: profile.username,
-        });
+      try {
+        const profile = await CalComAPIService.getUserProfile();
+        // Store user info for use in the app (e.g., to display "You" in bookings)
+        if (profile) {
+          // If the persisted cache was rehydrated for a different user (cold
+          // start before logout fully ran, or a foreign cache that survived
+          // restore), wipe everything before the next fetch lands so no PII
+          // from the previous identity flashes onto screen.
+          const cachedProfile = queryClient.getQueryData<UserProfile>(
+            queryKeys.userProfile.current()
+          );
+          if (cachedProfile && cachedProfile.id !== profile.id) {
+            if (__DEV__) {
+              console.debug(
+                "[AuthContext] Rehydrated cache belonged to a different user; clearing"
+              );
+            }
+            try {
+              queryClient.clear();
+            } catch (clearError) {
+              console.warn("Failed to clear stale in-memory cache:", clearError);
+            }
+            try {
+              await clearQueryCache();
+            } catch (cacheError) {
+              console.warn("Failed to clear stale persisted cache:", cacheError);
+            }
+          }
+          setUserInfo({
+            email: profile.email,
+            name: profile.name,
+            id: profile.id,
+            username: profile.username,
+          });
+        }
+      } catch (profileError) {
+        console.error("Failed to fetch user profile:", profileError);
+        // Don't fail login if profile fetch fails
       }
-    } catch (profileError) {
-      console.error("Failed to fetch user profile:", profileError);
-      // Don't fail login if profile fetch fails
-    }
-  }, []);
+    },
+    [queryClient]
+  );
 
   // Plain async fn (no useCallback): identity doesn't need to be stable for
   // memoization, and taking `service` explicitly lets cold-start callers pass
   // a freshly-rebuilt service without waiting for the state update to settle.
-  const saveOAuthTokens = async (
-    tokens: OAuthTokens,
-    service: CalComOAuthService | null
-  ) => {
+  const saveOAuthTokens = async (tokens: OAuthTokens, service: CalComOAuthService | null) => {
     await storage.set(OAUTH_TOKENS_KEY, JSON.stringify(tokens));
     await storage.set(AUTH_TYPE_KEY, "oauth");
 
@@ -162,38 +193,64 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   const logout = useCallback(async () => {
+    // Each cleanup step has its own try/catch so a failure in one does not
+    // skip the others. resetAuthState() always runs last to put the UI in a
+    // known logged-out state even if disk writes failed.
     try {
       await clearAuth();
-      // Clear user preferences to ensure fresh state for next user
-      try {
-        await generalStorage.removeItem(USER_PREFERENCES_KEY);
-      } catch (prefsError) {
-        console.warn("Failed to clear user preferences during logout:", prefsError);
-      }
-      // Clear cache before region reset so getStorageKey() still returns the correct key.
-      try {
-        await clearQueryCache();
-      } catch (cacheError) {
-        safeLogWarn("Failed to clear query cache during logout:", cacheError);
-      }
-      // Reset the persisted data region so the next user is prompted via the
-      // login-screen picker rather than silently inheriting this session's
-      // region (the extension background worker clears `cal_region` on logout
-      // too — keep the two surfaces in sync).
-      try {
-        await clearRegion();
-      } catch (regionError) {
-        console.warn("Failed to clear data region during logout:", regionError);
-      }
-      resetAuthState();
-    } catch (error) {
-      const message = getErrorMessage(error);
-      console.error("Failed to logout", message);
+    } catch (clearAuthError) {
+      const message = getErrorMessage(clearAuthError);
+      console.warn("Failed to clear auth tokens during logout:", message);
       if (__DEV__) {
-        console.debug("[AuthContext] logout failed", { message, stack: getErrorStack(error) });
+        console.debug("[AuthContext] clearAuth failed", {
+          message,
+          stack: getErrorStack(clearAuthError),
+        });
       }
     }
-  }, [clearAuth, resetAuthState]);
+    // Clear user preferences to ensure fresh state for next user
+    try {
+      await generalStorage.removeItem(USER_PREFERENCES_KEY);
+    } catch (prefsError) {
+      console.warn("Failed to clear user preferences during logout:", prefsError);
+    }
+    // Memory first, then disk. PersistQueryClient throttles persists
+    // (cache.config.ts: throttleTime = 1000ms); clearing the in-memory cache
+    // before the disk wipe prevents an in-flight persist from re-writing the
+    // previous user's data right after we erased it.
+    //
+    // IMPORTANT: both of these must run BEFORE clearRegion(). The persister's
+    // storage key is region-suffixed (`cal-companion-query-cache-{region}`),
+    // so if we reset the region first the disk wipe would target the
+    // default-US key and the user's actual region's cache would survive.
+    try {
+      queryClient.clear();
+    } catch (clearError) {
+      console.warn("Failed to clear in-memory query cache during logout:", clearError);
+    }
+    try {
+      await clearQueryCache();
+    } catch (cacheError) {
+      safeLogWarn("Failed to clear persisted query cache during logout:", cacheError);
+    }
+    // Reset the persisted data region so the next user is prompted via the
+    // login-screen picker rather than silently inheriting this session's
+    // region (the extension background worker clears `cal_region` on logout
+    // too — keep the two surfaces in sync).
+    try {
+      await clearRegion();
+    } catch (regionError) {
+      console.warn("Failed to clear data region during logout:", regionError);
+    }
+    // Wipe the home-screen widget so the previous user's meetings don't
+    // linger after sign-out (no-op on web).
+    try {
+      await clearWidgetBookings();
+    } catch (widgetError) {
+      console.warn("Failed to clear widget bookings during logout:", widgetError);
+    }
+    resetAuthState();
+  }, [clearAuth, resetAuthState, queryClient]);
 
   // Handle OAuth authentication. `service` is passed explicitly so the boot
   // effect can hand in a freshly-rebuilt service on cold-start region
@@ -416,7 +473,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
     try {
       currentService = createCalComOAuthService();
     } catch (serviceError) {
-      safeLogWarn("Failed to build OAuth service at login time, falling back to cached instance:", serviceError);
+      safeLogWarn(
+        "Failed to build OAuth service at login time, falling back to cached instance:",
+        serviceError
+      );
       currentService = oauthService;
     }
     if (!currentService) {

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -109,6 +109,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const setupAfterLogin = useCallback(
     async (token: string, refreshToken?: string) => {
       CalComAPIService.setAccessToken(token, refreshToken);
+      // Drop any user-profile singleton left over from a previous in-memory
+      // session (e.g. an extension iframe that outlived a logout, or a future
+      // in-session account switch). getUserProfile() returns the cached
+      // singleton without an API call if one exists, so without this clear it
+      // could hand us the previous user's profile — the mismatch check
+      // downstream would then see two matching ids and silently pass.
+      CalComAPIService.clearUserProfile();
 
       try {
         const profile = await CalComAPIService.getUserProfile();

--- a/apps/mobile/hooks/useWidgetSync.ts
+++ b/apps/mobile/hooks/useWidgetSync.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect } from "react";
 import { Platform } from "react-native";
 import { queryKeys } from "@/config/cache.config";
+import { useAuth } from "@/contexts/AuthContext";
 import { type Booking, CalComAPIService } from "@/services/calcom";
 import {
   clearWidgetBookings,
@@ -11,6 +12,7 @@ import {
 
 export function useWidgetSync() {
   const queryClient = useQueryClient();
+  const { isAuthenticated } = useAuth();
 
   const syncBookingsToWidget = useCallback(async () => {
     if (__DEV__) {
@@ -140,13 +142,19 @@ export function useWidgetSync() {
     if (Platform.OS === "web") {
       return;
     }
+    // Skip the initial sync (and the API fallback inside syncBookingsToWidget)
+    // until auth is verified — otherwise the hook fires on every cold start
+    // before tokens are loaded and triggers an unauthenticated /bookings request.
+    if (!isAuthenticated) {
+      return;
+    }
 
     syncBookingsToWidget();
 
     const cleanup = setupWidgetRefreshOnAppStateChange(syncBookingsToWidget);
 
     return cleanup;
-  }, [syncBookingsToWidget]);
+  }, [syncBookingsToWidget, isAuthenticated]);
 
   return {
     syncBookingsToWidget,

--- a/apps/mobile/utils/queryPersister.ts
+++ b/apps/mobile/utils/queryPersister.ts
@@ -30,6 +30,10 @@ const storage = generalStorage;
 const OAUTH_TOKENS_KEY = "cal_oauth_tokens";
 const AUTH_TYPE_KEY = "cal_auth_type";
 
+// Pre-region-suffix key. Removed on every restore so pre-migration cache data
+// doesn't accumulate on disk; `removeItem` is a no-op once the key is gone.
+const LEGACY_STORAGE_KEY = CACHE_CONFIG.persistence.storageKey;
+
 /**
  * Create a React Query persister that works across all platforms
  *
@@ -65,6 +69,16 @@ export const createQueryPersister = (): Persister => {
       await regionPreloaded;
       const storageKey = getStorageKey();
       try {
+        // Sweep the pre-region-suffix key on every restore so legacy data
+        // doesn't survive the migration. No-op once the key is gone.
+        if (LEGACY_STORAGE_KEY !== storageKey) {
+          try {
+            await storage.removeItem(LEGACY_STORAGE_KEY);
+          } catch (legacyError) {
+            safeLogWarn("[QueryPersister] Failed to clean up legacy cache key:", legacyError);
+          }
+        }
+
         // Bail early if the user is logged out — never restore another user's
         // cache into an unauthenticated session. Wipe the orphaned cache too
         // so a stale logout (e.g. one where queryClient.clear() succeeded but

--- a/apps/mobile/utils/queryPersister.ts
+++ b/apps/mobile/utils/queryPersister.ts
@@ -6,9 +6,9 @@
 
 import type { PersistedClient, Persister } from "@tanstack/react-query-persist-client";
 import { CACHE_CONFIG } from "@/config/cache.config";
-import { safeLogWarn } from "./safeLogger";
-import { generalStorage } from "./storage";
 import { getRegion, regionPreloaded } from "./region";
+import { safeLogWarn } from "./safeLogger";
+import { generalStorage, secureStorage } from "./storage";
 
 function getStorageKey(): string {
   return `${CACHE_CONFIG.persistence.storageKey}-${getRegion()}`;
@@ -16,6 +16,19 @@ function getStorageKey(): string {
 
 // Use the shared general storage adapter for cache persistence
 const storage = generalStorage;
+
+// Duplicated from AuthContext to avoid a circular import; keep these in sync.
+// If a persisted cache is found but the user is logged out, don't rehydrate a
+// previous user's data into an unauthenticated session. We check BOTH keys
+// because OAuth and web-session logins use different storage shapes:
+//   - OAuth login writes `cal_oauth_tokens` AND `cal_auth_type = "oauth"`.
+//   - Web-session login writes ONLY `cal_auth_type = "web_session"` — no OAuth
+//     tokens. Checking `cal_oauth_tokens` alone would wipe web-session users'
+//     persisted cache on every cold start.
+// Both keys are cleared atomically by `clearAuth()` in AuthContext, so the
+// presence of either reliably indicates the user has not logged out.
+const OAUTH_TOKENS_KEY = "cal_oauth_tokens";
+const AUTH_TYPE_KEY = "cal_auth_type";
 
 /**
  * Create a React Query persister that works across all platforms
@@ -52,6 +65,28 @@ export const createQueryPersister = (): Persister => {
       await regionPreloaded;
       const storageKey = getStorageKey();
       try {
+        // Bail early if the user is logged out — never restore another user's
+        // cache into an unauthenticated session. Wipe the orphaned cache too
+        // so a stale logout (e.g. one where queryClient.clear() succeeded but
+        // the throttled disk persist ran later) doesn't survive a cold start.
+        let hasAuth = false;
+        try {
+          const [tokens, authType] = await Promise.all([
+            secureStorage.get(OAUTH_TOKENS_KEY),
+            secureStorage.get(AUTH_TYPE_KEY),
+          ]);
+          hasAuth = Boolean(tokens) || Boolean(authType);
+        } catch (tokenError) {
+          safeLogWarn(
+            "[QueryPersister] Failed to read auth state, treating as logged out:",
+            tokenError
+          );
+        }
+        if (!hasAuth) {
+          await storage.removeItem(storageKey);
+          return undefined;
+        }
+
         const serialized = await storage.getItem(storageKey);
         if (!serialized) {
           return undefined;


### PR DESCRIPTION
## Summary

Builds on PR #91 (region-scoped persisted cache + logout reorder) with additional cross-user data-isolation hardening. The pieces in #91 are intentionally **not** duplicated here; this PR contains only what #91 did **not** address.

Three commits on top of current `main`:

1. **`fix(auth): isolate user data across logout and cold-start transitions`** — the original PR #92 work, rebased on top of #91 and updated with the web-session auth-type fix folded in.
   - **A1**: `AuthContext.logout()` now calls `queryClient.clear()` before `clearQueryCache()`. With `staleTime: Infinity` + `refetchOnMount: false`, the in-memory cache survives logout otherwise and the next login flashes the previous user's `userProfile`, `eventTypes`, `bookings`, and `schedules` on screen before the new fetch lands. Memory-first / disk-second avoids racing the `PersistQueryClient` throttled writer (`throttleTime: 1000ms` in `cache.config.ts`).
   - **A2 part 1**: `queryPersister.restoreClient` now bails out (and wipes the persisted cache) if neither `cal_oauth_tokens` *nor* `cal_auth_type` is present in `secureStorage`. Both keys are cleared atomically by `clearAuth()`, so the absence of either reliably indicates a logged-out cold start. Checking both keys covers the `loginFromWebSession` path that writes `cal_auth_type` without OAuth tokens (the OAuth-only check from the first draft of #92 would have wiped web-session users' cache on every cold start — caught by Devin Review, fix folded into this commit).
   - **A2 part 2**: `setupAfterLogin` reads `queryKeys.userProfile.current()` from `queryClient` after the new `getUserProfile()` fetch resolves. If the rehydrated cache profile id differs from the freshly fetched id, both the in-memory cache and the persisted cache are wiped before `setUserInfo()` is called, so a foreign cache that survived `restoreClient` never gets a chance to bleed PII into the UI.
   - **A3**: `clearWidgetBookings()` runs as a step inside `logout()`, so the iOS / Android home-screen widget no longer keeps showing the signed-out user's meetings after sign-out (no-op on web).
   - **A5**: The single top-level `try/catch` around `logout()` is replaced with one `try/catch` per cleanup step. A failure in `clearAuth()` no longer skips `clearRegion`, the cache wipes, the widget wipe, or `resetAuthState()`. `resetAuthState()` always runs last, so the UI is always returned to a known logged-out state even if any disk write failed.
   - **A6**: `useWidgetSync` returns early from its initial-mount effect when `isAuthenticated` is `false`. Previously the hook fired on every cold start before tokens were loaded and triggered an unauthenticated `/bookings` request that fell into the API error path.

2. **`fix(persister): sweep pre-region-suffix cache key on every restore`** — gap left by #91.
   PR #91 migrated the persisted cache key to `cal-companion-query-cache-{region}` but never reads or cleans up the pre-migration unsuffixed `cal-companion-query-cache` key. Users who upgraded across the migration have stale cache data sitting on disk forever — never re-read, never expired by `maxAge`, never garbage-collected. One-line fix: `removeItem(LEGACY_STORAGE_KEY)` near the top of `restoreClient`. Runs on every restore so it can't be skipped; `removeItem` on a missing key is a no-op so the cost after the first cleanup is negligible.

3. **`fix(auth): drop stale user-profile singleton before post-login refetch`** — defense-in-depth for A2 part 2.
   `CalComAPIService.getUserProfile()` is backed by a module-level singleton (`_userProfile` in `services/calcom/user.ts`). If the JS context survives between logout and the next login (long-lived extension iframe, rapid re-login, or a future in-session account-switch flow), the singleton can still hold the previous user's profile and `getUserProfile()` will return it without an API call. The A2 part 2 mismatch check would then see two matching ids and silently pass. `CalComAPIService.clearUserProfile()` between `setAccessToken` and `getUserProfile()` forces a fresh fetch tied to the just-installed access token, so identity detection sees the true new-user profile.

### What's intentionally NOT in this PR

PR #91 already landed these, so they are not reimplemented here:
- Region-scoping the persistence storage key.
- `clearQueryCache()` ordered before `clearRegion()` in `logout()`.
- `regionPreloaded` await on cold start in `restoreClient`.
- OAuth service rebuild on region change.

## Review & Testing Checklist for Human

Risk level: yellow (security-relevant edits, four touch-points across two files).

- [ ] **Confirm logout fully resets state when SecureStore fails.** With dev tooling, simulate a `clearAuth()` failure (e.g. inject a throw at the top of `clearAuth`). Verify the cache wipes, `clearRegion`, `clearWidgetBookings`, and `resetAuthState` all still run — i.e. UI flips to logged-out and the persisted cache is gone.
- [ ] **Confirm no logged-out cache restore.** With a populated persisted cache on disk AND no auth (delete both `cal_oauth_tokens` and `cal_auth_type` via debugger), cold-start the app. Confirm `restoreClient` returns `undefined`, the persisted cache key is wiped before the login screen renders, and the legacy unsuffixed key (`cal-companion-query-cache`) is also gone.
- [ ] **Web-session users still rehydrate.** Log in via the web session path (which writes `cal_auth_type = "web_session"` but no `cal_oauth_tokens`), navigate to populate cache, force-quit, re-launch. Confirm the persisted cache is rehydrated (not wiped) and the home screen shows bookings instantly.
- [ ] **Cross-user identity-mismatch wipes the cache.** Log in as user A, populate cache, log out. Without clearing storage, log in as user B. Confirm `setupAfterLogin` detects the id mismatch in the rehydrated cache and clears both in-memory + persisted caches before `setUserInfo()` lands — i.e. no flash of user A's bookings/events on screen.
- [ ] **Widget no longer shows previous user's meetings after sign-out.** On iOS or Android, log in, see meetings appear in the home-screen widget, then log out. Within the next widget refresh tick, confirm the widget shows the empty/logged-out state, not the previous user's meetings.

### Notes

- 3 commits on top of `origin/main` (post-#91). Force-pushed once on this branch to drop the redundant Task 1 + Task 2 work that #91 implemented independently — that's why the PR shows a force-push event.
- All commits pass local `tsc --noEmit` and `biome check`.
- No tests in `apps/mobile`. Manual verification only.

Link to Devin session: https://app.devin.ai/sessions/552bf0c30e2f49ae97026d75be802e24
Requested by: @dhairyashiil