### PR TITLE
fix(extension): region-aware URLs to prevent cross-region data leak

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-cd companion
-npx lint-staged
+bunx lint-staged

--- a/apps/extension/entrypoints/background/index.ts
+++ b/apps/extension/entrypoints/background/index.ts
@@ -1,5 +1,6 @@
 /// <reference types="chrome" />
 
+import { getCalApiUrl, getCalMarketingAppUrl } from "../../lib/region";
 import type { Booking } from "../../types/bookings.types";
 import type { OAuthTokens } from "../../types/oauth";
 
@@ -325,11 +326,12 @@ function isRestrictedUrl(url: string | undefined): boolean {
   return restrictedPatterns.some((pattern) => pattern.test(url));
 }
 
-// Open cal.com/app (Framer marketing page) in a new tab with auto-open parameter
+// Open the Cal.com Framer marketing landing in a new tab with auto-open parameter.
+// The marketing site is intentionally cross-region — see getCalMarketingAppUrl().
 function openAppPage(): void {
   const tabsAPI = getTabsAPI();
   if (tabsAPI) {
-    tabsAPI.create({ url: "https://cal.com/app?openExtension=true" });
+    tabsAPI.create({ url: getCalMarketingAppUrl() });
   }
 }
 
@@ -895,13 +897,9 @@ async function getStoredRegion(): Promise<"us" | "eu"> {
   }
 }
 
-function apiBaseUrlForRegion(region: "us" | "eu"): string {
-  return region === "eu" ? "https://api.cal.eu/v2" : "https://api.cal.com/v2";
-}
-
 async function getApiBaseUrl(): Promise<string> {
   const region = await getStoredRegion();
-  return apiBaseUrlForRegion(region);
+  return `${getCalApiUrl(region)}/v2`;
 }
 
 const tokenOperationTimestamps: number[] = [];
@@ -934,7 +932,7 @@ async function validateTokens(tokens: OAuthTokens, region?: "us" | "eu"): Promis
   }
 
   try {
-    const apiBaseUrl = region ? apiBaseUrlForRegion(region) : await getApiBaseUrl();
+    const apiBaseUrl = region ? `${getCalApiUrl(region)}/v2` : await getApiBaseUrl();
     const response = await fetchWithTimeout(`${apiBaseUrl}/me`, {
       headers: {
         Authorization: `Bearer ${tokens.accessToken}`,

--- a/apps/extension/entrypoints/content.ts
+++ b/apps/extension/entrypoints/content.ts
@@ -1,6 +1,7 @@
 /// <reference types="chrome" />
 import { initGoogleCalendarIntegration } from "../lib/google-calendar";
 import { initLinkedInIntegration } from "../lib/linkedin";
+import { getCalAppUrl, getCalWebUrl } from "../lib/region";
 import { escapeHtml } from "../lib/utils";
 
 /**
@@ -1091,7 +1092,7 @@ export default defineContentScript({
                     e.stopPropagation();
                     const bookingUrl =
                       eventType.bookingUrl ||
-                      `https://cal.com/${
+                      `${getCalWebUrl()}/${
                         eventType.users?.[0]?.username || "user"
                       }/${eventType.slug}`;
                     window.open(bookingUrl, "_blank");
@@ -1135,7 +1136,7 @@ export default defineContentScript({
                     // Copy to clipboard
                     const bookingUrl =
                       eventType.bookingUrl ||
-                      `https://cal.com/${
+                      `${getCalWebUrl()}/${
                         eventType.users?.[0]?.username || "user"
                       }/${eventType.slug}`;
                     navigator.clipboard
@@ -1197,7 +1198,7 @@ export default defineContentScript({
 
                   editBtn.addEventListener("click", (e) => {
                     e.stopPropagation();
-                    const editUrl = `https://app.cal.com/event-types/${eventType.id}`;
+                    const editUrl = `${getCalAppUrl()}/event-types/${eventType.id}`;
                     window.open(editUrl, "_blank");
                   });
                   editBtn.addEventListener("mouseenter", () => {
@@ -1308,7 +1309,7 @@ export default defineContentScript({
             // Construct the Cal.com booking link
             const bookingUrl =
               eventType.bookingUrl ||
-              `https://cal.com/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
+              `${getCalWebUrl()}/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
 
             // Try to insert at cursor position in the compose field
             const inserted = insertTextAtCursor(bookingUrl);
@@ -1336,7 +1337,7 @@ export default defineContentScript({
             // Construct the Cal.com booking link
             const bookingUrl =
               eventType.bookingUrl ||
-              `https://cal.com/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
+              `${getCalWebUrl()}/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
 
             // Try to insert at cursor position in the compose field
             const inserted = insertTextAtCursor(bookingUrl);
@@ -1840,7 +1841,7 @@ export default defineContentScript({
                 e.stopPropagation();
                 const bookingUrl =
                   eventType.bookingUrl ||
-                  `https://cal.com/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
+                  `${getCalWebUrl()}/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
                 window.open(bookingUrl, "_blank");
               });
               previewBtn.addEventListener("mouseenter", () => {
@@ -1882,7 +1883,7 @@ export default defineContentScript({
                 // Copy to clipboard
                 const bookingUrl =
                   eventType.bookingUrl ||
-                  `https://cal.com/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
+                  `${getCalWebUrl()}/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
                 navigator.clipboard
                   .writeText(bookingUrl)
                   .then(() => {
@@ -1942,7 +1943,7 @@ export default defineContentScript({
 
               editBtn.addEventListener("click", (e) => {
                 e.stopPropagation();
-                const editUrl = `https://app.cal.com/event-types/${eventType.id}`;
+                const editUrl = `${getCalAppUrl()}/event-types/${eventType.id}`;
                 window.open(editUrl, "_blank");
               });
               editBtn.addEventListener("mouseenter", () => {
@@ -2053,7 +2054,7 @@ export default defineContentScript({
         // Construct the Cal.com booking link
         const bookingUrl =
           eventType.bookingUrl ||
-          `https://cal.com/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
+          `${getCalWebUrl()}/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
 
         // Try to insert at cursor position in the message field
         const inserted = insertTextAtCursor(bookingUrl);
@@ -2242,7 +2243,7 @@ export default defineContentScript({
               .map((slot) => {
                 // URL-encode the timezone to handle special characters like "/"
                 const encodedTimezone = encodeURIComponent(timezone);
-                const bookingURL = `https://cal.com/${username}/${eventType.slug}?duration=${duration}&date=${slot.isoDate}&slot=${slot.isoTimestamp}&cal.tz=${encodedTimezone}`;
+                const bookingURL = `${getCalWebUrl()}/${username}/${eventType.slug}?duration=${duration}&date=${slot.isoDate}&slot=${slot.isoTimestamp}&cal.tz=${encodedTimezone}`;
 
                 return `
                   <td style="padding: 0px; width: 64px; display: inline-block; margin-right: 4px; margin-bottom: 4px; height: 24px; border: 1px solid #111827; border-radius: 3px;">
@@ -2306,7 +2307,7 @@ export default defineContentScript({
             </div>
             ${datesHTML}
             <div style="margin-top: 13px;">
-              <a href="https://cal.com/${username}/${eventType.slug}?cal.tz=${encodeURIComponent(
+              <a href="${getCalWebUrl()}/${username}/${eventType.slug}?cal.tz=${encodeURIComponent(
                 timezone
               )}" style="text-decoration: none; cursor: pointer; color: #0B57D0; font-size: 14px;">
                 See all available times →
@@ -3416,7 +3417,7 @@ export default defineContentScript({
               const username =
                 eventTypes.length > 0 ? eventTypes[0].users?.[0]?.username || "user" : "user";
 
-              const createUrl = `https://app.cal.com/event-types?dialog=new&eventPage=${username}`;
+              const createUrl = `${getCalAppUrl()}/event-types?dialog=new&eventPage=${username}`;
               window.open(createUrl, "_blank");
               showGmailNotification(
                 `Opening Cal.com to create ${parsedData.detectedDuration}min event type`,
@@ -3694,7 +3695,7 @@ export default defineContentScript({
               const selectedUsername = selectedEventType.users?.[0]?.username || "user";
 
               // Generate Cal.com URL with slot parameters
-              const baseUrl = `https://cal.com/${selectedUsername}/${selectedSlug}`;
+              const baseUrl = `${getCalWebUrl()}/${selectedUsername}/${selectedSlug}`;
               const params = new URLSearchParams({
                 overlayCalendar: "true",
                 date: slot.isoDate,

--- a/apps/extension/lib/google-calendar.ts
+++ b/apps/extension/lib/google-calendar.ts
@@ -1,4 +1,5 @@
 /// <reference types="chrome" />
+import { CAL_WEB_HOSTNAMES } from "./region";
 
 // Google Calendar integration: inject a no-show toggle next to attendees in event popups.
 const bookingStatusCache = new Map<string, { data: Map<string, boolean>; timestamp: number }>();
@@ -266,11 +267,12 @@ function injectStyles(): void {
 }
 
 /**
- * Extract booking UID from event description
- * Looks for patterns like: https://cal.com/booking/{uid} or https://app.cal.com/booking/{uid}
+ * Extract booking UID from event description.
+ * Matches both regions: https://cal.{com|eu}/booking/{uid} and
+ * https://app.cal.{com|eu}/booking/{uid}.
  */
 function extractBookingUid(text: string): string | null {
-  const regex = /https:\/\/(?:app\.)?cal\.com\/booking\/([a-zA-Z0-9]+)/;
+  const regex = /https:\/\/(?:app\.)?cal\.(?:com|eu)\/booking\/([a-zA-Z0-9]+)/;
   const match = text.match(regex);
   return match ? match[1] : null;
 }
@@ -1199,10 +1201,10 @@ function observeEventPopups(): void {
     }
 
     const text = element.textContent || "";
-    // Check if this looks like a Cal.com event
+    const lowerText = text.toLowerCase();
+    // Check if this looks like a Cal.com event (case-insensitive across both regions)
     const isCalComEvent =
-      text.includes("cal.com") ||
-      text.includes("Cal.com") ||
+      CAL_WEB_HOSTNAMES.some((host) => lowerText.includes(host)) ||
       text.includes("booking") ||
       extractBookingUid(text) !== null;
 
@@ -1354,11 +1356,11 @@ function observeEventPopups(): void {
         return;
       }
 
-      // Check if this is a Cal.com event
+      // Check if this is a Cal.com event (case-insensitive across both regions)
       const text = popup.textContent || "";
+      const lowerText = text.toLowerCase();
       const isCalComEvent =
-        text.includes("cal.com") ||
-        text.includes("Cal.com") ||
+        CAL_WEB_HOSTNAMES.some((host) => lowerText.includes(host)) ||
         text.includes("booking") ||
         extractBookingUid(text) !== null;
 

--- a/apps/extension/lib/linkedin.ts
+++ b/apps/extension/lib/linkedin.ts
@@ -1,4 +1,5 @@
 /// <reference types="chrome" />
+import { getCalAppUrl, getCalWebUrl } from "./region";
 import { escapeHtml } from "./utils";
 
 // LinkedIn integration: inject a Cal.com scheduling button in LinkedIn messaging
@@ -617,7 +618,7 @@ export function initLinkedInIntegration() {
     const editBtn = createActionButton(SVG_ICONS.EDIT, "Edit", "0 6px 6px 0", tooltipsToCleanup);
     editBtn.addEventListener("click", (e) => {
       e.stopPropagation();
-      const editUrl = `https://app.cal.com/event-types/${eventType.id}`;
+      const editUrl = `${getCalAppUrl()}/event-types/${eventType.id}`;
       window.open(editUrl, "_blank");
     });
 
@@ -668,7 +669,7 @@ export function initLinkedInIntegration() {
   function buildBookingUrl(eventType: EventType): string {
     return (
       eventType.bookingUrl ||
-      `https://cal.com/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`
+      `${getCalWebUrl()}/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`
     );
   }
 

--- a/apps/extension/lib/region.ts
+++ b/apps/extension/lib/region.ts
@@ -1,0 +1,138 @@
+/**
+ * Cal.com data region helpers for the Chrome extension.
+ *
+ * Mirrors `apps/mobile/utils/region.ts` but reads from
+ * `chrome.storage.local["cal_region"]` — the same key the background worker
+ * writes via the `sync-oauth-tokens` handler
+ * (`apps/extension/entrypoints/background/index.ts:26`).
+ *
+ * Region is cached synchronously in a module-level variable so content-script
+ * callsites can build URLs without an `await`. The cache is initialized on
+ * module import via the fire-and-forget `preloadRegion()` and kept in sync
+ * thereafter by a `chrome.storage.onChanged` listener.
+ *
+ * NEVER inline literal `cal.com` / `cal.eu` hostnames elsewhere in
+ * `apps/extension/**`. The CI grep `check:no-cal-hostnames` enforces this.
+ */
+
+export type CalRegion = "us" | "eu";
+
+const REGION_STORAGE_KEY = "cal_region";
+const DEFAULT_REGION: CalRegion = "us";
+
+let currentRegion: CalRegion = DEFAULT_REGION;
+let preloaded = false;
+
+function isValidRegion(value: unknown): value is CalRegion {
+  return value === "us" || value === "eu";
+}
+
+function isChromeStorageAvailable(): boolean {
+  return (
+    typeof chrome !== "undefined" &&
+    typeof chrome.storage !== "undefined" &&
+    typeof chrome.storage.local !== "undefined"
+  );
+}
+
+/**
+ * Load the persisted region from chrome.storage.local. Idempotent — subsequent
+ * calls re-read storage but do not re-register listeners. Best-effort: on
+ * storage failure the cache stays at its current value (default US for the
+ * first call, last-known otherwise).
+ */
+export async function preloadRegion(): Promise<CalRegion> {
+  if (!isChromeStorageAvailable()) {
+    preloaded = true;
+    return currentRegion;
+  }
+  try {
+    const result = await chrome.storage.local.get([REGION_STORAGE_KEY]);
+    if (isValidRegion(result[REGION_STORAGE_KEY])) {
+      currentRegion = result[REGION_STORAGE_KEY];
+    }
+  } catch {
+    // Best-effort; stay on default.
+  }
+  preloaded = true;
+  return currentRegion;
+}
+
+if (
+  typeof chrome !== "undefined" &&
+  chrome.storage?.onChanged &&
+  typeof chrome.storage.onChanged.addListener === "function"
+) {
+  chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== "local") return;
+    if (!changes[REGION_STORAGE_KEY]) return;
+    const next = changes[REGION_STORAGE_KEY].newValue;
+    if (isValidRegion(next)) {
+      currentRegion = next;
+    } else if (next === undefined) {
+      currentRegion = DEFAULT_REGION;
+    }
+  });
+}
+
+// Kick off the initial read on import. Fire-and-forget — the helpers below are
+// safe to call before this resolves (they fall back to the default).
+preloadRegion();
+
+export function getRegion(): CalRegion {
+  return currentRegion;
+}
+
+export function isRegionPreloaded(): boolean {
+  return preloaded;
+}
+
+/**
+ * `https://app.cal.{com|eu}` — Cal.com web app origin for the current region.
+ *
+ * Note: the very first synchronous call after extension load may return the
+ * US default before `preloadRegion()` resolves. In practice this is benign:
+ * content scripts only construct URLs in user-event handlers, by which time
+ * the async preload has completed.
+ */
+export function getCalAppUrl(region: CalRegion = currentRegion): string {
+  return region === "eu" ? "https://app.cal.eu" : "https://app.cal.com";
+}
+
+/**
+ * `https://api.cal.{com|eu}` — Cal.com API origin for the current region.
+ * Same first-call caveat as `getCalAppUrl()`.
+ */
+export function getCalApiUrl(region: CalRegion = currentRegion): string {
+  return region === "eu" ? "https://api.cal.eu" : "https://api.cal.com";
+}
+
+/**
+ * `https://cal.{com|eu}` — Cal.com booking-page origin for the current region.
+ * Same first-call caveat as `getCalAppUrl()`.
+ */
+export function getCalWebUrl(region: CalRegion = currentRegion): string {
+  return region === "eu" ? "https://cal.eu" : "https://cal.com";
+}
+
+/**
+ * Cal.com Framer marketing landing for the "open extension" deep link. Stays
+ * global — the Framer-hosted marketing site does not have an EU mirror.
+ * Same precedent as `getCalSupportUrl()` / `getCalHelpUrl()` in mobile's
+ * region module.
+ */
+export function getCalMarketingAppUrl(): string {
+  return "https://cal.com/app?openExtension=true";
+}
+
+/**
+ * Hostnames the extension recognizes as Cal.com booking surfaces across both
+ * regions. Use for regex / `text.includes(...)` host detection. Do NOT use to
+ * build outbound URLs (use the getters above).
+ */
+export const CAL_WEB_HOSTNAMES: ReadonlyArray<string> = [
+  "cal.com",
+  "cal.eu",
+  "app.cal.com",
+  "app.cal.eu",
+];

--- a/apps/mobile/scripts/check-no-cal-hostnames.sh
+++ b/apps/mobile/scripts/check-no-cal-hostnames.sh
@@ -1,35 +1,48 @@
 #!/usr/bin/env bash
-# Fail if any file under apps/mobile inlines a literal `cal.com` or `cal.eu`
-# hostname in code. Region-aware construction must go through the helpers in
-# `apps/mobile/utils/region.ts` so EU users get routed to `app.cal.eu` /
-# `api.cal.eu` / `cal.eu`.
+# Fail if any file under apps/mobile or apps/extension inlines a literal
+# `cal.com` / `cal.eu` hostname in code. Region-aware construction must go
+# through the helpers in:
+#   - apps/mobile/utils/region.ts        (mobile + web build)
+#   - apps/extension/lib/region.ts       (Chrome extension)
 #
-# Scope: scans the entire `apps/mobile` tree. `rg` honors `.gitignore` so
-# `node_modules/`, build artifacts, and other ignored paths are skipped
-# automatically — no manual directory list to drift out of sync.
+# Scope: scans both `apps/mobile` and `apps/extension`. `rg` honors
+# `.gitignore` so build artifacts and `node_modules/` are skipped.
 #
 # Filters applied on top of the raw matches:
-# - Word boundaries in `PATTERN` so incidental substrings like
-#   `group.com.cal.companion` (an iOS app-group id) are not flagged.
-# - Lines whose content starts with `//`, `*`, or `/*` are filtered, since
-#   documentation prose / docstring @example URLs don't cause runtime bugs.
-# - `ALLOWLIST` exempts files that legitimately reference the bare hostnames:
-#   the region helpers themselves, the env template, the hostname match-set
-#   used for video-call URL detection, and this script.
+#  - PATTERN uses word boundaries so incidental substrings like
+#    `group.com.cal.companion` (iOS app-group id) and `companion.cal.com`
+#    (extension OAuth/iframe origin) ARE captured by the pattern and then
+#    filtered out below — see CONTENT_ALLOWLIST.
+#  - FILE_ALLOWLIST exempts files that legitimately reference Cal hostnames:
+#    the region helpers, env templates, manifests / build configs that must
+#    stay static, and the hostname match-sets used for detection.
+#  - CONTENT_ALLOWLIST exempts the `companion.cal.com` token (the extension's
+#    OAuth landing / iframe origin — it matches the pattern but is not a Cal
+#    app URL).
+#  - Comment lines (starting with //, *, /*) are filtered.
 set -euo pipefail
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/../../.."  # repo root
 
-PATTERN='\bcal\.(com|eu)\b'
-ALLOWLIST='^(\./)?(utils/region\.ts|utils/booking\.ts|\.env\.example|scripts/check-no-cal-hostnames\.sh):'
+PATTERN='\b(app\.)?cal\.(com|eu)\b'
 
-raw=$(rg -n --no-heading "$PATTERN" . 2>/dev/null || true)
-hits=$(echo "$raw" | grep -Ev "$ALLOWLIST" | grep -Ev '^[^:]+:[0-9]+:[[:space:]]*(//|\*|/\*)' || true)
+FILE_ALLOWLIST='^(apps/mobile/utils/region\.ts|apps/mobile/utils/booking\.ts|apps/mobile/\.env\.example|apps/mobile/scripts/check-no-cal-hostnames\.sh|apps/extension/lib/region\.ts|apps/extension/\.env\.example|apps/extension/wxt\.config\.ts|apps/extension/public/manifest\.json):'
+
+# Match-anywhere allowlist for tokens that aren't Cal app URLs but happen to
+# contain a substring matching PATTERN.
+CONTENT_ALLOWLIST='companion\.cal\.com'
+
+raw=$(rg -n --no-heading "$PATTERN" apps/mobile apps/extension 2>/dev/null || true)
+hits=$(echo "$raw" \
+  | grep -Ev "$FILE_ALLOWLIST" \
+  | grep -Ev "$CONTENT_ALLOWLIST" \
+  | grep -Ev '^[^:]+:[0-9]+:[[:space:]]*(//|\*|/\*)' \
+  || true)
 
 if [[ -n "$hits" ]]; then
   {
-    echo "Hardcoded Cal hostname found. Use helpers from utils/region.ts:"
-    echo "  getCalAppUrl(), getCalApiUrl(), getCalWebUrl()"
-    echo "  getCalSupportUrl(), getCalHelpUrl(slug)"
+    echo "Hardcoded Cal hostname found. Use region helpers:"
+    echo "  apps/mobile/**:     import from utils/region.ts"
+    echo "  apps/extension/**:  import from lib/region.ts"
     echo ""
     echo "$hits"
   } >&2


### PR DESCRIPTION
## Summary

The Chrome extension's content scripts and background worker emitted client-side Cal.com URLs (Gmail booking links, LinkedIn integration links, "Edit event type" deep links, the "open Cal.com" tab, and the API base) that were hardcoded to `cal.com` / `app.cal.com` regardless of the user's data region. An EU host (whose data lives on cal.eu) composing a Gmail email would attach a `https://cal.com/<their-username>/<slot>` link to attendees — best case the recipient sees a 404; worst case the same username exists on cal.com (independent identity realm — a different person) and the recipient books with the wrong person, exfiltrating the EU host's calendar metadata.

The server-side fix in calcom/cal#2808 does NOT cover this — these URLs are emitted client-side from extension code, never validated against a region-bound JWT. The CI grep `check:no-cal-hostnames.sh` scanned only `apps/mobile`, so the extension drifted without enforcement.

### Changes
1. **New `apps/extension/lib/region.ts`** — mirrors `apps/mobile/utils/region.ts`. Reads `chrome.storage.local["cal_region"]` (the same key the background worker writes), caches synchronously, and refreshes via `chrome.storage.onChanged`. Exports `getCalAppUrl`, `getCalApiUrl`, `getCalWebUrl`, `getCalMarketingAppUrl`, `CAL_WEB_HOSTNAMES`, plus `preloadRegion`/`getRegion`.
2. **17 hardcoded callsites migrated** to the helpers:
   - `entrypoints/content.ts` — 13 sites (Gmail menu/embed/slot-picker links, edit/create event-type deep-links, fallback booking handles)
   - `lib/linkedin.ts` — 2 sites (edit event-type deep-link, booking URL fallback)
   - `lib/google-calendar.ts` — 3 sites: regex broadened to match `cal.{com|eu}/booking/<uid>`; two `text.includes("cal.com") || text.includes("Cal.com")` host checks replaced with a lowercased `CAL_WEB_HOSTNAMES.some(...)` scan so `cal.com`, `Cal.com`, `cal.eu`, `Cal.eu`, `app.cal.com`, `app.cal.eu` all trigger no-show button injection
   - `entrypoints/background/index.ts` — `openAppPage()` routes through `getCalMarketingAppUrl()` (Framer marketing is intentionally cross-region, same precedent as mobile's `getCalSupportUrl()`); `apiBaseUrlForRegion()` deleted, both call sites now use `${getCalApiUrl(region)}/v2` for one source of truth
3. **CI grep extended** to scan both `apps/mobile` and `apps/extension`. File-path-anchored allowlist (was content-anchored) so future code lines can't bypass by mentioning a hostname. Pattern broadened to also flag `app.cal.{com|eu}`. `companion.cal.com` (OAuth/iframe origin — different surface) stays content-allowlisted.
4. **`.husky/pre-commit`** — fixed a pre-existing broken hook (`cd companion` referencing a non-existent subdir, leftover from when this code lived inside `calcom/cal`). Replaced with `bunx lint-staged` run from the repo root. This was blocking all commits in fresh clones.

### Verified locally
- `bun run typecheck` — all 4 workspaces (extension, mobile, mcp-server, chat) clean
- `bun run lint:all` — biome + react-compiler eslint + the extended `check:no-cal-hostnames.sh` — exit 0
- Planted-regression test on the CI script: adding `https://cal.com/foo` or `https://app.cal.eu/foo` to extension code makes the script exit 1; reverting brings it back to exit 0

## Review & Testing Checklist for Human

- [ ] **Smoke-test in Chrome with both regions.** Build the extension (`cd apps/extension && bun dev`), load unpacked, then in the service worker DevTools console run `await chrome.storage.local.set({ cal_region: "eu" })`. Verify Gmail slot-picker links point to `cal.eu`, LinkedIn "Edit event type" points to `app.cal.eu`, and Google Calendar events whose description contains `https://cal.eu/booking/abc123` still get the no-show button. Switch back to `us` and confirm cal.com URLs return without an extension reload (the `chrome.storage.onChanged` listener should refresh the cache).
- [ ] **First-render sync caveat.** The very first call to `getCalWebUrl()` after extension load can return the US default if it lands before the fire-and-forget `preloadRegion()` resolves. In practice content scripts only call these helpers in user-event handlers, but worth eyeballing on a slow-starting Gmail tab.
- [ ] **Background `getApiBaseUrl()` still refreshes per call** — kept `await getStoredRegion()` in the path rather than reading the cached region from `lib/region.ts`, since the service worker can be suspended/woken and we want a fresh storage read per request. Confirm by toggling region and immediately triggering a background API call.
- [ ] **`apiBaseUrlForRegion` removal.** Two call sites updated (`getApiBaseUrl` and `validateTokens`); double-check no other callers I missed.
- [ ] **CI grep allowlist.** Confirm the allowlisted files (`wxt.config.ts`, `public/manifest.json`, `apps/extension/.env.example`) are genuinely intentional — they declare manifest `host_permissions` / privacy URL that must be static at build time.

### Notes
- The plan deliberately skipped adding `vitest` to `apps/extension` — the parallel mobile `utils/region.ts` module has no unit tests either, so adding test infra only on the extension side would be inconsistent. Validation is via the smoke test + the CI grep regression test above.
- Independent of calcom/cal#2808 (which fixes the server-side JWT keyring). Complementary, not overlapping.
- Independent of Becky's `<all_urls>` content-script scope reduction (separate bug, separate PR).
- The `.husky/pre-commit` fix is bundled here because it was blocking my own commits. Happy to split it into a separate PR if preferred.

Link to Devin session: https://app.devin.ai/sessions/ac67e96833434118859e913e2ed01489
Requested by: @dhairyashiil