### PR TITLE
chore: bump app version to 1.0.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-bug-ios.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-ios.yml
@@ -26,7 +26,7 @@ body:
     attributes:
       label: App Version
       description: Which version of the companion app are you running?
-      placeholder: "e.g., 1.0.6"
+      placeholder: "e.g., 1.0.7"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/3-bug-android.yml
+++ b/.github/ISSUE_TEMPLATE/3-bug-android.yml
@@ -26,7 +26,7 @@ body:
     attributes:
       label: App Version
       description: Which version of the companion app are you running?
-      placeholder: "e.g., 1.0.6"
+      placeholder: "e.g., 1.0.7"
     validations:
       required: true
 

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Calcom",
     "slug": "calcom-companion",
     "scheme": ["calcom", "expo-wxt-app"],
-    "version": "1.0.6",
+    "version": "1.0.7",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary

- Bumps `version` in `apps/mobile/app.json` from `1.0.6` → `1.0.7`
- Updates app version placeholder in iOS and Android GitHub issue templates to match

## Test plan

- [x] Verify `app.json` version reads `1.0.7`
- [x] Confirm issue template placeholders show `1.0.7`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/companion/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->