### PR TITLE
fix(mobile): harden push/auth flows and notification release setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ safari-extension/
 .env
 apps/mobile/.env
 apps/mobile/.env*.local
+apps/mobile/google-services.json
 apps/extension/.env
 apps/extension/.env*.local
 

--- a/apps/mobile/.easignore
+++ b/apps/mobile/.easignore
@@ -38,3 +38,4 @@ dev
 .env
 .env.*
 !.env.example
+google-services.json

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -1,6 +1,7 @@
 # local env files
 .env
 .env*.local
+google-services.json
 
 # Expo
 .expo/

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -1,0 +1,12 @@
+const appConfig = require("./app.json");
+
+module.exports = {
+  ...appConfig,
+  expo: {
+    ...appConfig.expo,
+    android: {
+      ...appConfig.expo.android,
+      googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
+    },
+  },
+};

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Calcom",
     "slug": "calcom-companion",
     "scheme": ["calcom", "expo-wxt-app"],
-    "version": "1.0.7",
+    "version": "1.0.8",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/apps/mobile/components/PushNotificationProvider.tsx
+++ b/apps/mobile/components/PushNotificationProvider.tsx
@@ -20,7 +20,6 @@ const LAST_HANDLED_NOTIF_KEY = "calcom_last_handled_notification_id";
 // Show notifications even when the app is in foreground.
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
-    shouldShowAlert: true,
     shouldPlaySound: true,
     shouldSetBadge: false,
     shouldShowBanner: true,

--- a/apps/mobile/components/PushNotificationProvider.tsx
+++ b/apps/mobile/components/PushNotificationProvider.tsx
@@ -4,7 +4,15 @@ import * as Notifications from "expo-notifications";
 import { useRouter } from "expo-router";
 import { type ReactNode, useEffect, useRef } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import { deregisterPushToken, requestAndRegisterPushToken } from "@/hooks/use-push-notifications";
+import {
+  deregisterPersistedPushRegistration,
+  requestAndRegisterPushToken,
+} from "@/hooks/use-push-notifications";
+
+// How long the pre-logout callback waits for an in-flight registration to
+// settle before deregistering, so a token that registered moments before
+// logout still gets removed — without blocking the UI logout indefinitely.
+const REGISTRATION_SETTLE_TIMEOUT_MS = 3000;
 
 const LAST_HANDLED_NOTIF_KEY = "calcom_last_handled_notification_id";
 
@@ -36,9 +44,9 @@ function handleNotificationUrl(url: string, router: ReturnType<typeof useRouter>
 }
 
 export function PushNotificationProvider({ children }: PushNotificationProviderProps) {
-  const { isAuthenticated, registerPreLogoutCallback } = useAuth();
+  const { isAuthenticated, userInfo, registerPreLogoutCallback } = useAuth();
   const router = useRouter();
-  const registeredTokenRef = useRef<string | null>(null);
+  const registrationInFlightRef = useRef<Promise<unknown> | null>(null);
   const coldStartHandledRef = useRef(false);
   const isAuthenticatedRef = useRef(isAuthenticated);
   const routerRef = useRef(router);
@@ -51,39 +59,41 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
     routerRef.current = router;
   }, [router]);
 
-  // Register token on login.
-  // Register token on login.
+  // Register token on login. The registration promise is tracked in a ref so
+  // the pre-logout callback can wait for an in-flight registration before
+  // deregistering. requestAndRegisterPushToken persists a durable record on
+  // success, which is what logout reads to deregister.
+  const userId = userInfo?.id;
   useEffect(() => {
-    if (!isAuthenticated) {
-      registeredTokenRef.current = null;
+    if (!isAuthenticated || userId == null) {
       return;
     }
 
-    let cancelled = false;
-    void (async () => {
-      const result = await requestAndRegisterPushToken();
-      if (cancelled) return;
-      if (result.success) {
-        registeredTokenRef.current = result.token;
-      } else if (result.token) {
-        // Server registration failed but token was obtained — store it so
-        // we can still deregister on logout.
-        registeredTokenRef.current = result.token;
+    const promise = requestAndRegisterPushToken({ userId });
+    registrationInFlightRef.current = promise;
+    void promise.finally(() => {
+      if (registrationInFlightRef.current === promise) {
+        registrationInFlightRef.current = null;
       }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [isAuthenticated]);
+    });
+  }, [isAuthenticated, userId]);
 
   // Deregister token before auth is cleared — the pre-logout callback runs
-  // while the Bearer token is still valid so the API call succeeds.
+  // while the Bearer token is still valid so the API call succeeds. Reading
+  // the persisted registration (instead of an in-memory ref) means logout can
+  // still clean up the server subscription after an app restart.
   useEffect(() => {
     return registerPreLogoutCallback(async () => {
-      if (registeredTokenRef.current) {
-        await deregisterPushToken(registeredTokenRef.current);
-        registeredTokenRef.current = null;
+      // Wait briefly for any in-flight registration to settle so a token that
+      // registered moments before logout is persisted and thus deregistered.
+      const inFlight = registrationInFlightRef.current;
+      if (inFlight) {
+        await Promise.race([
+          inFlight.catch(() => undefined),
+          new Promise((resolve) => setTimeout(resolve, REGISTRATION_SETTLE_TIMEOUT_MS)),
+        ]);
       }
+      await deregisterPersistedPushRegistration();
     });
   }, [registerPreLogoutCallback]);
 

--- a/apps/mobile/components/PushNotificationProvider.tsx
+++ b/apps/mobile/components/PushNotificationProvider.tsx
@@ -6,6 +6,7 @@ import { type ReactNode, useEffect, useRef } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import {
   deregisterPersistedPushRegistration,
+  drainPendingDeregistrations,
   requestAndRegisterPushToken,
 } from "@/hooks/use-push-notifications";
 
@@ -97,7 +98,16 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
           new Promise((resolve) => setTimeout(resolve, REGISTRATION_SETTLE_TIMEOUT_MS)),
         ]);
       }
-      await deregisterPersistedPushRegistration(userIdRef.current ?? undefined);
+      const currentUserId = userIdRef.current;
+      await deregisterPersistedPushRegistration(currentUserId ?? undefined);
+      // A registration that settled in the wait above (after logout advanced
+      // the generation) parks itself in the pending queue rather than the active
+      // slot. Drain it now — while the Bearer token is still valid — so its
+      // server subscription is deleted in this logout instead of lingering
+      // until the next login for this user.
+      if (currentUserId != null) {
+        await drainPendingDeregistrations(currentUserId);
+      }
     });
   }, [registerPreLogoutCallback]);
 

--- a/apps/mobile/components/PushNotificationProvider.tsx
+++ b/apps/mobile/components/PushNotificationProvider.tsx
@@ -89,6 +89,10 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
   // still clean up the server subscription after an app restart.
   useEffect(() => {
     return registerPreLogoutCallback(async () => {
+      // Snapshot the account being logged out BEFORE the settle wait. A relogin
+      // landing during the wait could repoint userIdRef at a new account, which
+      // would make us deregister/drain the wrong identity.
+      const currentUserId = userIdRef.current;
       // Wait briefly for any in-flight registration to settle so a token that
       // registered moments before logout is persisted and thus deregistered.
       const inFlight = registrationInFlightRef.current;
@@ -98,7 +102,6 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
           new Promise((resolve) => setTimeout(resolve, REGISTRATION_SETTLE_TIMEOUT_MS)),
         ]);
       }
-      const currentUserId = userIdRef.current;
       await deregisterPersistedPushRegistration(currentUserId ?? undefined);
       // A registration that settled in the wait above (after logout advanced
       // the generation) parks itself in the pending queue rather than the active

--- a/apps/mobile/components/PushNotificationProvider.tsx
+++ b/apps/mobile/components/PushNotificationProvider.tsx
@@ -64,6 +64,10 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
   // deregistering. requestAndRegisterPushToken persists a durable record on
   // success, which is what logout reads to deregister.
   const userId = userInfo?.id;
+  const userIdRef = useRef(userId);
+  useEffect(() => {
+    userIdRef.current = userId;
+  }, [userId]);
   useEffect(() => {
     if (!isAuthenticated || userId == null) {
       return;
@@ -93,7 +97,7 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
           new Promise((resolve) => setTimeout(resolve, REGISTRATION_SETTLE_TIMEOUT_MS)),
         ]);
       }
-      await deregisterPersistedPushRegistration();
+      await deregisterPersistedPushRegistration(userIdRef.current ?? undefined);
     });
   }, [registerPreLogoutCallback]);
 

--- a/apps/mobile/components/booking-list-item/BookingListItem.ios.tsx
+++ b/apps/mobile/components/booking-list-item/BookingListItem.ios.tsx
@@ -4,7 +4,12 @@ import { isLiquidGlassAvailable } from "expo-glass-effect";
 import React from "react";
 import { Pressable, useColorScheme, View } from "react-native";
 import type { SFSymbols7_0 } from "sf-symbols-typescript";
-import { getBookingActions } from "@/utils/booking-actions";
+import {
+  getBookingActions,
+  isUserHost,
+  isUserOrganizer,
+  normalizeBooking,
+} from "@/utils/booking-actions";
 import {
   BadgesRow,
   BookingDescription,
@@ -57,6 +62,14 @@ export const BookingListItem: React.FC<BookingListItemProps> = ({
       isOnline: true, // Assume online
     });
   }, [booking, userEmail]);
+  const canConfirmOrReject = React.useMemo(() => {
+    const normalizedBooking = normalizeBooking(booking);
+    return (
+      isPending &&
+      (isUserOrganizer(normalizedBooking, undefined, userEmail) ||
+        isUserHost(normalizedBooking, undefined, userEmail))
+    );
+  }, [booking, isPending, userEmail]);
 
   const colorScheme = useColorScheme();
   const isDark = colorScheme === "dark";
@@ -200,7 +213,7 @@ export const BookingListItem: React.FC<BookingListItemProps> = ({
       >
         <ConfirmRejectButtons
           booking={booking}
-          isPending={isPending}
+          isPending={canConfirmOrReject}
           isConfirming={isConfirming}
           isDeclining={isDeclining}
           onConfirm={onConfirm}

--- a/apps/mobile/components/booking-list-item/BookingListItem.ios.tsx
+++ b/apps/mobile/components/booking-list-item/BookingListItem.ios.tsx
@@ -213,7 +213,8 @@ export const BookingListItem: React.FC<BookingListItemProps> = ({
       >
         <ConfirmRejectButtons
           booking={booking}
-          isPending={canConfirmOrReject}
+          isPending={isPending}
+          canConfirmOrReject={canConfirmOrReject}
           isConfirming={isConfirming}
           isDeclining={isDeclining}
           onConfirm={onConfirm}

--- a/apps/mobile/components/booking-list-item/BookingListItem.tsx
+++ b/apps/mobile/components/booking-list-item/BookingListItem.tsx
@@ -11,7 +11,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Text } from "@/components/ui/text";
 import { getColors } from "@/constants/colors";
-import { getBookingActions } from "@/utils/booking-actions";
+import {
+  getBookingActions,
+  isUserHost,
+  isUserOrganizer,
+  normalizeBooking,
+} from "@/utils/booking-actions";
 import {
   BadgesRow,
   BookingDescription,
@@ -83,6 +88,14 @@ export const BookingListItem: React.FC<BookingListItemProps> = ({
       isOnline: true,
     });
   }, [booking, userEmail]);
+  const canConfirmOrReject = React.useMemo(() => {
+    const normalizedBooking = normalizeBooking(booking);
+    return (
+      isPending &&
+      (isUserOrganizer(normalizedBooking, undefined, userEmail) ||
+        isUserHost(normalizedBooking, undefined, userEmail))
+    );
+  }, [booking, isPending, userEmail]);
 
   type DropdownAction = {
     label: string;
@@ -196,7 +209,7 @@ export const BookingListItem: React.FC<BookingListItemProps> = ({
       >
         <ConfirmRejectButtons
           booking={booking}
-          isPending={isPending}
+          isPending={canConfirmOrReject}
           isConfirming={isConfirming}
           isDeclining={isDeclining}
           onConfirm={onConfirm}

--- a/apps/mobile/components/booking-list-item/BookingListItem.tsx
+++ b/apps/mobile/components/booking-list-item/BookingListItem.tsx
@@ -209,7 +209,8 @@ export const BookingListItem: React.FC<BookingListItemProps> = ({
       >
         <ConfirmRejectButtons
           booking={booking}
-          isPending={canConfirmOrReject}
+          isPending={isPending}
+          canConfirmOrReject={canConfirmOrReject}
           isConfirming={isConfirming}
           isDeclining={isDeclining}
           onConfirm={onConfirm}

--- a/apps/mobile/components/booking-list-item/BookingListItemParts.tsx
+++ b/apps/mobile/components/booking-list-item/BookingListItemParts.tsx
@@ -3,7 +3,7 @@ import { Linking, Text, TouchableOpacity, useColorScheme, View } from "react-nat
 import { SvgImage } from "@/components/SvgImage";
 import { getColors } from "@/constants/colors";
 import type { Booking } from "@/services/calcom";
-import { showErrorAlert } from "@/utils/alerts";
+import { showErrorAlert, showInfoAlert } from "@/utils/alerts";
 import type { BookingListItemData } from "./useBookingListItemData";
 
 interface TimeAndDateRowProps {
@@ -140,6 +140,7 @@ export function MeetingLink({ meetingInfo }: MeetingLinkProps) {
 interface ConfirmRejectButtonsProps {
   booking: Booking;
   isPending: boolean;
+  canConfirmOrReject: boolean;
   isConfirming: boolean;
   isDeclining: boolean;
   onConfirm: (booking: Booking) => void;
@@ -149,6 +150,7 @@ interface ConfirmRejectButtonsProps {
 export function ConfirmRejectButtons({
   booking,
   isPending,
+  canConfirmOrReject,
   isConfirming,
   isDeclining,
   onConfirm,
@@ -175,6 +177,10 @@ export function ConfirmRejectButtons({
         disabled={isConfirming || isDeclining}
         onPress={(e) => {
           e.stopPropagation();
+          if (!canConfirmOrReject) {
+            showInfoAlert("Not authorized", "You are not authorized to reject this booking.");
+            return;
+          }
           onReject(booking);
         }}
       >
@@ -193,6 +199,10 @@ export function ConfirmRejectButtons({
         disabled={isConfirming || isDeclining}
         onPress={(e) => {
           e.stopPropagation();
+          if (!canConfirmOrReject) {
+            showInfoAlert("Not authorized", "You are not authorized to confirm this booking.");
+            return;
+          }
           onConfirm(booking);
         }}
       >

--- a/apps/mobile/components/booking-list-screen/BookingListScreen.tsx
+++ b/apps/mobile/components/booking-list-screen/BookingListScreen.tsx
@@ -42,7 +42,13 @@ import {
   useRescheduleBooking,
 } from "@/hooks";
 import type { Booking, EventType } from "@/services/calcom";
-import { showErrorAlert, showInfoAlert, showSilentSuccessAlert, showSuccessAlert } from "@/utils/alerts";
+import {
+  showErrorAlert,
+  showInfoAlert,
+  showSilentSuccessAlert,
+  showSuccessAlert,
+} from "@/utils/alerts";
+import { isUserHost, isUserOrganizer, normalizeBooking } from "@/utils/booking-actions";
 import type { ListItem, RecurringBookingGroup } from "@/utils/bookings-utils";
 import {
   filterByEventType,
@@ -154,6 +160,20 @@ export const BookingListScreen: React.FC<BookingListScreenProps> = ({
     isDeclining,
     isRescheduling,
   });
+
+  const currentUserId = userInfo ? userInfo.id : undefined;
+  const currentUserEmail = userInfo ? userInfo.email : undefined;
+
+  const canConfirmOrRejectBooking = React.useCallback(
+    (booking: Booking) => {
+      const normalizedBooking = normalizeBooking(booking);
+      return (
+        isUserOrganizer(normalizedBooking, currentUserId, currentUserEmail) ||
+        isUserHost(normalizedBooking, currentUserId, currentUserEmail)
+      );
+    },
+    [currentUserId, currentUserEmail]
+  );
 
   // Navigate to reschedule screen (same pattern as booking detail)
   const handleNavigateToReschedule = React.useCallback(
@@ -437,6 +457,11 @@ export const BookingListScreen: React.FC<BookingListScreenProps> = ({
         return;
       }
 
+      if (unconfirmedBookings.some((booking) => !canConfirmOrRejectBooking(booking))) {
+        showInfoAlert("Not authorized", "You are not authorized to confirm these bookings.");
+        return;
+      }
+
       Alert.alert(
         "Confirm All",
         `Are you sure you want to confirm ${unconfirmedBookings.length} unconfirmed bookings?`,
@@ -481,14 +506,17 @@ export const BookingListScreen: React.FC<BookingListScreenProps> = ({
                   `Confirmed ${successCount} bookings. Failed to confirm ${errorCount}.`
                 );
               } else {
-                showSilentSuccessAlert("Success", `All ${successCount} bookings have been confirmed.`);
+                showSilentSuccessAlert(
+                  "Success",
+                  `All ${successCount} bookings have been confirmed.`
+                );
               }
             },
           },
         ]
       );
     },
-    [confirmBookingMutation]
+    [canConfirmOrRejectBooking, confirmBookingMutation]
   );
 
   // Reject all unconfirmed bookings in a recurring series
@@ -503,6 +531,11 @@ export const BookingListScreen: React.FC<BookingListScreenProps> = ({
 
       if (unconfirmedBookings.length === 0) {
         showInfoAlert("Info", "No unconfirmed bookings to reject.");
+        return;
+      }
+
+      if (unconfirmedBookings.some((booking) => !canConfirmOrRejectBooking(booking))) {
+        showInfoAlert("Not authorized", "You are not authorized to reject these bookings.");
         return;
       }
 
@@ -589,7 +622,7 @@ export const BookingListScreen: React.FC<BookingListScreenProps> = ({
         ]
       );
     },
-    [declineBookingMutation]
+    [canConfirmOrRejectBooking, declineBookingMutation]
   );
 
   const renderBookingItem = ({ item }: { item: Booking }) => {
@@ -1078,7 +1111,10 @@ export const BookingListScreen: React.FC<BookingListScreenProps> = ({
                       `Rejected ${successCount} bookings. Failed to reject ${errorCount}.`
                     );
                   } else {
-                    showSilentSuccessAlert("Success", `All ${successCount} bookings have been rejected.`);
+                    showSilentSuccessAlert(
+                      "Success",
+                      `All ${successCount} bookings have been rejected.`
+                    );
                   }
                 }}
               >

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -56,6 +56,10 @@ const ACCESS_TOKEN_KEY = "cal_access_token";
 const REFRESH_TOKEN_KEY = "cal_refresh_token";
 const OAUTH_TOKENS_KEY = "cal_oauth_tokens";
 const AUTH_TYPE_KEY = "cal_auth_type";
+// Identity marker for the persisted query cache owner envelope. Written after
+// the user profile resolves and read by the query persister to reject a cache
+// that belongs to a different user. Keep in sync with queryPersister.ts.
+const AUTH_USER_ID_KEY = "cal_auth_user_id";
 
 type AuthType = "oauth" | "web_session";
 
@@ -148,6 +152,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
               console.warn("Failed to clear stale persisted cache:", cacheError);
             }
           }
+          // Mark the cache owner so the persister can reject another user's
+          // cache on the next cold start. Written before setUserInfo so it is
+          // in place by the time queries for this identity start persisting.
+          try {
+            await storage.set(AUTH_USER_ID_KEY, String(profile.id));
+          } catch (idError) {
+            console.warn("Failed to persist auth user id:", idError);
+          }
           setUserInfo({
             email: profile.email,
             name: profile.name,
@@ -180,7 +192,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
   };
 
   const clearAuth = useCallback(async () => {
-    await storage.removeAll([ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY, OAUTH_TOKENS_KEY, AUTH_TYPE_KEY]);
+    await storage.removeAll([
+      ACCESS_TOKEN_KEY,
+      REFRESH_TOKEN_KEY,
+      OAUTH_TOKENS_KEY,
+      AUTH_TYPE_KEY,
+      AUTH_USER_ID_KEY,
+    ]);
 
     if (oauthService) {
       try {
@@ -458,8 +476,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     return () => {
       cancelled = true;
       unsubscribeRegion();
-      CalComAPIService.setTokenRefreshCallback(() => Promise.resolve());
-      CalComAPIService.setAuthFailureCallback(() => Promise.resolve());
+      // Provider is unmounting — this is the only place callbacks should be
+      // torn down. Logout/401 recovery must NOT clear them (see clearAuth).
+      CalComAPIService.clearAuthCallbacks();
     };
   }, []);
 
@@ -513,6 +532,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
     setLoading(true);
     try {
+      // Wipe any prior identity's cache before a new login / account switch:
+      // memory first (so a throttled persist can't re-write it), then disk.
+      try {
+        queryClient.clear();
+      } catch (memoryCacheError) {
+        safeLogWarn("Failed to clear in-memory query cache before login:", memoryCacheError);
+      }
       try {
         await clearQueryCache();
       } catch (cacheError) {

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -115,6 +115,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // Common post-login setup: configure API service and fetch user profile
   const setupAfterLogin = useCallback(
     async (token: string, refreshToken?: string) => {
+      // Capture the session generation up front. The profile fetch below is a
+      // network round-trip; a logout/account switch during it must not let this
+      // (now stale) login write the old identity into state or the cache owner.
+      const generationAtStart = CalComAPIService.getAuthGeneration();
       CalComAPIService.setAccessToken(token, refreshToken);
       // Drop any user-profile singleton left over from a previous in-memory
       // session (e.g. an extension iframe that outlived a logout, or a future
@@ -126,6 +130,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
       try {
         const profile = await CalComAPIService.getUserProfile();
+        // A logout/account switch during the fetch above invalidates this login.
+        // Bail before writing the owner marker or identity so we don't resurrect
+        // or mislabel the cache under the previous user.
+        if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+          return;
+        }
         // Store user info for use in the app (e.g., to display "You" in bookings)
         if (profile) {
           // If the persisted cache was rehydrated for a different user (cold
@@ -213,7 +223,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (stored.accessToken !== accessToken) {
         return;
       }
-      await storage.removeAll([OAUTH_TOKENS_KEY, AUTH_TYPE_KEY]);
+      await storage.remove(OAUTH_TOKENS_KEY);
+      // Only clear the auth-type marker if it still says "oauth". A web-session
+      // login that interleaved with this rollback may have flipped it to
+      // "web_session"; removing it then would erase the newer session's marker.
+      const authType = await storage.get(AUTH_TYPE_KEY);
+      if (authType === "oauth") {
+        await storage.remove(AUTH_TYPE_KEY);
+      }
       if (service) {
         try {
           await service.clearTokensFromExtension();
@@ -616,6 +633,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
       } catch (idError) {
         console.warn("Failed to persist auth user id:", idError);
       }
+      // Re-check after the owner-marker write: the synchronous state flip below
+      // must not run if a logout/newer login advanced the generation during it.
+      if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+        return;
+      }
       setUserInfo({
         id: sessionUserInfo.id,
         email: sessionUserInfo.email,
@@ -672,6 +694,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       // Start a new auth session generation so any in-flight request/refresh
       // from a previous identity is invalidated and can't apply under this one.
       CalComAPIService.beginAuthGeneration();
+      // Capture the generation for this login. The authorization flow below is a
+      // long await (browser redirect + token exchange); a logout or newer login
+      // during it must abort this flow before it persists tokens or flips auth.
+      const generationAtStart = CalComAPIService.getAuthGeneration();
       // Wipe any prior identity's cache before a new login / account switch:
       // memory first (so a throttled persist can't re-write it), then disk.
       try {
@@ -685,9 +711,20 @@ export function AuthProvider({ children }: AuthProviderProps) {
         safeLogWarn("Failed to clear query cache before login:", cacheError);
       }
       const tokens = await currentService.startAuthorizationFlow();
+      if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+        setLoading(false);
+        return;
+      }
 
       // Save tokens
       await saveOAuthTokens(tokens, currentService);
+      if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+        // The write may have landed before this check; undo it if it's still
+        // ours so a logged-out/replaced session isn't resurrected.
+        await rollbackPersistedTokensIfMatches(tokens.accessToken, currentService);
+        setLoading(false);
+        return;
+      }
 
       // Update state
       setAccessToken(tokens.accessToken);

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -203,11 +203,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
   ) => {
     try {
       const raw = await storage.get(OAUTH_TOKENS_KEY);
-      if (raw) {
-        const stored = JSON.parse(raw) as OAuthTokens;
-        if (stored.accessToken !== accessToken) {
-          return;
-        }
+      // No stored oauth tokens means there's nothing of ours to undo — a newer
+      // login already replaced/cleared them (e.g. a web-session login that
+      // writes only AUTH_TYPE_KEY). Bail so we don't wipe that newer marker.
+      if (!raw) {
+        return;
+      }
+      const stored = JSON.parse(raw) as OAuthTokens;
+      if (stored.accessToken !== accessToken) {
+        return;
       }
       await storage.removeAll([OAUTH_TOKENS_KEY, AUTH_TYPE_KEY]);
       if (service) {
@@ -460,13 +464,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
       newRefreshToken?: string,
       expiresAt?: number
     ) => {
+      // The refresh that produced these tokens validated the generation
+      // before invoking this callback, but logout/account switch can still
+      // advance it during the awaits below. Re-check before each write so we
+      // never persist a dead session's tokens (which boot would resurrect)
+      // or repoint in-memory auth at the previous identity. Captured outside the
+      // try so the catch can tell a dead-session failure from a live one.
+      const generationAtStart = CalComAPIService.getAuthGeneration();
       try {
-        // The refresh that produced these tokens validated the generation
-        // before invoking this callback, but logout/account switch can still
-        // advance it during the awaits below. Re-check before each write so we
-        // never persist a dead session's tokens (which boot would resurrect)
-        // or repoint in-memory auth at the previous identity.
-        const generationAtStart = CalComAPIService.getAuthGeneration();
         const tokens: OAuthTokens = {
           accessToken: newAccessToken,
           refreshToken: newRefreshToken || refreshTokenRef.current || undefined,
@@ -503,7 +508,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
             stack: getErrorStack(error),
           });
         }
-        await logoutRef.current();
+        // Only tear down auth if this refresh still belongs to the current
+        // session. If logout/login advanced the generation while the write was
+        // failing, this is a dead session's failure and must not log out the
+        // newer one.
+        if (CalComAPIService.getAuthGeneration() === generationAtStart) {
+          await logoutRef.current();
+        }
       }
     };
 
@@ -564,6 +575,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       CalComAPIService.clearAuth();
       setAccessToken(null);
       setRefreshToken(null);
+      // Capture the generation after the synchronous bumps above. If a logout or
+      // another login advances it during the awaits below, this web-session
+      // login is stale and must abort before applying its identity/tokens.
+      const generationAtStart = CalComAPIService.getAuthGeneration();
       try {
         await clearAuth();
       } catch (clearError) {
@@ -586,6 +601,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
       } catch (cacheError) {
         safeLogWarn("Failed to clear persisted query cache before web login:", cacheError);
       }
+      // A logout/login may have started while we were clearing above. Bail
+      // before writing this session's owner marker or flipping auth state, so a
+      // stale web login can't apply on top of the newer session.
+      if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+        return;
+      }
       // Persist the cache-owner marker before flipping to authenticated. A
       // web session may never reach setupAfterLogin (no token, or getUserProfile
       // fails), and the query persister now refuses to write ownerless cache, so
@@ -607,6 +628,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
       // Try to get tokens from web session
       const tokens = await WebAuthService.getTokensFromWebSession();
+      // Re-check after the network await: a concurrent logout/login here must
+      // not have this session's tokens applied under it.
+      if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+        return;
+      }
       if (tokens.accessToken) {
         setAccessToken(tokens.accessToken);
         setRefreshToken(tokens.refreshToken || null);

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -424,7 +424,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setIsWebSession(false);
 
       // Setup API service and refresh function
+      const generationBeforeProfile = CalComAPIService.getAuthGeneration();
       await setupAfterLogin(tokens.accessToken, tokens.refreshToken);
+      // A logout/new login during the profile fetch invalidates this boot flow;
+      // installing this (now stale) service as the refresh fn would let it
+      // refresh under the newer session.
+      if (CalComAPIService.getAuthGeneration() !== generationBeforeProfile) {
+        return;
+      }
       if (tokens.refreshToken) {
         setupRefreshTokenFunction(service);
       }
@@ -774,6 +781,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
       // Setup API service and refresh function
       await setupAfterLogin(tokens.accessToken, tokens.refreshToken);
+      // A logout/new login during the profile fetch invalidates this login;
+      // don't install this (now stale) service as the session's refresh fn.
+      if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+        setLoading(false);
+        return;
+      }
       if (tokens.refreshToken) {
         setupRefreshTokenFunction(currentService);
       }

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -230,6 +230,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   const logout = useCallback(async () => {
+    // Advance the auth generation up front (tokens stay valid for the
+    // pre-logout DELETE below) so any refresh/request/push registration that
+    // resolves during this potentially slow logout sequence is treated as a
+    // dead session and not applied/persisted as active.
+    CalComAPIService.invalidateAuthSession();
     // Run pre-logout callbacks while auth tokens are still valid (e.g. push
     // token deregistration needs a valid Bearer token for the API call).
     for (const callback of preLogoutCallbacksRef.current) {
@@ -308,14 +313,24 @@ export function AuthProvider({ children }: AuthProviderProps) {
       let tokens = storedTokens;
       let tokensWereRefreshed = false;
       if (service.isTokenExpired(storedTokens) && storedTokens.refreshToken) {
+        // Capture the generation around the boot refresh: if the user logs out
+        // or starts a new login while this in-flight refresh resolves, applying
+        // its result would resurrect the previous stored session.
+        const generationAtStart = CalComAPIService.getAuthGeneration();
         try {
           console.log("Access token expired, refreshing...");
           tokens = await service.refreshAccessToken(storedTokens.refreshToken);
+          if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+            return;
+          }
           await saveOAuthTokens(tokens, service);
           tokensWereRefreshed = true;
         } catch (refreshError) {
           console.error("Failed to refresh token:", refreshError);
           await clearAuth();
+          return;
+        }
+        if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
           return;
         }
       }
@@ -407,6 +422,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
       expiresAt?: number
     ) => {
       try {
+        // The refresh that produced these tokens validated the generation
+        // before invoking this callback, but logout/account switch can still
+        // advance it during the awaits below. Re-check before each write so we
+        // never persist a dead session's tokens (which boot would resurrect)
+        // or repoint in-memory auth at the previous identity.
+        const generationAtStart = CalComAPIService.getAuthGeneration();
         const tokens: OAuthTokens = {
           accessToken: newAccessToken,
           refreshToken: newRefreshToken || refreshTokenRef.current || undefined,
@@ -414,7 +435,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
           expiresAt,
         };
 
+        if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+          return;
+        }
         await saveOAuthTokens(tokens, activeService);
+        if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+          return;
+        }
         setAccessToken(newAccessToken);
         if (newRefreshToken) {
           setRefreshToken(newRefreshToken);

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -442,17 +442,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setIsAuthenticated(true);
       setIsWebSession(false);
 
-      // Setup API service and refresh function
+      // Install the refresh function before setupAfterLogin() performs its
+      // authenticated /me request. A fresh access token can still receive a 401
+      // (clock skew, token propagation, regional auth mismatch); without this,
+      // the request layer has no refresh path and logs the user out.
+      if (tokens.refreshToken) {
+        setupRefreshTokenFunction(service);
+      }
+
+      // Setup API service and fetch profile.
       const generationBeforeProfile = CalComAPIService.getAuthGeneration();
       await setupAfterLogin(tokens.accessToken, tokens.refreshToken);
       // A logout/new login during the profile fetch invalidates this boot flow;
-      // installing this (now stale) service as the refresh fn would let it
-      // refresh under the newer session.
+      // this stale boot flow must not keep applying work after that point.
       if (CalComAPIService.getAuthGeneration() !== generationBeforeProfile) {
         return;
-      }
-      if (tokens.refreshToken) {
-        setupRefreshTokenFunction(service);
       }
 
       if (!tokensWereRefreshed) {
@@ -585,6 +589,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
     CalComAPIService.setTokenRefreshCallback(handleTokenRefresh);
     CalComAPIService.setAuthFailureCallback(() => logoutRef.current());
+    if (activeService) {
+      setupRefreshTokenFunction(activeService);
+    }
 
     (async () => {
       const initialRegion = getRegion();
@@ -806,16 +813,20 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setIsAuthenticated(true);
       setIsWebSession(false);
 
-      // Setup API service and refresh function
+      // Install the refresh function before setupAfterLogin() performs its
+      // authenticated /me request. If that request sees a recoverable 401, the
+      // request layer can refresh instead of immediately logging out.
+      if (tokens.refreshToken) {
+        setupRefreshTokenFunction(currentService);
+      }
+
+      // Setup API service and fetch profile.
       await setupAfterLogin(tokens.accessToken, tokens.refreshToken);
       // A logout/new login during the profile fetch invalidates this login;
-      // don't install this (now stale) service as the session's refresh fn.
+      // don't keep applying this now-stale session.
       if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
         setLoading(false);
         return;
-      }
-      if (tokens.refreshToken) {
-        setupRefreshTokenFunction(currentService);
       }
 
       // Clear PKCE parameters

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -484,6 +484,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const loginFromWebSession = async (sessionUserInfo: UserProfile) => {
     try {
+      // Persist the cache-owner marker before flipping to authenticated. A
+      // web session may never reach setupAfterLogin (no token, or getUserProfile
+      // fails), and the query persister now refuses to write ownerless cache, so
+      // without this marker web-session users would lose cache persistence.
+      try {
+        await storage.set(AUTH_USER_ID_KEY, String(sessionUserInfo.id));
+      } catch (idError) {
+        console.warn("Failed to persist auth user id:", idError);
+      }
       setUserInfo({
         id: sessionUserInfo.id,
         email: sessionUserInfo.email,

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -303,7 +303,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     };
   }, []);
 
-  const logout = useCallback(async () => {
+  const logoutInFlightRef = useRef<Promise<void> | null>(null);
+
+  const performLogout = useCallback(async () => {
     // Advance the auth generation up front (tokens stay valid for the
     // pre-logout DELETE below) so any refresh/request/push registration that
     // resolves during this potentially slow logout sequence is treated as a
@@ -376,6 +378,23 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
     resetAuthState();
   }, [clearAuth, resetAuthState, queryClient]);
+
+  const logout = useCallback(async () => {
+    // Coalesce concurrent logouts. Two parallel requests can both 401, fail the
+    // same single-flight refresh, and each call onAuthFailure -> logout(); without
+    // this the pre-logout callbacks (e.g. push deregistration) would run twice.
+    // Sharing the in-flight promise runs the sequence exactly once.
+    if (logoutInFlightRef.current) {
+      return logoutInFlightRef.current;
+    }
+    const run = performLogout();
+    logoutInFlightRef.current = run;
+    try {
+      await run;
+    } finally {
+      logoutInFlightRef.current = null;
+    }
+  }, [performLogout]);
 
   // Handle OAuth authentication. `service` is passed explicitly so the boot
   // effect can hand in a freshly-rebuilt service on cold-start region
@@ -611,8 +630,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const loginFromWebSession = async (sessionUserInfo: UserProfile) => {
     try {
-      // Start a new auth session generation so any in-flight request/refresh
-      // from a previous identity is invalidated and can't apply under this one.
+      // Both calls below bump authGeneration (+2 total, not +1): beginAuthGeneration
+      // invalidates in-flight work from the previous identity, and clearAuth clears
+      // tokens (which needs its own bump). loginWithOAuth only calls beginAuthGeneration
+      // because it doesn't need to clear prior tokens up front.
       CalComAPIService.beginAuthGeneration();
       // Clear the previous identity's tokens BEFORE flipping to the new user.
       // getTokensFromWebSession() below may return no token, in which case the
@@ -691,6 +712,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
       await CalComAPIService.runAuthTransition(async () => {
         await storage.set(AUTH_TYPE_KEY, "web_session");
       });
+      // Re-check after the marker-write await (it can queue behind another
+      // transition): a logout interleaving here must not let this stale login
+      // repoint auth at its token via setAccessToken / setupAfterLogin.
+      if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+        return;
+      }
       if (tokens.accessToken) {
         setAccessToken(tokens.accessToken);
         setRefreshToken(tokens.refreshToken || null);

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -170,6 +170,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
           } catch (idError) {
             console.warn("Failed to persist auth user id:", idError);
           }
+          // Final re-check before the synchronous state flip: the cache-clear
+          // and owner-marker writes above are awaits, and a logout/switch during
+          // them must not let this stale login set the previous identity.
+          if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+            return;
+          }
           setUserInfo({
             email: profile.email,
             name: profile.name,
@@ -646,15 +652,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
       });
       setIsAuthenticated(true);
       setIsWebSession(true);
-      await storage.set(AUTH_TYPE_KEY, "web_session");
 
       // Try to get tokens from web session
       const tokens = await WebAuthService.getTokensFromWebSession();
       // Re-check after the network await: a concurrent logout/login here must
-      // not have this session's tokens applied under it.
+      // not have this session's tokens or marker applied under it.
       if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
         return;
       }
+      // Persist the web-session marker only once we've committed (after the
+      // recheck), so an aborted stale login never leaves a "web_session" marker
+      // behind. Written even when there's no token so the persister keeps cache.
+      await storage.set(AUTH_TYPE_KEY, "web_session");
       if (tokens.accessToken) {
         setAccessToken(tokens.accessToken);
         setRefreshToken(tokens.refreshToken || null);
@@ -709,6 +718,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
         await clearQueryCache();
       } catch (cacheError) {
         safeLogWarn("Failed to clear query cache before login:", cacheError);
+      }
+      // Drop the previous owner marker too. Until setupAfterLogin fetches the
+      // new profile and writes the new id, the persister must see no owner and
+      // refuse to persist — otherwise new-user queries in that window would be
+      // wrapped under the previous user's id.
+      try {
+        await storage.remove(AUTH_USER_ID_KEY);
+      } catch (idError) {
+        safeLogWarn("Failed to clear previous auth user id before login:", idError);
       }
       const tokens = await currentService.startAuthorizationFlow();
       if (CalComAPIService.getAuthGeneration() !== generationAtStart) {

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -484,6 +484,26 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const loginFromWebSession = async (sessionUserInfo: UserProfile) => {
     try {
+      // Start a new auth session generation so any in-flight request/refresh
+      // from a previous identity is invalidated and can't apply under this one.
+      CalComAPIService.beginAuthGeneration();
+      // Wipe any prior identity's cache before flipping to authenticated:
+      // memory first (so a throttled persist can't re-write it), then disk.
+      // Without this, the previous user's in-memory React Query data would be
+      // re-persisted under the new owner id we write just below — mislabeling
+      // user A's cache as user B's (loginWithOAuth already does this; a
+      // web-session login that never reaches setupAfterLogin would otherwise
+      // skip it entirely).
+      try {
+        queryClient.clear();
+      } catch (memoryCacheError) {
+        safeLogWarn("Failed to clear in-memory query cache before web login:", memoryCacheError);
+      }
+      try {
+        await clearQueryCache();
+      } catch (cacheError) {
+        safeLogWarn("Failed to clear persisted query cache before web login:", cacheError);
+      }
       // Persist the cache-owner marker before flipping to authenticated. A
       // web session may never reach setupAfterLogin (no token, or getUserProfile
       // fails), and the query persister now refuses to write ownerless cache, so
@@ -541,6 +561,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
     setLoading(true);
     try {
+      // Start a new auth session generation so any in-flight request/refresh
+      // from a previous identity is invalidated and can't apply under this one.
+      CalComAPIService.beginAuthGeneration();
       // Wipe any prior identity's cache before a new login / account switch:
       // memory first (so a throttled persist can't re-write it), then disk.
       try {

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -191,6 +191,37 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   };
 
+  // Undo a token persist that a refresh completed just as the session changed
+  // (logout/account switch). `saveOAuthTokens` is not atomic, so a stale
+  // refresh can land its disk write before the post-write epoch re-check. We
+  // remove the persisted tokens ONLY when storage still holds exactly the ones
+  // this refresh wrote — a newer login may have already written its own tokens,
+  // and those must never be clobbered.
+  const rollbackPersistedTokensIfMatches = async (
+    accessToken: string,
+    service: CalComOAuthService | null
+  ) => {
+    try {
+      const raw = await storage.get(OAUTH_TOKENS_KEY);
+      if (raw) {
+        const stored = JSON.parse(raw) as OAuthTokens;
+        if (stored.accessToken !== accessToken) {
+          return;
+        }
+      }
+      await storage.removeAll([OAUTH_TOKENS_KEY, AUTH_TYPE_KEY]);
+      if (service) {
+        try {
+          await service.clearTokensFromExtension();
+        } catch (extensionError) {
+          console.warn("Failed to clear extension tokens during rollback:", extensionError);
+        }
+      }
+    } catch (error) {
+      console.warn("Failed to roll back stale refreshed tokens:", error);
+    }
+  };
+
   const clearAuth = useCallback(async () => {
     await storage.removeAll([
       ACCESS_TOKEN_KEY,
@@ -327,10 +358,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
           tokensWereRefreshed = true;
         } catch (refreshError) {
           console.error("Failed to refresh token:", refreshError);
-          await clearAuth();
+          // Only clear if this boot session is still current — a logout or new
+          // login may have advanced the generation while the refresh failed,
+          // and clearing would wipe that newer session's auth.
+          if (CalComAPIService.getAuthGeneration() === generationAtStart) {
+            await clearAuth();
+          }
           return;
         }
         if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+          // The write may have landed before this check; undo it (only if it's
+          // still ours) so a logged-out/replaced session isn't resurrected.
+          await rollbackPersistedTokensIfMatches(tokens.accessToken, service);
           return;
         }
       }
@@ -440,6 +479,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
         }
         await saveOAuthTokens(tokens, activeService);
         if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+          // The write may have landed before this check; undo it (only if it's
+          // still ours) so the dead session isn't resurrected, and skip the
+          // in-memory writes.
+          await rollbackPersistedTokensIfMatches(newAccessToken, activeService);
           return;
         }
         setAccessToken(newAccessToken);
@@ -514,6 +557,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
       // Start a new auth session generation so any in-flight request/refresh
       // from a previous identity is invalidated and can't apply under this one.
       CalComAPIService.beginAuthGeneration();
+      // Clear the previous identity's tokens BEFORE flipping to the new user.
+      // getTokensFromWebSession() below may return no token, in which case the
+      // prior OAuth bearer would otherwise stay live in CalComAPIService + React
+      // state under the new user's UI and cache owner.
+      CalComAPIService.clearAuth();
+      setAccessToken(null);
+      setRefreshToken(null);
+      try {
+        await clearAuth();
+      } catch (clearError) {
+        safeLogWarn("Failed to clear prior auth tokens before web login:", clearError);
+      }
       // Wipe any prior identity's cache before flipping to authenticated:
       // memory first (so a throttled persist can't re-write it), then disk.
       // Without this, the previous user's in-memory React Query data would be

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -166,7 +166,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
           // cache on the next cold start. Written before setUserInfo so it is
           // in place by the time queries for this identity start persisting.
           try {
-            await storage.set(AUTH_USER_ID_KEY, String(profile.id));
+            await CalComAPIService.runAuthTransition(async () => {
+              await storage.set(AUTH_USER_ID_KEY, String(profile.id));
+            });
           } catch (idError) {
             console.warn("Failed to persist auth user id:", idError);
           }
@@ -195,8 +197,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // memoization, and taking `service` explicitly lets cold-start callers pass
   // a freshly-rebuilt service without waiting for the state update to settle.
   const saveOAuthTokens = async (tokens: OAuthTokens, service: CalComOAuthService | null) => {
-    await storage.set(OAUTH_TOKENS_KEY, JSON.stringify(tokens));
-    await storage.set(AUTH_TYPE_KEY, "oauth");
+    // Write both markers as one atomic section so a concurrent rollback/clear
+    // can't observe a half-written pair. No network inside the lock.
+    await CalComAPIService.runAuthTransition(async () => {
+      await storage.set(OAUTH_TOKENS_KEY, JSON.stringify(tokens));
+      await storage.set(AUTH_TYPE_KEY, "oauth");
+    });
 
     if (service) {
       try {
@@ -218,26 +224,32 @@ export function AuthProvider({ children }: AuthProviderProps) {
     service: CalComOAuthService | null
   ) => {
     try {
-      const raw = await storage.get(OAUTH_TOKENS_KEY);
-      // No stored oauth tokens means there's nothing of ours to undo — a newer
-      // login already replaced/cleared them (e.g. a web-session login that
-      // writes only AUTH_TYPE_KEY). Bail so we don't wipe that newer marker.
-      if (!raw) {
-        return;
-      }
-      const stored = JSON.parse(raw) as OAuthTokens;
-      if (stored.accessToken !== accessToken) {
-        return;
-      }
-      await storage.remove(OAUTH_TOKENS_KEY);
-      // Only clear the auth-type marker if it still says "oauth". A web-session
-      // login that interleaved with this rollback may have flipped it to
-      // "web_session"; removing it then would erase the newer session's marker.
-      const authType = await storage.get(AUTH_TYPE_KEY);
-      if (authType === "oauth") {
-        await storage.remove(AUTH_TYPE_KEY);
-      }
-      if (service) {
+      // The read-and-conditional-remove must be atomic against other marker
+      // mutations (e.g. a concurrent web-session login writing "web_session"),
+      // so it runs as one auth-transition section. No network inside the lock.
+      const didRollback = await CalComAPIService.runAuthTransition(async () => {
+        const raw = await storage.get(OAUTH_TOKENS_KEY);
+        // No stored oauth tokens means there's nothing of ours to undo — a newer
+        // login already replaced/cleared them (e.g. a web-session login that
+        // writes only AUTH_TYPE_KEY). Bail so we don't wipe that newer marker.
+        if (!raw) {
+          return false;
+        }
+        const stored = JSON.parse(raw) as OAuthTokens;
+        if (stored.accessToken !== accessToken) {
+          return false;
+        }
+        await storage.remove(OAUTH_TOKENS_KEY);
+        // Only clear the auth-type marker if it still says "oauth". A web-session
+        // login that ran before this section may have flipped it to
+        // "web_session"; removing it then would erase the newer session's marker.
+        const authType = await storage.get(AUTH_TYPE_KEY);
+        if (authType === "oauth") {
+          await storage.remove(AUTH_TYPE_KEY);
+        }
+        return true;
+      });
+      if (didRollback && service) {
         try {
           await service.clearTokensFromExtension();
         } catch (extensionError) {
@@ -250,13 +262,17 @@ export function AuthProvider({ children }: AuthProviderProps) {
   };
 
   const clearAuth = useCallback(async () => {
-    await storage.removeAll([
-      ACCESS_TOKEN_KEY,
-      REFRESH_TOKEN_KEY,
-      OAUTH_TOKENS_KEY,
-      AUTH_TYPE_KEY,
-      AUTH_USER_ID_KEY,
-    ]);
+    // Clearing every marker is one atomic section so a concurrent login's
+    // marker writes either all precede or all follow it. No network inside.
+    await CalComAPIService.runAuthTransition(async () => {
+      await storage.removeAll([
+        ACCESS_TOKEN_KEY,
+        REFRESH_TOKEN_KEY,
+        OAUTH_TOKENS_KEY,
+        AUTH_TYPE_KEY,
+        AUTH_USER_ID_KEY,
+      ]);
+    });
 
     if (oauthService) {
       try {
@@ -635,7 +651,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
       // fails), and the query persister now refuses to write ownerless cache, so
       // without this marker web-session users would lose cache persistence.
       try {
-        await storage.set(AUTH_USER_ID_KEY, String(sessionUserInfo.id));
+        await CalComAPIService.runAuthTransition(async () => {
+          await storage.set(AUTH_USER_ID_KEY, String(sessionUserInfo.id));
+        });
       } catch (idError) {
         console.warn("Failed to persist auth user id:", idError);
       }
@@ -663,7 +681,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
       // Persist the web-session marker only once we've committed (after the
       // recheck), so an aborted stale login never leaves a "web_session" marker
       // behind. Written even when there's no token so the persister keeps cache.
-      await storage.set(AUTH_TYPE_KEY, "web_session");
+      await CalComAPIService.runAuthTransition(async () => {
+        await storage.set(AUTH_TYPE_KEY, "web_session");
+      });
       if (tokens.accessToken) {
         setAccessToken(tokens.accessToken);
         setRefreshToken(tokens.refreshToken || null);
@@ -724,7 +744,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
       // refuse to persist — otherwise new-user queries in that window would be
       // wrapped under the previous user's id.
       try {
-        await storage.remove(AUTH_USER_ID_KEY);
+        await CalComAPIService.runAuthTransition(async () => {
+          await storage.remove(AUTH_USER_ID_KEY);
+        });
       } catch (idError) {
         safeLogWarn("Failed to clear previous auth user id before login:", idError);
       }

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -308,6 +308,13 @@ export async function requestAndRegisterPushToken(params: {
 
   const platform = getPlatform();
 
+  // Final check right before the POST: if the session already changed (e.g. a
+  // logout/switch during the awaits above), don't create the server row at all.
+  // Once the POST is in flight the post-await guard below handles cleanup.
+  if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+    return { success: false, reason: "auth-session-changed-during-registration", token };
+  }
+
   try {
     await CalComAPIService.registerAppPushSubscription({
       token,

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -4,7 +4,9 @@ import * as Device from "expo-device";
 import * as Notifications from "expo-notifications";
 import { Platform } from "react-native";
 import { CalComAPIService } from "@/services/calcom";
+import { ApiRequestError } from "@/services/calcom/request";
 import { type CalRegion, getRegion } from "@/utils/region";
+import { safeLogWarn } from "@/utils/safeLogger";
 import { secureStorage } from "@/utils/storage";
 
 const DEVICE_ID_KEY = "calcom_push_device_id";
@@ -27,6 +29,31 @@ export type PersistedPushRegistration = {
   userId: number;
   registeredAt: string;
 };
+
+/**
+ * Stable, non-reversible short hash of an Expo push token, safe to log.
+ * Never log the raw token (it is PII / a routing credential).
+ */
+async function hashPushToken(token: string): Promise<string> {
+  try {
+    const digest = await Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.SHA256, token);
+    return digest.slice(0, 16);
+  } catch {
+    return "unhashable";
+  }
+}
+
+async function safeRegistrationLogContext(
+  registration: PersistedPushRegistration
+): Promise<Record<string, unknown>> {
+  return {
+    currentRegion: getRegion(),
+    persistedRegion: registration.region,
+    userId: registration.userId,
+    deviceId: registration.deviceId,
+    tokenHash: await hashPushToken(registration.token),
+  };
+}
 
 export async function getPersistedPushRegistration(): Promise<PersistedPushRegistration | null> {
   try {
@@ -70,9 +97,28 @@ export async function deregisterPersistedPushRegistration(): Promise<boolean> {
     await CalComAPIService.removeAppPushSubscription(persisted.token);
     await clearPersistedPushRegistration();
     return true;
-  } catch {
-    // Keep the persisted record; the server prunes stale tokens on failed
-    // sends, and a future logout/launch can retry deletion.
+  } catch (error) {
+    // A 404 means the server has no such subscription. If it was registered in
+    // the region we're currently talking to, it is genuinely gone (e.g. pruned
+    // by invalid-token cleanup), so clear the stale record. If the persisted
+    // region differs, the 404 only means "not in this region" — we can't safely
+    // resolve it until cross-region ownership lands, so keep the record.
+    if (error instanceof ApiRequestError && error.status === 404) {
+      if (persisted.region === getRegion()) {
+        await clearPersistedPushRegistration();
+        return true;
+      }
+      safeLogWarn(
+        "[push] unregister 404 for a different region; keeping record",
+        await safeRegistrationLogContext(persisted)
+      );
+      return false;
+    }
+    // Keep the persisted record; a future logout/launch can retry deletion.
+    safeLogWarn(
+      "[push] failed to deregister persisted token",
+      await safeRegistrationLogContext(persisted)
+    );
     return false;
   }
 }
@@ -170,6 +216,21 @@ export async function requestAndRegisterPushToken(params: {
       reason: error instanceof Error ? error.message : "server-registration-failed",
       token,
     };
+  }
+
+  // There is a single persisted registration slot. If a previous record exists
+  // for a different token (e.g. a token whose deregistration failed earlier),
+  // try to resolve it before we overwrite it, so the old subscription isn't
+  // silently orphaned. If it can't be resolved now, deregister logs it safely.
+  const previous = await getPersistedPushRegistration();
+  if (previous && previous.token !== token) {
+    const resolved = await deregisterPersistedPushRegistration();
+    if (!resolved) {
+      safeLogWarn(
+        "[push] overwriting an unresolved previous registration",
+        await safeRegistrationLogContext(previous)
+      );
+    }
   }
 
   await persistPushRegistration({

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -101,6 +101,16 @@ function isSameRegistration(a: PersistedPushRegistration, b: PersistedPushRegist
   );
 }
 
+/**
+ * Stricter equality for removing an exact pending record. Includes registeredAt
+ * so the drain only drops the precise records it snapshotted and deleted — a
+ * newer record sharing the same subscription identity (but queued while the
+ * DELETEs were in flight) is preserved.
+ */
+function isSamePendingRecord(a: PersistedPushRegistration, b: PersistedPushRegistration): boolean {
+  return isSameRegistration(a, b) && a.registeredAt === b.registeredAt;
+}
+
 // The pending queue is a read-modify-write on a single storage key, so
 // concurrent enqueue/drain calls (e.g. a registration parking a record while a
 // login-triggered drain runs) could clobber each other and lose records.
@@ -211,7 +221,7 @@ export async function drainPendingDeregistrations(currentUserId: number): Promis
   await runPendingQueueMutation(async () => {
     const current = await getPendingDeregistrations();
     const remaining = current.filter(
-      (record) => !removed.some((deleted) => isSameRegistration(record, deleted))
+      (record) => !removed.some((deleted) => isSamePendingRecord(record, deleted))
     );
     await setPendingDeregistrations(remaining);
   });
@@ -432,6 +442,19 @@ export async function requestAndRegisterPushToken(params: {
         );
       }
     }
+  }
+
+  // The previous-registration cleanup above awaits storage/network work, so the
+  // session can have changed since the post-POST recheck. Recheck once more here:
+  // persisting now would write a dead session's record as the ACTIVE
+  // registration after logout already ran. Park it for owner-scoped cleanup instead.
+  if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+    await enqueuePendingDeregistration(newRecord);
+    safeLogWarn(
+      "[push] session changed before persisting registration; queued for owner-scoped cleanup",
+      await safeRegistrationLogContext(newRecord)
+    );
+    return { success: false, reason: "auth-session-changed-during-registration", token };
   }
 
   await persistPushRegistration(newRecord);

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -132,25 +132,30 @@ async function enqueuePendingDeregistration(record: PersistedPushRegistration): 
 
 /**
  * Best-effort retry of previously-unresolved deregistrations. Only attempts
- * records registered in the region we're currently talking to — cross-region
- * cleanup needs server-side global ownership, which is an explicit non-goal —
- * and drops a record once the server confirms deletion or reports it already
- * gone (404). Failures are kept for the next attempt.
+ * records that belong to the CURRENT user AND region: the DELETE is
+ * authenticated as the current user, so a 404 for a record owned by a different
+ * user only means "not owned by this user" — not "already deleted" — and
+ * dropping it would orphan that user's still-live subscription. Cross-user /
+ * cross-region cleanup needs server-side global ownership, which is an explicit
+ * non-goal. For owned records, a confirmed deletion or an authoritative 404
+ * drops the record; everything else is kept for the next attempt.
  */
-async function drainPendingDeregistrations(): Promise<void> {
+async function drainPendingDeregistrations(currentUserId: number): Promise<void> {
   const pending = await getPendingDeregistrations();
   if (pending.length === 0) return;
 
   const currentRegion = getRegion();
   const remaining: PersistedPushRegistration[] = [];
   for (const record of pending) {
-    if (record.region !== currentRegion) {
+    if (record.region !== currentRegion || record.userId !== currentUserId) {
       remaining.push(record);
       continue;
     }
     try {
       await CalComAPIService.removeAppPushSubscription(record.token);
     } catch (error) {
+      // Authoritative: the record belongs to the authenticated current user,
+      // so a 404 means the row is genuinely gone.
       if (error instanceof ApiRequestError && error.status === 404) {
         continue;
       }
@@ -251,7 +256,7 @@ export async function requestAndRegisterPushToken(params: {
 
   // Retry any earlier deregistrations that couldn't be resolved (e.g. an
   // offline logout) now that we're authenticated and online again.
-  await drainPendingDeregistrations();
+  await drainPendingDeregistrations(params.userId);
 
   let finalStatus: Notifications.PermissionStatus;
   try {

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -101,6 +101,23 @@ function isSameRegistration(a: PersistedPushRegistration, b: PersistedPushRegist
   );
 }
 
+// The pending queue is a read-modify-write on a single storage key, so
+// concurrent enqueue/drain calls (e.g. a registration parking a record while a
+// login-triggered drain runs) could clobber each other and lose records.
+// Serialize every queue mutation through this chain so each get->modify->set
+// runs atomically. Sections here only touch the queue and never re-enter it, so
+// the chain can't self-deadlock.
+let pendingQueueChain: Promise<unknown> = Promise.resolve();
+
+function runPendingQueueMutation<T>(section: () => Promise<T>): Promise<T> {
+  const result = pendingQueueChain.then(section, section);
+  pendingQueueChain = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
+}
+
 async function getPendingDeregistrations(): Promise<PersistedPushRegistration[]> {
   try {
     const raw = await secureStorage.get(PENDING_DEREGISTRATIONS_KEY);
@@ -130,13 +147,15 @@ async function setPendingDeregistrations(records: PersistedPushRegistration[]): 
 const MAX_PENDING_DEREGISTRATIONS = 50;
 
 async function enqueuePendingDeregistration(record: PersistedPushRegistration): Promise<void> {
-  const pending = await getPendingDeregistrations();
-  if (pending.some((r) => isSameRegistration(r, record))) return;
-  const next = [...pending, record];
-  if (next.length > MAX_PENDING_DEREGISTRATIONS) {
-    next.splice(0, next.length - MAX_PENDING_DEREGISTRATIONS);
-  }
-  await setPendingDeregistrations(next);
+  await runPendingQueueMutation(async () => {
+    const pending = await getPendingDeregistrations();
+    if (pending.some((r) => isSameRegistration(r, record))) return;
+    const next = [...pending, record];
+    if (next.length > MAX_PENDING_DEREGISTRATIONS) {
+      next.splice(0, next.length - MAX_PENDING_DEREGISTRATIONS);
+    }
+    await setPendingDeregistrations(next);
+  });
 }
 
 /**
@@ -150,32 +169,34 @@ async function enqueuePendingDeregistration(record: PersistedPushRegistration): 
  * drops the record; everything else is kept for the next attempt.
  */
 export async function drainPendingDeregistrations(currentUserId: number): Promise<void> {
-  const pending = await getPendingDeregistrations();
-  if (pending.length === 0) return;
+  await runPendingQueueMutation(async () => {
+    const pending = await getPendingDeregistrations();
+    if (pending.length === 0) return;
 
-  const currentRegion = getRegion();
-  const remaining: PersistedPushRegistration[] = [];
-  for (const record of pending) {
-    if (record.region !== currentRegion || record.userId !== currentUserId) {
-      remaining.push(record);
-      continue;
-    }
-    try {
-      await CalComAPIService.removeAppPushSubscription(record.token);
-    } catch (error) {
-      // Authoritative: the record belongs to the authenticated current user,
-      // so a 404 means the row is genuinely gone.
-      if (error instanceof ApiRequestError && error.status === 404) {
+    const currentRegion = getRegion();
+    const remaining: PersistedPushRegistration[] = [];
+    for (const record of pending) {
+      if (record.region !== currentRegion || record.userId !== currentUserId) {
+        remaining.push(record);
         continue;
       }
-      remaining.push(record);
-      safeLogWarn(
-        "[push] pending deregistration retry failed",
-        await safeRegistrationLogContext(record)
-      );
+      try {
+        await CalComAPIService.removeAppPushSubscription(record.token);
+      } catch (error) {
+        // Authoritative: the record belongs to the authenticated current user,
+        // so a 404 means the row is genuinely gone.
+        if (error instanceof ApiRequestError && error.status === 404) {
+          continue;
+        }
+        remaining.push(record);
+        safeLogWarn(
+          "[push] pending deregistration retry failed",
+          await safeRegistrationLogContext(record)
+        );
+      }
     }
-  }
-  await setPendingDeregistrations(remaining);
+    await setPendingDeregistrations(remaining);
+  });
 }
 
 /**
@@ -351,24 +372,17 @@ export async function requestAndRegisterPushToken(params: {
   // flight. Do NOT persist it as the active registration — that would leave a
   // logged-out (or previous) user's subscription live in our local state.
   if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
-    // Best-effort immediate cleanup: if the Bearer is still valid (the change
-    // was an account switch, or logout hasn't cleared tokens yet) the server
-    // row is removed right now. Only if that fails do we park it for a session
-    // that can delete it (the pre-logout drain, or the next login for this
-    // user/region); the backend same-device dedup is the final backstop.
-    try {
-      await CalComAPIService.removeAppPushSubscription(token);
-      safeLogWarn(
-        "[push] registration completed after session change; deleted immediately",
-        await safeRegistrationLogContext(newRecord)
-      );
-    } catch {
-      await enqueuePendingDeregistration(newRecord);
-      safeLogWarn(
-        "[push] registration completed after logout/account switch; queued for cleanup",
-        await safeRegistrationLogContext(newRecord)
-      );
-    }
+    // Don't delete by token here. The Expo push token is per-device, so a new
+    // session that took over this device likely re-registered the SAME token;
+    // a token-only DELETE authenticated as that new user would remove their
+    // just-created row. Park it instead — the owner-scoped drain resolves it
+    // under this record's own user/region on their next login (the same
+    // same-token safeguard applied to the previous-registration path below).
+    await enqueuePendingDeregistration(newRecord);
+    safeLogWarn(
+      "[push] registration completed after logout/account switch; queued for owner-scoped cleanup",
+      await safeRegistrationLogContext(newRecord)
+    );
     return { success: false, reason: "auth-session-changed-during-registration", token };
   }
 

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -334,14 +334,25 @@ export async function requestAndRegisterPushToken(params: {
   // The session was logged out or switched while this registration was in
   // flight. Do NOT persist it as the active registration — that would leave a
   // logged-out (or previous) user's subscription live in our local state.
-  // Park it for retry instead; the backend's same-device dedup also clears it
-  // on the next login for this device.
   if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
-    await enqueuePendingDeregistration(newRecord);
-    safeLogWarn(
-      "[push] registration completed after logout/account switch; queued for cleanup",
-      await safeRegistrationLogContext(newRecord)
-    );
+    // Best-effort immediate cleanup: if the Bearer is still valid (the change
+    // was an account switch, or logout hasn't cleared tokens yet) the server
+    // row is removed right now. Only if that fails do we park it for a session
+    // that can delete it (the pre-logout drain, or the next login for this
+    // user/region); the backend same-device dedup is the final backstop.
+    try {
+      await CalComAPIService.removeAppPushSubscription(token);
+      safeLogWarn(
+        "[push] registration completed after session change; deleted immediately",
+        await safeRegistrationLogContext(newRecord)
+      );
+    } catch {
+      await enqueuePendingDeregistration(newRecord);
+      safeLogWarn(
+        "[push] registration completed after logout/account switch; queued for cleanup",
+        await safeRegistrationLogContext(newRecord)
+      );
+    }
     return { success: false, reason: "auth-session-changed-during-registration", token };
   }
 

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -161,8 +161,14 @@ const MAX_PENDING_DEREGISTRATIONS = 50;
 async function enqueuePendingDeregistration(record: PersistedPushRegistration): Promise<void> {
   await runPendingQueueMutation(async () => {
     const pending = await getPendingDeregistrations();
-    if (pending.some((r) => isSameRegistration(r, record))) return;
-    const next = [...pending, record];
+    // Keep one record per subscription identity, but never drop a newer one: a
+    // late re-registration can produce a record with the same identity tuple and
+    // a newer registeredAt while a drain holds an older snapshot. Returning early
+    // here would let the drain remove the old record and leave the new server row
+    // with no cleanup entry. Replace any same-identity record with the newer one.
+    const existing = pending.find((r) => isSameRegistration(r, record));
+    if (existing && existing.registeredAt >= record.registeredAt) return;
+    const next = [...pending.filter((r) => !isSameRegistration(r, record)), record];
     if (next.length > MAX_PENDING_DEREGISTRATIONS) {
       next.splice(0, next.length - MAX_PENDING_DEREGISTRATIONS);
     }

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -140,7 +140,7 @@ async function enqueuePendingDeregistration(record: PersistedPushRegistration): 
  * non-goal. For owned records, a confirmed deletion or an authoritative 404
  * drops the record; everything else is kept for the next attempt.
  */
-async function drainPendingDeregistrations(currentUserId: number): Promise<void> {
+export async function drainPendingDeregistrations(currentUserId: number): Promise<void> {
   const pending = await getPendingDeregistrations();
   if (pending.length === 0) return;
 
@@ -352,13 +352,26 @@ export async function requestAndRegisterPushToken(params: {
   // silently dropping it — otherwise the old subscription becomes unretryable.
   const previous = await getPersistedPushRegistration();
   if (previous && !isSameRegistration(previous, newRecord)) {
-    const resolved = await deregisterPersistedPushRegistration(params.userId);
-    if (!resolved) {
+    if (previous.token === newRecord.token) {
+      // Same physical push token, only the owner/region/device metadata differs.
+      // The registration above already took over this token for the current
+      // user, and deleting by this token now (authenticated as the current user)
+      // would remove that just-created row. Park the previous record so the
+      // ownership-scoped drain resolves it under its own identity/region later.
       await enqueuePendingDeregistration(previous);
       safeLogWarn(
-        "[push] queued unresolved previous registration for retry",
+        "[push] previous registration shares the new token; queued for owner-scoped cleanup",
         await safeRegistrationLogContext(previous)
       );
+    } else {
+      const resolved = await deregisterPersistedPushRegistration(params.userId);
+      if (!resolved) {
+        await enqueuePendingDeregistration(previous);
+        safeLogWarn(
+          "[push] queued unresolved previous registration for retry",
+          await safeRegistrationLogContext(previous)
+        );
+      }
     }
   }
 

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -105,8 +105,10 @@ function isSameRegistration(a: PersistedPushRegistration, b: PersistedPushRegist
 // concurrent enqueue/drain calls (e.g. a registration parking a record while a
 // login-triggered drain runs) could clobber each other and lose records.
 // Serialize every queue mutation through this chain so each get->modify->set
-// runs atomically. Sections here only touch the queue and never re-enter it, so
-// the chain can't self-deadlock.
+// runs atomically. Sections passed here MUST do storage work only and MUST NOT
+// perform network I/O: a DELETE can 401 -> logout -> re-enter drain, which would
+// block on this chain while the holder blocks on logout (a deadlock). Drain
+// therefore does its DELETEs outside the lock and only the final removal under it.
 let pendingQueueChain: Promise<unknown> = Promise.resolve();
 
 function runPendingQueueMutation<T>(section: () => Promise<T>): Promise<T> {
@@ -169,32 +171,48 @@ async function enqueuePendingDeregistration(record: PersistedPushRegistration): 
  * drops the record; everything else is kept for the next attempt.
  */
 export async function drainPendingDeregistrations(currentUserId: number): Promise<void> {
-  await runPendingQueueMutation(async () => {
-    const pending = await getPendingDeregistrations();
-    if (pending.length === 0) return;
+  // A single storage read is atomic, so snapshot the queue without the lock.
+  const pending = await getPendingDeregistrations();
+  if (pending.length === 0) return;
 
-    const currentRegion = getRegion();
-    const remaining: PersistedPushRegistration[] = [];
-    for (const record of pending) {
-      if (record.region !== currentRegion || record.userId !== currentUserId) {
-        remaining.push(record);
+  const currentRegion = getRegion();
+  // Perform the DELETE calls OUTSIDE the queue lock. removeAppPushSubscription
+  // can 401, which triggers logout, whose pre-logout callback re-enters this
+  // drain; holding the lock across that network I/O would deadlock (the
+  // re-entrant drain would block on the lock this call still holds while this
+  // call blocks on logout). Collect the records we confirm are gone, then drop
+  // just those under the lock.
+  const removed: PersistedPushRegistration[] = [];
+  for (const record of pending) {
+    if (record.region !== currentRegion || record.userId !== currentUserId) {
+      continue;
+    }
+    try {
+      await CalComAPIService.removeAppPushSubscription(record.token);
+      removed.push(record);
+    } catch (error) {
+      // Authoritative: the record belongs to the authenticated current user,
+      // so a 404 means the row is genuinely gone.
+      if (error instanceof ApiRequestError && error.status === 404) {
+        removed.push(record);
         continue;
       }
-      try {
-        await CalComAPIService.removeAppPushSubscription(record.token);
-      } catch (error) {
-        // Authoritative: the record belongs to the authenticated current user,
-        // so a 404 means the row is genuinely gone.
-        if (error instanceof ApiRequestError && error.status === 404) {
-          continue;
-        }
-        remaining.push(record);
-        safeLogWarn(
-          "[push] pending deregistration retry failed",
-          await safeRegistrationLogContext(record)
-        );
-      }
+      safeLogWarn(
+        "[push] pending deregistration retry failed",
+        await safeRegistrationLogContext(record)
+      );
     }
+  }
+
+  if (removed.length === 0) return;
+
+  // Re-read under the lock and drop only the confirmed-removed records,
+  // preserving anything enqueued while the DELETEs were in flight.
+  await runPendingQueueMutation(async () => {
+    const current = await getPendingDeregistrations();
+    const remaining = current.filter(
+      (record) => !removed.some((deleted) => isSameRegistration(record, deleted))
+    );
     await setPendingDeregistrations(remaining);
   });
 }

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -330,6 +330,11 @@ export async function requestAndRegisterPushToken(params: {
   // offline logout) now that we're authenticated and online again.
   await drainPendingDeregistrations(params.userId);
 
+  // Android 13+ needs a notification channel before the runtime permission
+  // prompt can appear. Create it before get/requestPermissionsAsync so the
+  // first-login registration path can actually ask for permission.
+  await ensureAndroidChannel();
+
   let finalStatus: Notifications.PermissionStatus;
   try {
     const { status: existingStatus } = await Notifications.getPermissionsAsync();
@@ -349,8 +354,6 @@ export async function requestAndRegisterPushToken(params: {
   if (finalStatus !== "granted") {
     return { success: false, reason: "notification-permission-denied" };
   }
-
-  await ensureAndroidChannel();
 
   const projectId = Constants.expoConfig?.extra?.eas?.projectId ?? Constants.easConfig?.projectId;
   if (!projectId) {

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -11,6 +11,11 @@ import { secureStorage } from "@/utils/storage";
 
 const DEVICE_ID_KEY = "calcom_push_device_id";
 const PERSISTED_REGISTRATION_KEY = "calcom_push_registration";
+// Records we failed to deregister (offline, or belonging to a different
+// region/user) are parked here instead of being dropped, so a later launch can
+// retry their deletion. Keeps the single active-registration slot uncluttered
+// while ensuring an unresolved subscription stays retryable.
+const PENDING_DEREGISTRATIONS_KEY = "calcom_push_pending_deregistrations";
 
 export type PushRegistrationResult =
   | { success: true; token: string }
@@ -80,6 +85,83 @@ export async function clearPersistedPushRegistration(): Promise<void> {
   } catch {
     // Best-effort.
   }
+}
+
+/**
+ * Two registrations refer to the same server subscription only when the full
+ * identity tuple matches. Comparing the token alone misses cases where the same
+ * token is re-used across a region/user change, so we compare all four fields.
+ */
+function isSameRegistration(a: PersistedPushRegistration, b: PersistedPushRegistration): boolean {
+  return (
+    a.token === b.token &&
+    a.userId === b.userId &&
+    a.region === b.region &&
+    a.deviceId === b.deviceId
+  );
+}
+
+async function getPendingDeregistrations(): Promise<PersistedPushRegistration[]> {
+  try {
+    const raw = await secureStorage.get(PENDING_DEREGISTRATIONS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as PersistedPushRegistration[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+async function setPendingDeregistrations(records: PersistedPushRegistration[]): Promise<void> {
+  try {
+    if (records.length === 0) {
+      await secureStorage.remove(PENDING_DEREGISTRATIONS_KEY);
+      return;
+    }
+    await secureStorage.set(PENDING_DEREGISTRATIONS_KEY, JSON.stringify(records));
+  } catch {
+    // Best-effort.
+  }
+}
+
+async function enqueuePendingDeregistration(record: PersistedPushRegistration): Promise<void> {
+  const pending = await getPendingDeregistrations();
+  if (pending.some((r) => isSameRegistration(r, record))) return;
+  await setPendingDeregistrations([...pending, record]);
+}
+
+/**
+ * Best-effort retry of previously-unresolved deregistrations. Only attempts
+ * records registered in the region we're currently talking to — cross-region
+ * cleanup needs server-side global ownership, which is an explicit non-goal —
+ * and drops a record once the server confirms deletion or reports it already
+ * gone (404). Failures are kept for the next attempt.
+ */
+async function drainPendingDeregistrations(): Promise<void> {
+  const pending = await getPendingDeregistrations();
+  if (pending.length === 0) return;
+
+  const currentRegion = getRegion();
+  const remaining: PersistedPushRegistration[] = [];
+  for (const record of pending) {
+    if (record.region !== currentRegion) {
+      remaining.push(record);
+      continue;
+    }
+    try {
+      await CalComAPIService.removeAppPushSubscription(record.token);
+    } catch (error) {
+      if (error instanceof ApiRequestError && error.status === 404) {
+        continue;
+      }
+      remaining.push(record);
+      safeLogWarn(
+        "[push] pending deregistration retry failed",
+        await safeRegistrationLogContext(record)
+      );
+    }
+  }
+  await setPendingDeregistrations(remaining);
 }
 
 /**
@@ -162,6 +244,15 @@ export async function requestAndRegisterPushToken(params: {
     return { success: false, reason: "simulators-do-not-support-push-notifications" };
   }
 
+  // Capture the auth session at the start. If the user logs out or switches
+  // accounts while registration is in flight, the generation changes and we
+  // must not persist this as an active registration for a now-dead session.
+  const generationAtStart = CalComAPIService.getAuthGeneration();
+
+  // Retry any earlier deregistrations that couldn't be resolved (e.g. an
+  // offline logout) now that we're authenticated and online again.
+  await drainPendingDeregistrations();
+
   let finalStatus: Notifications.PermissionStatus;
   try {
     const { status: existingStatus } = await Notifications.getPermissionsAsync();
@@ -218,29 +309,47 @@ export async function requestAndRegisterPushToken(params: {
     };
   }
 
-  // There is a single persisted registration slot. If a previous record exists
-  // for a different token (e.g. a token whose deregistration failed earlier),
-  // try to resolve it before we overwrite it, so the old subscription isn't
-  // silently orphaned. If it can't be resolved now, deregister logs it safely.
-  const previous = await getPersistedPushRegistration();
-  if (previous && previous.token !== token) {
-    const resolved = await deregisterPersistedPushRegistration();
-    if (!resolved) {
-      safeLogWarn(
-        "[push] overwriting an unresolved previous registration",
-        await safeRegistrationLogContext(previous)
-      );
-    }
-  }
-
-  await persistPushRegistration({
+  const newRecord: PersistedPushRegistration = {
     token,
     deviceId,
     platform,
     region: getRegion(),
     userId: params.userId,
     registeredAt: new Date().toISOString(),
-  });
+  };
+
+  // The session was logged out or switched while this registration was in
+  // flight. Do NOT persist it as the active registration — that would leave a
+  // logged-out (or previous) user's subscription live in our local state.
+  // Park it for retry instead; the backend's same-device dedup also clears it
+  // on the next login for this device.
+  if (CalComAPIService.getAuthGeneration() !== generationAtStart) {
+    await enqueuePendingDeregistration(newRecord);
+    safeLogWarn(
+      "[push] registration completed after logout/account switch; queued for cleanup",
+      await safeRegistrationLogContext(newRecord)
+    );
+    return { success: false, reason: "auth-session-changed-during-registration", token };
+  }
+
+  // There is a single active persisted registration slot. If a previous record
+  // refers to a different subscription (different token/user/region/device),
+  // try to deregister it before overwriting. If it can't be resolved now
+  // (offline, or a different region/user), park it for retry instead of
+  // silently dropping it — otherwise the old subscription becomes unretryable.
+  const previous = await getPersistedPushRegistration();
+  if (previous && !isSameRegistration(previous, newRecord)) {
+    const resolved = await deregisterPersistedPushRegistration();
+    if (!resolved) {
+      await enqueuePendingDeregistration(previous);
+      safeLogWarn(
+        "[push] queued unresolved previous registration for retry",
+        await safeRegistrationLogContext(previous)
+      );
+    }
+  }
+
+  await persistPushRegistration(newRecord);
 
   return { success: true, token };
 }

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -4,13 +4,78 @@ import * as Device from "expo-device";
 import * as Notifications from "expo-notifications";
 import { Platform } from "react-native";
 import { CalComAPIService } from "@/services/calcom";
+import { type CalRegion, getRegion } from "@/utils/region";
 import { secureStorage } from "@/utils/storage";
 
 const DEVICE_ID_KEY = "calcom_push_device_id";
+const PERSISTED_REGISTRATION_KEY = "calcom_push_registration";
 
 export type PushRegistrationResult =
   | { success: true; token: string }
   | { success: false; reason: string; token?: string };
+
+/**
+ * A durable record of the last successful server-side push registration.
+ * Persisted to secure storage so logout (even after an app restart, when the
+ * in-memory token ref is gone) can still deregister the server subscription.
+ */
+export type PersistedPushRegistration = {
+  token: string;
+  deviceId: string;
+  platform: "IOS" | "ANDROID";
+  region: CalRegion;
+  userId: number;
+  registeredAt: string;
+};
+
+export async function getPersistedPushRegistration(): Promise<PersistedPushRegistration | null> {
+  try {
+    const raw = await secureStorage.get(PERSISTED_REGISTRATION_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as PersistedPushRegistration;
+  } catch {
+    return null;
+  }
+}
+
+async function persistPushRegistration(record: PersistedPushRegistration): Promise<void> {
+  try {
+    await secureStorage.set(PERSISTED_REGISTRATION_KEY, JSON.stringify(record));
+  } catch {
+    // Best-effort: cross-restart deregistration is a hardening nicety, not
+    // critical to the login flow.
+  }
+}
+
+export async function clearPersistedPushRegistration(): Promise<void> {
+  try {
+    await secureStorage.remove(PERSISTED_REGISTRATION_KEY);
+  } catch {
+    // Best-effort.
+  }
+}
+
+/**
+ * Deregister the persisted push subscription on the server and clear the
+ * persisted record only once the server confirms deletion. Returns true when
+ * there is nothing left registered (either deletion succeeded or no record
+ * existed). On failure the record is kept so a later attempt can retry, and
+ * the caller is never blocked.
+ */
+export async function deregisterPersistedPushRegistration(): Promise<boolean> {
+  const persisted = await getPersistedPushRegistration();
+  if (!persisted) return true;
+
+  try {
+    await CalComAPIService.removeAppPushSubscription(persisted.token);
+    await clearPersistedPushRegistration();
+    return true;
+  } catch {
+    // Keep the persisted record; the server prunes stale tokens on failed
+    // sends, and a future logout/launch can retry deletion.
+    return false;
+  }
+}
 
 async function getDeviceId(): Promise<string> {
   let id: string | undefined;
@@ -44,7 +109,9 @@ export async function ensureAndroidChannel(): Promise<void> {
   }
 }
 
-export async function requestAndRegisterPushToken(): Promise<PushRegistrationResult> {
+export async function requestAndRegisterPushToken(params: {
+  userId: number;
+}): Promise<PushRegistrationResult> {
   if (!Device.isDevice) {
     return { success: false, reason: "simulators-do-not-support-push-notifications" };
   }
@@ -89,10 +156,12 @@ export async function requestAndRegisterPushToken(): Promise<PushRegistrationRes
 
   const deviceId = await getDeviceId();
 
+  const platform = getPlatform();
+
   try {
     await CalComAPIService.registerAppPushSubscription({
       token,
-      platform: getPlatform(),
+      platform,
       deviceId,
     });
   } catch (error) {
@@ -103,13 +172,14 @@ export async function requestAndRegisterPushToken(): Promise<PushRegistrationRes
     };
   }
 
-  return { success: true, token };
-}
+  await persistPushRegistration({
+    token,
+    deviceId,
+    platform,
+    region: getRegion(),
+    userId: params.userId,
+    registeredAt: new Date().toISOString(),
+  });
 
-export async function deregisterPushToken(token: string): Promise<void> {
-  try {
-    await CalComAPIService.removeAppPushSubscription(token);
-  } catch {
-    // Best-effort: server cleans up stale tokens on failed send attempts.
-  }
+  return { success: true, token };
 }

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -175,8 +175,13 @@ async function drainPendingDeregistrations(currentUserId: number): Promise<void>
  * there is nothing left registered (either deletion succeeded or no record
  * existed). On failure the record is kept so a later attempt can retry, and
  * the caller is never blocked.
+ *
+ * `currentUserId` is the user the DELETE is authenticated as. It gates whether
+ * a 404 can be treated as authoritative (see below).
  */
-export async function deregisterPersistedPushRegistration(): Promise<boolean> {
+export async function deregisterPersistedPushRegistration(
+  currentUserId?: number
+): Promise<boolean> {
   const persisted = await getPersistedPushRegistration();
   if (!persisted) return true;
 
@@ -185,18 +190,21 @@ export async function deregisterPersistedPushRegistration(): Promise<boolean> {
     await clearPersistedPushRegistration();
     return true;
   } catch (error) {
-    // A 404 means the server has no such subscription. If it was registered in
-    // the region we're currently talking to, it is genuinely gone (e.g. pruned
-    // by invalid-token cleanup), so clear the stale record. If the persisted
-    // region differs, the 404 only means "not in this region" — we can't safely
-    // resolve it until cross-region ownership lands, so keep the record.
+    // A 404 means "no such subscription for the authenticated user". It is only
+    // authoritative ("genuinely gone") when the record was registered in the
+    // current region AND belongs to the current user — the DELETE is authed as
+    // `currentUserId`, so a 404 for a different user's record only means "not
+    // owned by this user", not "deleted". Cross-region records are likewise
+    // unresolvable here. Keep anything we can't authoritatively confirm so the
+    // caller can re-queue it for a session that can.
     if (error instanceof ApiRequestError && error.status === 404) {
-      if (persisted.region === getRegion()) {
+      const ownedByCurrentUser = currentUserId != null && persisted.userId === currentUserId;
+      if (persisted.region === getRegion() && ownedByCurrentUser) {
         await clearPersistedPushRegistration();
         return true;
       }
       safeLogWarn(
-        "[push] unregister 404 for a different region; keeping record",
+        "[push] unregister 404 not authoritative for this session; keeping record",
         await safeRegistrationLogContext(persisted)
       );
       return false;
@@ -344,7 +352,7 @@ export async function requestAndRegisterPushToken(params: {
   // silently dropping it — otherwise the old subscription becomes unretryable.
   const previous = await getPersistedPushRegistration();
   if (previous && !isSameRegistration(previous, newRecord)) {
-    const resolved = await deregisterPersistedPushRegistration();
+    const resolved = await deregisterPersistedPushRegistration(params.userId);
     if (!resolved) {
       await enqueuePendingDeregistration(previous);
       safeLogWarn(

--- a/apps/mobile/hooks/use-push-notifications.ts
+++ b/apps/mobile/hooks/use-push-notifications.ts
@@ -124,10 +124,19 @@ async function setPendingDeregistrations(records: PersistedPushRegistration[]): 
   }
 }
 
+// Cross-user/cross-region records can't be drained until the right identity
+// logs back in, so the queue can grow on shared devices. Cap it so it can't
+// accumulate unboundedly; oldest records are evicted first.
+const MAX_PENDING_DEREGISTRATIONS = 50;
+
 async function enqueuePendingDeregistration(record: PersistedPushRegistration): Promise<void> {
   const pending = await getPendingDeregistrations();
   if (pending.some((r) => isSameRegistration(r, record))) return;
-  await setPendingDeregistrations([...pending, record]);
+  const next = [...pending, record];
+  if (next.length > MAX_PENDING_DEREGISTRATIONS) {
+    next.splice(0, next.length - MAX_PENDING_DEREGISTRATIONS);
+  }
+  await setPendingDeregistrations(next);
 }
 
 /**

--- a/apps/mobile/hooks/useAppStoreRating.ts
+++ b/apps/mobile/hooks/useAppStoreRating.ts
@@ -21,22 +21,22 @@ function getStorageKey(trigger: RatingTriggerType): string {
 }
 
 async function requestReviewIfAvailable(): Promise<boolean> {
-  // Only available on native platforms (iOS/Android)
-  if (Platform.OS === "web") {
+  // Review prompts are a production-only, best-effort native feature.
+  if (__DEV__ || Platform.OS === "web") {
     return false;
   }
 
   try {
     // Dynamic import to avoid bundling issues on web
     const StoreReview = await import("expo-store-review");
-    const isAvailable = await StoreReview.isAvailableAsync();
-    if (isAvailable) {
-      await StoreReview.requestReview();
-      return true;
+    const hasReviewAction = await StoreReview.hasAction();
+    if (!hasReviewAction) {
+      return false;
     }
-    return false;
-  } catch (error) {
-    console.warn("Failed to request app store review:", error);
+
+    await StoreReview.requestReview();
+    return true;
+  } catch (_error) {
     return false;
   }
 }
@@ -74,13 +74,20 @@ async function markAsTriggered(trigger: RatingTriggerType): Promise<void> {
  * await requestRating(RatingTrigger.BOOKING_CONFIRMED);
  */
 export async function requestRating(trigger: RatingTriggerType): Promise<boolean> {
+  if (__DEV__ || Platform.OS === "web") {
+    return false;
+  }
+
   const alreadyTriggered = await hasAlreadyTriggered(trigger);
   if (alreadyTriggered) {
     return false;
   }
 
-  await markAsTriggered(trigger);
-  return requestReviewIfAvailable();
+  const didRequestReview = await requestReviewIfAvailable();
+  if (didRequestReview) {
+    await markAsTriggered(trigger);
+  }
+  return didRequestReview;
 }
 
 /**

--- a/apps/mobile/hooks/useBookingActions.ts
+++ b/apps/mobile/hooks/useBookingActions.ts
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Alert, Platform } from "react-native";
 import type { Booking } from "@/services/calcom";
 import { showErrorAlert, showSilentSuccessAlert, showSuccessAlert } from "@/utils/alerts";
+import { safeLogError, safeLogInfo, safeLogWarn } from "@/utils/safeLogger";
 
 interface UseBookingActionsParams {
   router: ReturnType<typeof useRouter>;
@@ -68,6 +69,26 @@ export const useBookingActions = ({
 
   // Selected booking for actions modal
   const [selectedBooking, setSelectedBooking] = useState<Booking | null>(null);
+
+  const getActionLogContext = (booking: Booking, extra?: Record<string, unknown>) => ({
+    bookingUid: booking.uid,
+    bookingStatus: booking.status,
+    platform: Platform.OS,
+    isConfirming,
+    isDeclining,
+    ...extra,
+  });
+
+  const getActionErrorDiagnostics = (error: unknown) => {
+    if (error instanceof Error) {
+      return {
+        name: error.name,
+        message: error.message,
+      };
+    }
+
+    return { error };
+  };
 
   /**
    * Navigate to booking detail page
@@ -327,18 +348,29 @@ export const useBookingActions = ({
    * Show alert and confirm booking
    */
   const handleConfirmBooking = (booking: Booking) => {
+    safeLogInfo("[useBookingActions] confirm alert opened", getActionLogContext(booking));
+
     Alert.alert("Confirm Booking", `Are you sure you want to confirm "${booking.title}"?`, [
       { text: "Cancel", style: "cancel" },
       {
         text: "Confirm",
         onPress: () => {
+          safeLogInfo("[useBookingActions] confirm alert accepted", getActionLogContext(booking));
           confirmMutation(
             { uid: booking.uid },
             {
               onSuccess: () => {
+                safeLogInfo(
+                  "[useBookingActions] confirm alert mutation succeeded",
+                  getActionLogContext(booking)
+                );
                 showSilentSuccessAlert("Success", "Booking confirmed successfully");
               },
               onError: (error) => {
+                safeLogError("[useBookingActions] confirm alert mutation failed", {
+                  ...getActionLogContext(booking),
+                  error: getActionErrorDiagnostics(error),
+                });
                 showErrorAlert("Error", error.message || "Failed to confirm booking");
               },
             }
@@ -352,6 +384,7 @@ export const useBookingActions = ({
    * Open reject modal (used by iOS for custom modal UI)
    */
   const handleOpenRejectModal = (booking: Booking) => {
+    safeLogInfo("[useBookingActions] reject modal opened", getActionLogContext(booking));
     setRejectBooking(booking);
     setRejectReason("");
     setShowRejectModal(true);
@@ -361,6 +394,8 @@ export const useBookingActions = ({
    * Show alert and reject booking (Android Alert.prompt pattern)
    */
   const handleRejectBooking = (booking: Booking) => {
+    safeLogInfo("[useBookingActions] reject alert opened", getActionLogContext(booking));
+
     Alert.alert("Decline Booking", `Are you sure you want to decline "${booking.title}"?`, [
       { text: "Cancel", style: "cancel" },
       {
@@ -376,13 +411,28 @@ export const useBookingActions = ({
               {
                 text: "OK",
                 onPress: (reason?: string) => {
+                  safeLogInfo("[useBookingActions] reject alert submitted", {
+                    ...getActionLogContext(booking),
+                    hasReason: Boolean(reason?.trim()),
+                    reasonLength: reason?.length ?? 0,
+                  });
                   declineMutation(
                     { uid: booking.uid, reason: reason || undefined },
                     {
                       onSuccess: () => {
+                        safeLogInfo(
+                          "[useBookingActions] reject alert mutation succeeded",
+                          getActionLogContext(booking)
+                        );
                         showSilentSuccessAlert("Success", "Booking declined successfully");
                       },
                       onError: (error) => {
+                        safeLogError("[useBookingActions] reject alert mutation failed", {
+                          ...getActionLogContext(booking),
+                          hasReason: Boolean(reason?.trim()),
+                          reasonLength: reason?.length ?? 0,
+                          error: getActionErrorDiagnostics(error),
+                        });
                         showErrorAlert("Error", error.message || "Failed to decline booking");
                       },
                     }
@@ -404,21 +454,44 @@ export const useBookingActions = ({
    * @param reasonOverride - Optional reason passed directly to avoid race condition with state updates
    */
   const handleSubmitReject = (reasonOverride?: string) => {
-    if (!rejectBooking) return;
+    if (!rejectBooking) {
+      safeLogWarn("[useBookingActions] reject submit ignored; no selected booking", {
+        platform: Platform.OS,
+        hasReasonOverride: reasonOverride !== undefined,
+      });
+      return;
+    }
+    const booking = rejectBooking;
 
     // Use passed reason if provided, otherwise fall back to state
     const reason = reasonOverride !== undefined ? reasonOverride : rejectReason;
+    safeLogInfo("[useBookingActions] reject modal submitted", {
+      ...getActionLogContext(booking),
+      hasReason: Boolean(reason?.trim()),
+      reasonLength: reason?.length ?? 0,
+      usedReasonOverride: reasonOverride !== undefined,
+    });
 
     declineMutation(
-      { uid: rejectBooking.uid, reason: reason || undefined },
+      { uid: booking.uid, reason: reason || undefined },
       {
         onSuccess: () => {
+          safeLogInfo(
+            "[useBookingActions] reject modal mutation succeeded",
+            getActionLogContext(booking)
+          );
           setShowRejectModal(false);
           setRejectBooking(null);
           setRejectReason("");
           showSilentSuccessAlert("Success", "Booking rejected successfully");
         },
-        onError: (_error) => {
+        onError: (error) => {
+          safeLogError("[useBookingActions] reject modal mutation failed", {
+            ...getActionLogContext(booking),
+            hasReason: Boolean(reason?.trim()),
+            reasonLength: reason?.length ?? 0,
+            error: getActionErrorDiagnostics(error),
+          });
           showErrorAlert("Error", "Failed to reject booking. Please try again.");
         },
       }
@@ -438,13 +511,23 @@ export const useBookingActions = ({
    * Inline confirm handler (for use directly in JSX)
    */
   const handleInlineConfirm = (booking: Booking) => {
+    safeLogInfo("[useBookingActions] inline confirm pressed", getActionLogContext(booking));
+
     confirmMutation(
       { uid: booking.uid },
       {
         onSuccess: () => {
+          safeLogInfo(
+            "[useBookingActions] inline confirm mutation succeeded",
+            getActionLogContext(booking)
+          );
           showSilentSuccessAlert("Success", "Booking confirmed successfully");
         },
-        onError: (_error) => {
+        onError: (error) => {
+          safeLogError("[useBookingActions] inline confirm mutation failed", {
+            ...getActionLogContext(booking),
+            error: getActionErrorDiagnostics(error),
+          });
           showErrorAlert("Error", "Failed to confirm booking. Please try again.");
         },
       }

--- a/apps/mobile/hooks/useBookingActions.ts
+++ b/apps/mobile/hooks/useBookingActions.ts
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { Alert, Platform } from "react-native";
 import type { Booking } from "@/services/calcom";
 import { showErrorAlert, showSilentSuccessAlert, showSuccessAlert } from "@/utils/alerts";
-import { safeLogError, safeLogInfo, safeLogWarn } from "@/utils/safeLogger";
 
 interface UseBookingActionsParams {
   router: ReturnType<typeof useRouter>;
@@ -69,26 +68,6 @@ export const useBookingActions = ({
 
   // Selected booking for actions modal
   const [selectedBooking, setSelectedBooking] = useState<Booking | null>(null);
-
-  const getActionLogContext = (booking: Booking, extra?: Record<string, unknown>) => ({
-    bookingUid: booking.uid,
-    bookingStatus: booking.status,
-    platform: Platform.OS,
-    isConfirming,
-    isDeclining,
-    ...extra,
-  });
-
-  const getActionErrorDiagnostics = (error: unknown) => {
-    if (error instanceof Error) {
-      return {
-        name: error.name,
-        message: error.message,
-      };
-    }
-
-    return { error };
-  };
 
   /**
    * Navigate to booking detail page
@@ -348,29 +327,18 @@ export const useBookingActions = ({
    * Show alert and confirm booking
    */
   const handleConfirmBooking = (booking: Booking) => {
-    safeLogInfo("[useBookingActions] confirm alert opened", getActionLogContext(booking));
-
     Alert.alert("Confirm Booking", `Are you sure you want to confirm "${booking.title}"?`, [
       { text: "Cancel", style: "cancel" },
       {
         text: "Confirm",
         onPress: () => {
-          safeLogInfo("[useBookingActions] confirm alert accepted", getActionLogContext(booking));
           confirmMutation(
             { uid: booking.uid },
             {
               onSuccess: () => {
-                safeLogInfo(
-                  "[useBookingActions] confirm alert mutation succeeded",
-                  getActionLogContext(booking)
-                );
                 showSilentSuccessAlert("Success", "Booking confirmed successfully");
               },
               onError: (error) => {
-                safeLogError("[useBookingActions] confirm alert mutation failed", {
-                  ...getActionLogContext(booking),
-                  error: getActionErrorDiagnostics(error),
-                });
                 showErrorAlert("Error", error.message || "Failed to confirm booking");
               },
             }
@@ -384,7 +352,6 @@ export const useBookingActions = ({
    * Open reject modal (used by iOS for custom modal UI)
    */
   const handleOpenRejectModal = (booking: Booking) => {
-    safeLogInfo("[useBookingActions] reject modal opened", getActionLogContext(booking));
     setRejectBooking(booking);
     setRejectReason("");
     setShowRejectModal(true);
@@ -394,8 +361,6 @@ export const useBookingActions = ({
    * Show alert and reject booking (Android Alert.prompt pattern)
    */
   const handleRejectBooking = (booking: Booking) => {
-    safeLogInfo("[useBookingActions] reject alert opened", getActionLogContext(booking));
-
     Alert.alert("Decline Booking", `Are you sure you want to decline "${booking.title}"?`, [
       { text: "Cancel", style: "cancel" },
       {
@@ -411,28 +376,13 @@ export const useBookingActions = ({
               {
                 text: "OK",
                 onPress: (reason?: string) => {
-                  safeLogInfo("[useBookingActions] reject alert submitted", {
-                    ...getActionLogContext(booking),
-                    hasReason: Boolean(reason?.trim()),
-                    reasonLength: reason?.length ?? 0,
-                  });
                   declineMutation(
                     { uid: booking.uid, reason: reason || undefined },
                     {
                       onSuccess: () => {
-                        safeLogInfo(
-                          "[useBookingActions] reject alert mutation succeeded",
-                          getActionLogContext(booking)
-                        );
                         showSilentSuccessAlert("Success", "Booking declined successfully");
                       },
                       onError: (error) => {
-                        safeLogError("[useBookingActions] reject alert mutation failed", {
-                          ...getActionLogContext(booking),
-                          hasReason: Boolean(reason?.trim()),
-                          reasonLength: reason?.length ?? 0,
-                          error: getActionErrorDiagnostics(error),
-                        });
                         showErrorAlert("Error", error.message || "Failed to decline booking");
                       },
                     }
@@ -454,44 +404,22 @@ export const useBookingActions = ({
    * @param reasonOverride - Optional reason passed directly to avoid race condition with state updates
    */
   const handleSubmitReject = (reasonOverride?: string) => {
-    if (!rejectBooking) {
-      safeLogWarn("[useBookingActions] reject submit ignored; no selected booking", {
-        platform: Platform.OS,
-        hasReasonOverride: reasonOverride !== undefined,
-      });
-      return;
-    }
+    if (!rejectBooking) return;
     const booking = rejectBooking;
 
     // Use passed reason if provided, otherwise fall back to state
     const reason = reasonOverride !== undefined ? reasonOverride : rejectReason;
-    safeLogInfo("[useBookingActions] reject modal submitted", {
-      ...getActionLogContext(booking),
-      hasReason: Boolean(reason?.trim()),
-      reasonLength: reason?.length ?? 0,
-      usedReasonOverride: reasonOverride !== undefined,
-    });
 
     declineMutation(
       { uid: booking.uid, reason: reason || undefined },
       {
         onSuccess: () => {
-          safeLogInfo(
-            "[useBookingActions] reject modal mutation succeeded",
-            getActionLogContext(booking)
-          );
           setShowRejectModal(false);
           setRejectBooking(null);
           setRejectReason("");
           showSilentSuccessAlert("Success", "Booking rejected successfully");
         },
-        onError: (error) => {
-          safeLogError("[useBookingActions] reject modal mutation failed", {
-            ...getActionLogContext(booking),
-            hasReason: Boolean(reason?.trim()),
-            reasonLength: reason?.length ?? 0,
-            error: getActionErrorDiagnostics(error),
-          });
+        onError: (_error) => {
           showErrorAlert("Error", "Failed to reject booking. Please try again.");
         },
       }
@@ -511,23 +439,13 @@ export const useBookingActions = ({
    * Inline confirm handler (for use directly in JSX)
    */
   const handleInlineConfirm = (booking: Booking) => {
-    safeLogInfo("[useBookingActions] inline confirm pressed", getActionLogContext(booking));
-
     confirmMutation(
       { uid: booking.uid },
       {
         onSuccess: () => {
-          safeLogInfo(
-            "[useBookingActions] inline confirm mutation succeeded",
-            getActionLogContext(booking)
-          );
           showSilentSuccessAlert("Success", "Booking confirmed successfully");
         },
-        onError: (error) => {
-          safeLogError("[useBookingActions] inline confirm mutation failed", {
-            ...getActionLogContext(booking),
-            error: getActionErrorDiagnostics(error),
-          });
+        onError: (_error) => {
           showErrorAlert("Error", "Failed to confirm booking. Please try again.");
         },
       }

--- a/apps/mobile/hooks/useBookings.ts
+++ b/apps/mobile/hooks/useBookings.ts
@@ -230,6 +230,7 @@ export function useConfirmBooking() {
 
   return useMutation({
     mutationFn: ({ uid }: { uid: string }) => CalComAPIService.confirmBooking(uid),
+    retry: false,
     onMutate: (variables) => {
       safeLogInfo("[useConfirmBooking] mutation started", { bookingUid: variables.uid });
     },
@@ -279,6 +280,7 @@ export function useDeclineBooking() {
   return useMutation({
     mutationFn: ({ uid, reason }: { uid: string; reason?: string }) =>
       CalComAPIService.declineBooking(uid, reason),
+    retry: false,
     onMutate: (variables) => {
       safeLogInfo("[useDeclineBooking] mutation started", {
         bookingUid: variables.uid,

--- a/apps/mobile/hooks/useBookings.ts
+++ b/apps/mobile/hooks/useBookings.ts
@@ -13,18 +13,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CACHE_CONFIG, queryKeys } from "@/config/cache.config";
 import { RatingTrigger, requestRating } from "@/hooks/useAppStoreRating";
 import { type Booking, CalComAPIService } from "@/services/calcom";
-import { safeLogError, safeLogInfo } from "@/utils/safeLogger";
-
-function getMutationErrorDiagnostics(error: unknown) {
-  if (error instanceof Error) {
-    return {
-      name: error.name,
-      message: error.message,
-    };
-  }
-
-  return { error };
-}
 
 /**
  * Filter options for fetching bookings
@@ -231,16 +219,7 @@ export function useConfirmBooking() {
   return useMutation({
     mutationFn: ({ uid }: { uid: string }) => CalComAPIService.confirmBooking(uid),
     retry: false,
-    onMutate: (variables) => {
-      safeLogInfo("[useConfirmBooking] mutation started", { bookingUid: variables.uid });
-    },
-    onSuccess: (booking, variables) => {
-      safeLogInfo("[useConfirmBooking] mutation succeeded", {
-        bookingUid: variables.uid,
-        returnedUid: booking?.uid,
-        returnedStatus: booking?.status,
-      });
-
+    onSuccess: (_, variables) => {
       // Invalidate all booking queries to refetch fresh data
       queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
 
@@ -252,11 +231,7 @@ export function useConfirmBooking() {
       // Request app store rating on first booking confirmation
       requestRating(RatingTrigger.BOOKING_CONFIRMED);
     },
-    onError: (error, variables) => {
-      safeLogError("[useConfirmBooking] mutation failed", {
-        bookingUid: variables.uid,
-        error: getMutationErrorDiagnostics(error),
-      });
+    onError: (_error) => {
       console.error("Failed to confirm booking");
     },
   });
@@ -281,20 +256,7 @@ export function useDeclineBooking() {
     mutationFn: ({ uid, reason }: { uid: string; reason?: string }) =>
       CalComAPIService.declineBooking(uid, reason),
     retry: false,
-    onMutate: (variables) => {
-      safeLogInfo("[useDeclineBooking] mutation started", {
-        bookingUid: variables.uid,
-        hasReason: Boolean(variables.reason?.trim()),
-        reasonLength: variables.reason?.length ?? 0,
-      });
-    },
-    onSuccess: (booking, variables) => {
-      safeLogInfo("[useDeclineBooking] mutation succeeded", {
-        bookingUid: variables.uid,
-        returnedUid: booking?.uid,
-        returnedStatus: booking?.status,
-      });
-
+    onSuccess: (_, variables) => {
       // Invalidate all booking queries to refetch fresh data
       queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
 
@@ -306,13 +268,7 @@ export function useDeclineBooking() {
       // Request app store rating on first booking rejection
       requestRating(RatingTrigger.BOOKING_REJECTED);
     },
-    onError: (error, variables) => {
-      safeLogError("[useDeclineBooking] mutation failed", {
-        bookingUid: variables.uid,
-        hasReason: Boolean(variables.reason?.trim()),
-        reasonLength: variables.reason?.length ?? 0,
-        error: getMutationErrorDiagnostics(error),
-      });
+    onError: (_error) => {
       console.error("Failed to decline booking");
     },
   });

--- a/apps/mobile/hooks/useBookings.ts
+++ b/apps/mobile/hooks/useBookings.ts
@@ -13,6 +13,18 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CACHE_CONFIG, queryKeys } from "@/config/cache.config";
 import { RatingTrigger, requestRating } from "@/hooks/useAppStoreRating";
 import { type Booking, CalComAPIService } from "@/services/calcom";
+import { safeLogError, safeLogInfo } from "@/utils/safeLogger";
+
+function getMutationErrorDiagnostics(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+    };
+  }
+
+  return { error };
+}
 
 /**
  * Filter options for fetching bookings
@@ -218,7 +230,16 @@ export function useConfirmBooking() {
 
   return useMutation({
     mutationFn: ({ uid }: { uid: string }) => CalComAPIService.confirmBooking(uid),
-    onSuccess: (_, variables) => {
+    onMutate: (variables) => {
+      safeLogInfo("[useConfirmBooking] mutation started", { bookingUid: variables.uid });
+    },
+    onSuccess: (booking, variables) => {
+      safeLogInfo("[useConfirmBooking] mutation succeeded", {
+        bookingUid: variables.uid,
+        returnedUid: booking?.uid,
+        returnedStatus: booking?.status,
+      });
+
       // Invalidate all booking queries to refetch fresh data
       queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
 
@@ -230,7 +251,11 @@ export function useConfirmBooking() {
       // Request app store rating on first booking confirmation
       requestRating(RatingTrigger.BOOKING_CONFIRMED);
     },
-    onError: (_error) => {
+    onError: (error, variables) => {
+      safeLogError("[useConfirmBooking] mutation failed", {
+        bookingUid: variables.uid,
+        error: getMutationErrorDiagnostics(error),
+      });
       console.error("Failed to confirm booking");
     },
   });
@@ -254,7 +279,20 @@ export function useDeclineBooking() {
   return useMutation({
     mutationFn: ({ uid, reason }: { uid: string; reason?: string }) =>
       CalComAPIService.declineBooking(uid, reason),
-    onSuccess: (_, variables) => {
+    onMutate: (variables) => {
+      safeLogInfo("[useDeclineBooking] mutation started", {
+        bookingUid: variables.uid,
+        hasReason: Boolean(variables.reason?.trim()),
+        reasonLength: variables.reason?.length ?? 0,
+      });
+    },
+    onSuccess: (booking, variables) => {
+      safeLogInfo("[useDeclineBooking] mutation succeeded", {
+        bookingUid: variables.uid,
+        returnedUid: booking?.uid,
+        returnedStatus: booking?.status,
+      });
+
       // Invalidate all booking queries to refetch fresh data
       queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
 
@@ -266,7 +304,13 @@ export function useDeclineBooking() {
       // Request app store rating on first booking rejection
       requestRating(RatingTrigger.BOOKING_REJECTED);
     },
-    onError: (_error) => {
+    onError: (error, variables) => {
+      safeLogError("[useDeclineBooking] mutation failed", {
+        bookingUid: variables.uid,
+        hasReason: Boolean(variables.reason?.trim()),
+        reasonLength: variables.reason?.length ?? 0,
+        error: getMutationErrorDiagnostics(error),
+      });
       console.error("Failed to decline booking");
     },
   });

--- a/apps/mobile/hooks/useWidgetSync.ts
+++ b/apps/mobile/hooks/useWidgetSync.ts
@@ -15,14 +15,7 @@ export function useWidgetSync() {
   const { isAuthenticated } = useAuth();
 
   const syncBookingsToWidget = useCallback(async () => {
-    if (__DEV__) {
-      console.log("[Widget Debug] syncBookingsToWidget called, Platform:", Platform.OS);
-    }
-
     if (Platform.OS === "web") {
-      if (__DEV__) {
-        console.log("[Widget Debug] Skipping - web platform");
-      }
       return;
     }
 
@@ -38,14 +31,6 @@ export function useWidgetSync() {
     let cachedBookings: Booking[] | undefined;
     for (const filters of possibleFilters) {
       const cached = queryClient.getQueryData<Booking[]>(queryKeys.bookings.list(filters));
-      if (__DEV__) {
-        console.log(
-          "[Widget Debug] Checking cache for filters:",
-          JSON.stringify(filters),
-          "found:",
-          cached?.length ?? 0
-        );
-      }
       if (cached !== undefined && cached.length > 0) {
         cachedBookings = cached;
         break;
@@ -53,20 +38,6 @@ export function useWidgetSync() {
     }
 
     if (cachedBookings !== undefined && cachedBookings.length > 0) {
-      if (__DEV__) {
-        console.log("[Widget Debug] Using cached bookings, count:", cachedBookings.length);
-        console.log("[Widget Debug] Current time (UTC):", new Date().toISOString());
-      }
-
-      // Log each booking's times for debugging - check both property name formats
-      if (__DEV__) {
-        cachedBookings.slice(0, 3).forEach((booking, i) => {
-          console.log(
-            `[Widget Debug] Booking ${i}: startTime=${booking.startTime}, start=${booking.start}, endTime=${booking.endTime}, end=${booking.end}`
-          );
-        });
-      }
-
       try {
         // Filter bookings that haven't ended yet (includes ongoing meetings)
         // Sort by start time to show soonest first
@@ -75,19 +46,10 @@ export function useWidgetSync() {
           .filter((booking) => {
             const endTimeStr = booking.endTime || booking.end;
             if (!endTimeStr) {
-              if (__DEV__) {
-                console.log(`[Widget Debug] Booking ${booking.id}: No end time found, skipping`);
-              }
               return false;
             }
             const endTime = new Date(endTimeStr);
-            const isUpcoming = endTime > new Date();
-            if (__DEV__) {
-              console.log(
-                `[Widget Debug] Booking ${booking.id}: endTime=${endTime.toISOString()}, isUpcoming=${isUpcoming}`
-              );
-            }
-            return isUpcoming;
+            return endTime > new Date();
           })
           .sort((a, b) => {
             const aStart = new Date(a.startTime || a.start || "").getTime();
@@ -95,27 +57,17 @@ export function useWidgetSync() {
             return aStart - bStart;
           });
 
-        if (__DEV__) {
-          console.log("[Widget Debug] Filtered upcoming bookings, count:", upcomingBookings.length);
-        }
         await updateWidgetBookings(upcomingBookings);
       } catch (error) {
         console.warn("Failed to sync cached bookings to widget:", error);
       }
     } else {
       // No cached data found, fetch from API
-      if (__DEV__) {
-        console.log("[Widget Debug] No cached data, fetching from API...");
-      }
       try {
         const bookings = await CalComAPIService.getBookings({
           status: ["upcoming"],
           limit: 10,
         });
-
-        if (__DEV__) {
-          console.log("[Widget Debug] API returned bookings, count:", bookings.length);
-        }
 
         // Filter bookings that haven't ended yet (includes ongoing meetings)
         const upcomingBookings = bookings
@@ -125,12 +77,6 @@ export function useWidgetSync() {
           })
           .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
 
-        if (__DEV__) {
-          console.log(
-            "[Widget Debug] Filtered upcoming bookings from API, count:",
-            upcomingBookings.length
-          );
-        }
         await updateWidgetBookings(upcomingBookings);
       } catch (error) {
         console.warn("Failed to fetch and sync bookings to widget:", error);

--- a/apps/mobile/services/calcom/auth.ts
+++ b/apps/mobile/services/calcom/auth.ts
@@ -32,6 +32,47 @@ type RefreshResult = { accessToken: string; refreshToken?: string; expiresAt?: n
 // refresh token so parallel 401s trigger exactly one network refresh.
 let inFlightRefresh: { refreshToken: string; promise: Promise<RefreshResult> } | null = null;
 
+// Monotonic auth session generation ("epoch"). Bumped on every logout/clear and
+// on every new login/account switch. In-flight refreshes and requests capture
+// the generation when they start; if it changes before they finish, the session
+// they belonged to is gone, so their results must be discarded rather than
+// applied — otherwise a stale refresh could resurrect a logged-out identity or
+// a stale request could replay under a different user. A plain token-string
+// comparison can't tell "same session refreshed" apart from "logged out and
+// back in"; the generation can.
+let authGeneration = 0;
+
+/**
+ * Error thrown when an in-flight refresh resolves after the auth session it
+ * belonged to has been replaced (logout or account switch). Callers should
+ * abort rather than retry under the new identity.
+ */
+export class AuthSessionChangedError extends Error {
+  constructor() {
+    super("Auth session changed before the refresh completed.");
+    this.name = "AuthSessionChangedError";
+  }
+}
+
+/**
+ * Current auth session generation. Capture this when a request/refresh starts
+ * and re-check it before applying any result.
+ */
+export function getAuthGeneration(): number {
+  return authGeneration;
+}
+
+/**
+ * Begin a new auth session generation. Call at the start of every login /
+ * account switch so any in-flight work from the previous identity is
+ * invalidated. Returns the new generation.
+ */
+export function beginAuthGeneration(): number {
+  authGeneration += 1;
+  inFlightRefresh = null;
+  return authGeneration;
+}
+
 /**
  * Set OAuth access token for authentication
  */
@@ -65,6 +106,9 @@ export function clearAuth(): void {
   authConfig.accessToken = undefined;
   authConfig.refreshToken = undefined;
   inFlightRefresh = null;
+  // Advance the epoch so any in-flight refresh/request from this session is
+  // discarded instead of being applied after logout.
+  authGeneration += 1;
 }
 
 /**
@@ -94,9 +138,16 @@ export function refreshAuthTokensSingleFlight(refreshToken: string): Promise<Ref
     return Promise.reject(new Error("No refresh token function configured."));
   }
   const onTokensRefreshed = tokenRefreshCallback;
+  const generationAtStart = authGeneration;
 
   const promise = (async () => {
     const newTokens = await refreshFn(refreshToken);
+    // The session was logged out or switched while the refresh was in flight.
+    // Applying these tokens now would resurrect the previous identity, so
+    // discard the result and let the caller abort.
+    if (authGeneration !== generationAtStart) {
+      throw new AuthSessionChangedError();
+    }
     authConfig.accessToken = newTokens.accessToken;
     if (newTokens.refreshToken) {
       authConfig.refreshToken = newTokens.refreshToken;

--- a/apps/mobile/services/calcom/auth.ts
+++ b/apps/mobile/services/calcom/auth.ts
@@ -18,11 +18,19 @@ let tokenRefreshCallback:
 
 // Refresh token function - will be set by AuthContext
 let refreshTokenFunction:
-  | ((refreshToken: string) => Promise<{ accessToken: string; refreshToken?: string; expiresAt?: number }>)
+  | ((
+      refreshToken: string
+    ) => Promise<{ accessToken: string; refreshToken?: string; expiresAt?: number }>)
   | null = null;
 
 // Auth failure callback - invoked when 401 + refresh failure leaves the app in a zombie session
 let authFailureCallback: (() => Promise<void>) | null = null;
+
+type RefreshResult = { accessToken: string; refreshToken?: string; expiresAt?: number };
+
+// Single-flight refresh state: dedupe concurrent refreshes for the same
+// refresh token so parallel 401s trigger exactly one network refresh.
+let inFlightRefresh: { refreshToken: string; promise: Promise<RefreshResult> } | null = null;
 
 /**
  * Set OAuth access token for authentication
@@ -38,20 +46,78 @@ export function setAccessToken(accessToken: string, refreshToken?: string): void
  * Set refresh token function for automatic token refresh
  */
 export function setRefreshTokenFunction(
-  refreshFn: (refreshToken: string) => Promise<{ accessToken: string; refreshToken?: string; expiresAt?: number }>
+  refreshFn: (
+    refreshToken: string
+  ) => Promise<{ accessToken: string; refreshToken?: string; expiresAt?: number }>
 ): void {
   refreshTokenFunction = refreshFn;
 }
 
 /**
- * Clear all authentication
+ * Clear authentication token state (access + refresh tokens).
+ *
+ * Deliberately does NOT clear the callback functions: a 401-driven logout or a
+ * normal logout must not erase the mounted AuthProvider's callbacks, otherwise
+ * a subsequent login -> 401 could not refresh (the refresh path requires
+ * `tokenRefreshCallback`). Use `clearAuthCallbacks()` on provider unmount.
  */
 export function clearAuth(): void {
   authConfig.accessToken = undefined;
   authConfig.refreshToken = undefined;
+  inFlightRefresh = null;
+}
+
+/**
+ * Clear the auth callback functions. Only the AuthProvider should call this,
+ * and only on unmount — not on logout or 401 recovery.
+ */
+export function clearAuthCallbacks(): void {
   tokenRefreshCallback = null;
   refreshTokenFunction = null;
   authFailureCallback = null;
+  inFlightRefresh = null;
+}
+
+/**
+ * Refresh the auth tokens, coalescing concurrent callers that share the same
+ * refresh token into a single network refresh (single-flight). On success the
+ * in-memory auth config is updated and the token-refresh callback is notified
+ * so AuthContext can persist the new tokens.
+ */
+export function refreshAuthTokensSingleFlight(refreshToken: string): Promise<RefreshResult> {
+  if (inFlightRefresh && inFlightRefresh.refreshToken === refreshToken) {
+    return inFlightRefresh.promise;
+  }
+
+  const refreshFn = refreshTokenFunction;
+  if (!refreshFn) {
+    return Promise.reject(new Error("No refresh token function configured."));
+  }
+  const onTokensRefreshed = tokenRefreshCallback;
+
+  const promise = (async () => {
+    const newTokens = await refreshFn(refreshToken);
+    authConfig.accessToken = newTokens.accessToken;
+    if (newTokens.refreshToken) {
+      authConfig.refreshToken = newTokens.refreshToken;
+    }
+    // Notify AuthContext to persist the new tokens (including expiresAt for
+    // proactive refresh).
+    if (onTokensRefreshed) {
+      await onTokensRefreshed(newTokens.accessToken, newTokens.refreshToken, newTokens.expiresAt);
+    }
+    return newTokens;
+  })();
+
+  inFlightRefresh = { refreshToken, promise };
+  void promise
+    .catch(() => undefined)
+    .finally(() => {
+      if (inFlightRefresh?.promise === promise) {
+        inFlightRefresh = null;
+      }
+    });
+  return promise;
 }
 
 /**

--- a/apps/mobile/services/calcom/auth.ts
+++ b/apps/mobile/services/calcom/auth.ts
@@ -62,6 +62,29 @@ export function getAuthGeneration(): number {
   return authGeneration;
 }
 
+// Serial queue that makes auth/storage marker mutations atomic with respect to
+// one another. The epoch checks guard the *network-await* windows; this guards
+// the *storage read-modify-write* windows that no epoch recheck can close (e.g.
+// a rollback reading `cal_auth_type` and then removing it while a web-session
+// login writes "web_session" in between). Sections passed here MUST be short,
+// MUST NOT perform network I/O, and MUST NOT call runAuthTransition again
+// (nesting would self-deadlock the queue).
+let authTransitionChain: Promise<unknown> = Promise.resolve();
+
+/**
+ * Run a storage/auth-marker critical section exclusively, serialized against
+ * every other such section. See the constraints on `authTransitionChain` above.
+ */
+export function runAuthTransition<T>(section: () => Promise<T>): Promise<T> {
+  const result = authTransitionChain.then(section, section);
+  // Keep the chain alive regardless of this section's outcome.
+  authTransitionChain = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
+}
+
 /**
  * Begin a new auth session generation. Call at the start of every login /
  * account switch so any in-flight work from the previous identity is

--- a/apps/mobile/services/calcom/auth.ts
+++ b/apps/mobile/services/calcom/auth.ts
@@ -74,6 +74,19 @@ export function beginAuthGeneration(): number {
 }
 
 /**
+ * Advance the auth generation WITHOUT clearing the current tokens. Call at the
+ * very start of logout: pre-logout cleanup (e.g. push deregistration) still
+ * needs a valid Bearer token, but any refresh/request/registration that
+ * resolves during the (potentially slow) logout sequence must be treated as
+ * belonging to a now-dead session rather than applied. `clearAuth()` advances
+ * the generation again once the tokens are actually cleared.
+ */
+export function invalidateAuthSession(): void {
+  authGeneration += 1;
+  inFlightRefresh = null;
+}
+
+/**
  * Set OAuth access token for authentication
  */
 export function setAccessToken(accessToken: string, refreshToken?: string): void {

--- a/apps/mobile/services/calcom/auth.ts
+++ b/apps/mobile/services/calcom/auth.ts
@@ -75,6 +75,14 @@ let authTransitionChain: Promise<unknown> = Promise.resolve();
 // nesting mistake (a section directly calling runAuthTransition) without
 // false-positiving legitimate concurrent callers: a section's sync prefix can't
 // be interrupted, so any caller observing this flag set is nesting.
+//
+// This deliberately does NOT stay set across the section's own awaits: a
+// legitimate concurrent caller calls runAuthTransition synchronously while
+// another section is mid-await, and must be allowed to queue (not throw).
+// The cost is that async re-entry (a section awaiting, then re-calling
+// runAuthTransition) isn't caught and would deadlock — but no section does that
+// (sections are tiny storage writes that never re-enter), and catching it would
+// require AsyncLocalStorage context tracking, which isn't warranted here.
 let inSectionSyncPrefix = false;
 
 /**

--- a/apps/mobile/services/calcom/auth.ts
+++ b/apps/mobile/services/calcom/auth.ts
@@ -71,12 +71,31 @@ export function getAuthGeneration(): number {
 // (nesting would self-deadlock the queue).
 let authTransitionChain: Promise<unknown> = Promise.resolve();
 
+// True only while a section's synchronous prefix runs. Used to catch the common
+// nesting mistake (a section directly calling runAuthTransition) without
+// false-positiving legitimate concurrent callers: a section's sync prefix can't
+// be interrupted, so any caller observing this flag set is nesting.
+let inSectionSyncPrefix = false;
+
 /**
  * Run a storage/auth-marker critical section exclusively, serialized against
  * every other such section. See the constraints on `authTransitionChain` above.
  */
 export function runAuthTransition<T>(section: () => Promise<T>): Promise<T> {
-  const result = authTransitionChain.then(section, section);
+  if (inSectionSyncPrefix) {
+    throw new Error(
+      "runAuthTransition must not be called from within another auth-transition section (nesting would self-deadlock the serial queue)."
+    );
+  }
+  const guarded = (): Promise<T> => {
+    inSectionSyncPrefix = true;
+    try {
+      return section();
+    } finally {
+      inSectionSyncPrefix = false;
+    }
+  };
+  const result = authTransitionChain.then(guarded, guarded);
   // Keep the chain alive regardless of this section's outcome.
   authTransitionChain = result.then(
     () => undefined,

--- a/apps/mobile/services/calcom/bookings.ts
+++ b/apps/mobile/services/calcom/bookings.ts
@@ -24,6 +24,17 @@ import type {
 import { makeRequest } from "./request";
 import { getUserProfile } from "./user";
 
+function getBookingErrorDiagnostics(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+    };
+  }
+
+  return { error };
+}
+
 /**
  * Determine user's participation role in a booking
  */
@@ -264,6 +275,8 @@ export async function rescheduleBooking(
  */
 export async function confirmBooking(bookingUid: string): Promise<Booking> {
   try {
+    safeLogInfo("[CalComAPIService] confirmBooking request", { bookingUid });
+
     const response = await makeRequest<{ status: string; data: Booking }>(
       `/bookings/${bookingUid}/confirm`,
       {
@@ -277,12 +290,20 @@ export async function confirmBooking(bookingUid: string): Promise<Booking> {
     );
 
     if (response?.data) {
+      safeLogInfo("[CalComAPIService] confirmBooking success", {
+        bookingUid,
+        returnedUid: response.data.uid,
+        returnedStatus: response.data.status,
+      });
       return response.data;
     }
 
     throw new Error("Invalid response from confirm booking API");
   } catch (error) {
-    safeLogError("confirmBooking error", { error, bookingUid });
+    safeLogError("[CalComAPIService] confirmBooking error", {
+      bookingUid,
+      error: getBookingErrorDiagnostics(error),
+    });
     throw error;
   }
 }
@@ -296,6 +317,12 @@ export async function declineBooking(bookingUid: string, reason?: string): Promi
     if (reason) {
       body.reason = reason;
     }
+
+    safeLogInfo("[CalComAPIService] declineBooking request", {
+      bookingUid,
+      hasReason: Boolean(reason?.trim()),
+      reasonLength: reason?.length ?? 0,
+    });
 
     const response = await makeRequest<{ status: string; data: Booking }>(
       `/bookings/${bookingUid}/decline`,
@@ -311,12 +338,22 @@ export async function declineBooking(bookingUid: string, reason?: string): Promi
     );
 
     if (response?.data) {
+      safeLogInfo("[CalComAPIService] declineBooking success", {
+        bookingUid,
+        returnedUid: response.data.uid,
+        returnedStatus: response.data.status,
+      });
       return response.data;
     }
 
     throw new Error("Invalid response from decline booking API");
   } catch (error) {
-    console.error("declineBooking error");
+    safeLogError("[CalComAPIService] declineBooking error", {
+      bookingUid,
+      hasReason: Boolean(reason?.trim()),
+      reasonLength: reason?.length ?? 0,
+      error: getBookingErrorDiagnostics(error),
+    });
     throw error;
   }
 }

--- a/apps/mobile/services/calcom/bookings.ts
+++ b/apps/mobile/services/calcom/bookings.ts
@@ -275,8 +275,6 @@ export async function rescheduleBooking(
  */
 export async function confirmBooking(bookingUid: string): Promise<Booking> {
   try {
-    safeLogInfo("[CalComAPIService] confirmBooking request", { bookingUid });
-
     const response = await makeRequest<{ status: string; data: Booking }>(
       `/bookings/${bookingUid}/confirm`,
       {
@@ -290,11 +288,6 @@ export async function confirmBooking(bookingUid: string): Promise<Booking> {
     );
 
     if (response?.data) {
-      safeLogInfo("[CalComAPIService] confirmBooking success", {
-        bookingUid,
-        returnedUid: response.data.uid,
-        returnedStatus: response.data.status,
-      });
       return response.data;
     }
 
@@ -318,12 +311,6 @@ export async function declineBooking(bookingUid: string, reason?: string): Promi
       body.reason = reason;
     }
 
-    safeLogInfo("[CalComAPIService] declineBooking request", {
-      bookingUid,
-      hasReason: Boolean(reason?.trim()),
-      reasonLength: reason?.length ?? 0,
-    });
-
     const response = await makeRequest<{ status: string; data: Booking }>(
       `/bookings/${bookingUid}/decline`,
       {
@@ -338,11 +325,6 @@ export async function declineBooking(bookingUid: string, reason?: string): Promi
     );
 
     if (response?.data) {
-      safeLogInfo("[CalComAPIService] declineBooking success", {
-        bookingUid,
-        returnedUid: response.data.uid,
-        returnedStatus: response.data.status,
-      });
       return response.data;
     }
 

--- a/apps/mobile/services/calcom/index.ts
+++ b/apps/mobile/services/calcom/index.ts
@@ -43,6 +43,7 @@ import {
   clearAuthCallbacks,
   getAuthGeneration,
   invalidateAuthSession,
+  runAuthTransition,
   setAccessToken,
   setAuthFailureCallback,
   setRefreshTokenFunction,
@@ -121,6 +122,7 @@ export const CalComAPIService = {
   beginAuthGeneration,
   getAuthGeneration,
   invalidateAuthSession,
+  runAuthTransition,
 
   // User
   getCurrentUser,

--- a/apps/mobile/services/calcom/index.ts
+++ b/apps/mobile/services/calcom/index.ts
@@ -38,8 +38,10 @@ export type {
 
 // Import all functions from submodules
 import {
+  beginAuthGeneration,
   clearAuth,
   clearAuthCallbacks,
+  getAuthGeneration,
   setAccessToken,
   setAuthFailureCallback,
   setRefreshTokenFunction,
@@ -115,6 +117,8 @@ export const CalComAPIService = {
   clearAuthCallbacks,
   setTokenRefreshCallback,
   setAuthFailureCallback,
+  beginAuthGeneration,
+  getAuthGeneration,
 
   // User
   getCurrentUser,

--- a/apps/mobile/services/calcom/index.ts
+++ b/apps/mobile/services/calcom/index.ts
@@ -42,6 +42,7 @@ import {
   clearAuth,
   clearAuthCallbacks,
   getAuthGeneration,
+  invalidateAuthSession,
   setAccessToken,
   setAuthFailureCallback,
   setRefreshTokenFunction,
@@ -119,6 +120,7 @@ export const CalComAPIService = {
   setAuthFailureCallback,
   beginAuthGeneration,
   getAuthGeneration,
+  invalidateAuthSession,
 
   // User
   getCurrentUser,

--- a/apps/mobile/services/calcom/index.ts
+++ b/apps/mobile/services/calcom/index.ts
@@ -39,6 +39,7 @@ export type {
 // Import all functions from submodules
 import {
   clearAuth,
+  clearAuthCallbacks,
   setAccessToken,
   setAuthFailureCallback,
   setRefreshTokenFunction,
@@ -111,6 +112,7 @@ export const CalComAPIService = {
   setAccessToken,
   setRefreshTokenFunction,
   clearAuth,
+  clearAuthCallbacks,
   setTokenRefreshCallback,
   setAuthFailureCallback,
 

--- a/apps/mobile/services/calcom/notifications.ts
+++ b/apps/mobile/services/calcom/notifications.ts
@@ -26,11 +26,17 @@ export async function registerAppPushSubscription(
 
 export async function removeAppPushSubscription(token: string): Promise<{ status: string }> {
   try {
-    return await makeRequest<{ status: string }>("/notifications/subscriptions/app-push", {
-      method: "DELETE",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ token }),
-    });
+    return await makeRequest<{ status: string }>(
+      "/notifications/subscriptions/app-push",
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      },
+      "2024-08-13",
+      false,
+      { skipAuthFailure: true }
+    );
   } catch (error) {
     console.error("removeAppPushSubscription error");
     throw error;

--- a/apps/mobile/services/calcom/request.ts
+++ b/apps/mobile/services/calcom/request.ts
@@ -13,6 +13,7 @@ import {
   getAuthHeader,
   getRefreshTokenFunction,
   getTokenRefreshCallback,
+  refreshAuthTokensSingleFlight,
 } from "./auth";
 import { safeParseErrorJson, safeParseJson } from "./utils";
 
@@ -72,6 +73,10 @@ export async function makeRequest<T>(
   isRetry: boolean = false
 ): Promise<T> {
   const url = `${getApiBaseUrl()}${endpoint}`;
+  // Capture the access token this request used so that, on a 401, we can tell
+  // whether a parallel request already refreshed it (in which case we just
+  // retry rather than refresh again or tear down a now-valid session).
+  const accessTokenAtRequest = getAuthConfig().accessToken;
 
   const response = await fetchWithTimeout(
     url,
@@ -104,28 +109,30 @@ export async function makeRequest<T>(
     // Handle specific error cases
     if (response.status === 401) {
       const authConfig = getAuthConfig();
+
+      // A parallel request already refreshed the access token while this one
+      // was in flight — retry with the new token instead of refreshing again.
+      if (!isRetry && authConfig.accessToken && authConfig.accessToken !== accessTokenAtRequest) {
+        return makeRequest<T>(endpoint, options, apiVersion, true);
+      }
+
+      const refreshToken = authConfig.refreshToken;
       const refreshTokenFunction = getRefreshTokenFunction();
       const tokenRefreshCallback = getTokenRefreshCallback();
 
-      if (!isRetry && authConfig.refreshToken && refreshTokenFunction && tokenRefreshCallback) {
+      if (!isRetry && refreshToken && refreshTokenFunction && tokenRefreshCallback) {
         try {
-          const newTokens = await refreshTokenFunction(authConfig.refreshToken);
-
-          authConfig.accessToken = newTokens.accessToken;
-          if (newTokens.refreshToken) {
-            authConfig.refreshToken = newTokens.refreshToken;
-          }
-
-          // Notify AuthContext to update stored tokens (including expiresAt for proactive refresh)
-          await tokenRefreshCallback(
-            newTokens.accessToken,
-            newTokens.refreshToken,
-            newTokens.expiresAt
-          );
-
-          // Retry the original request with the new token
+          // Single-flight: concurrent 401s sharing this refresh token coalesce
+          // into one network refresh.
+          await refreshAuthTokensSingleFlight(refreshToken);
+          // Retry the original request with the new token.
           return makeRequest<T>(endpoint, options, apiVersion, true);
         } catch (refreshError) {
+          // If another request refreshed successfully while ours lost the race,
+          // don't log out a now-valid session — retry instead.
+          if (getAuthConfig().accessToken && getAuthConfig().accessToken !== accessTokenAtRequest) {
+            return makeRequest<T>(endpoint, options, apiVersion, true);
+          }
           safeLogError("Token refresh failed:", refreshError);
           const onAuthFailure = getAuthFailureCallback();
           clearAuth();

--- a/apps/mobile/services/calcom/request.ts
+++ b/apps/mobile/services/calcom/request.ts
@@ -157,8 +157,14 @@ export async function makeRequest<T>(
           // into one network refresh.
           await refreshAuthTokensSingleFlight(refreshToken);
         } catch (refreshError) {
-          // The refresh resolved into a different session (logout/switch) — abort.
-          if (refreshError instanceof AuthSessionChangedError) {
+          // The session was logged out or switched while the refresh was in
+          // flight (the refresh threw, or resolved into a different session).
+          // Abort WITHOUT logging out — clearing auth here would tear down the
+          // new, valid session because this stale request finished late.
+          if (
+            refreshError instanceof AuthSessionChangedError ||
+            getAuthGeneration() !== generationAtRequest
+          ) {
             throw new ApiRequestError(
               response.status,
               `API Error: ${response.status} ${errorMessage}`

--- a/apps/mobile/services/calcom/request.ts
+++ b/apps/mobile/services/calcom/request.ts
@@ -4,7 +4,7 @@
 
 import { fetchWithTimeout } from "@/utils/network";
 import { getCalApiUrl } from "@/utils/region";
-import { safeLogError } from "@/utils/safeLogger";
+import { safeLogError, safeLogInfo, safeLogWarn } from "@/utils/safeLogger";
 
 import {
   AuthSessionChangedError,
@@ -43,6 +43,47 @@ export class ApiRequestError extends Error {
 }
 
 export const REQUEST_TIMEOUT_MS = 30000;
+
+function getRequestAuthDiagnostics({
+  endpoint,
+  method,
+  apiVersion,
+  isRetry,
+  responseStatus,
+  generationAtRequest,
+  accessTokenAtRequest,
+}: {
+  endpoint: string;
+  method?: string;
+  apiVersion: string;
+  isRetry: boolean;
+  responseStatus: number;
+  generationAtRequest: number;
+  accessTokenAtRequest?: string;
+}) {
+  const authConfig = getAuthConfig();
+  const currentGeneration = getAuthGeneration();
+
+  return {
+    endpoint,
+    method: method || "GET",
+    apiVersion,
+    isRetry,
+    responseStatus,
+    generationAtRequest,
+    currentGeneration,
+    generationChanged: currentGeneration !== generationAtRequest,
+    hadAccessTokenAtRequest: Boolean(accessTokenAtRequest),
+    hasCurrentAccessToken: Boolean(authConfig.accessToken),
+    accessTokenChanged: Boolean(
+      authConfig.accessToken && authConfig.accessToken !== accessTokenAtRequest
+    ),
+    hasRefreshToken: Boolean(authConfig.refreshToken),
+    hasRefreshTokenFunction: Boolean(getRefreshTokenFunction()),
+    hasTokenRefreshCallback: Boolean(getTokenRefreshCallback()),
+    hasAuthFailureCallback: Boolean(getAuthFailureCallback()),
+  };
+}
 
 /**
  * Test function for bookings API specifically
@@ -132,11 +173,26 @@ export async function makeRequest<T>(
     // Handle specific error cases
     if (response.status === 401) {
       const authConfig = getAuthConfig();
+      const diagnostics = getRequestAuthDiagnostics({
+        endpoint,
+        method: options.method,
+        apiVersion,
+        isRetry,
+        responseStatus: response.status,
+        generationAtRequest,
+        accessTokenAtRequest,
+      });
+
+      safeLogWarn("[CalComAPIService] 401 response", diagnostics);
 
       // The session was logged out or switched while this request was in flight.
       // Abort instead of retrying — a retry would send this request under the
       // new identity's credentials.
       if (getAuthGeneration() !== generationAtRequest) {
+        safeLogWarn(
+          "[CalComAPIService] 401 belongs to stale auth generation; aborting",
+          diagnostics
+        );
         throw new ApiRequestError(response.status, `API Error: ${response.status} ${errorMessage}`);
       }
 
@@ -144,6 +200,10 @@ export async function makeRequest<T>(
       // was in flight (same session) — retry with the new token instead of
       // refreshing again.
       if (!isRetry && authConfig.accessToken && authConfig.accessToken !== accessTokenAtRequest) {
+        safeLogInfo(
+          "[CalComAPIService] 401 retrying with token refreshed by parallel request",
+          diagnostics
+        );
         return makeRequest<T>(endpoint, options, apiVersion, true);
       }
 
@@ -153,6 +213,7 @@ export async function makeRequest<T>(
 
       if (!isRetry && refreshToken && refreshTokenFunction && tokenRefreshCallback) {
         try {
+          safeLogInfo("[CalComAPIService] 401 attempting token refresh", diagnostics);
           // Single-flight: concurrent 401s sharing this refresh token coalesce
           // into one network refresh.
           await refreshAuthTokensSingleFlight(refreshToken);
@@ -165,6 +226,10 @@ export async function makeRequest<T>(
             refreshError instanceof AuthSessionChangedError ||
             getAuthGeneration() !== generationAtRequest
           ) {
+            safeLogWarn(
+              "[CalComAPIService] token refresh resolved after auth generation changed; aborting",
+              diagnostics
+            );
             throw new ApiRequestError(
               response.status,
               `API Error: ${response.status} ${errorMessage}`
@@ -177,9 +242,17 @@ export async function makeRequest<T>(
             getAuthConfig().accessToken &&
             getAuthConfig().accessToken !== accessTokenAtRequest
           ) {
+            safeLogInfo(
+              "[CalComAPIService] token refresh race resolved by another request; retrying",
+              diagnostics
+            );
             return makeRequest<T>(endpoint, options, apiVersion, true);
           }
-          safeLogError("Token refresh failed:", refreshError);
+          safeLogError("[CalComAPIService] token refresh failed", {
+            diagnostics,
+            error: refreshError,
+          });
+          safeLogWarn("[CalComAPIService] clearing auth after failed token refresh", diagnostics);
           const onAuthFailure = getAuthFailureCallback();
           clearAuth();
           // Trigger full logout so AuthContext resets isAuthenticated
@@ -191,15 +264,24 @@ export async function makeRequest<T>(
         // and must not be torn down because this stale request finished late.
         // (Checked outside the try so it isn't mistaken for a refresh failure.)
         if (getAuthGeneration() !== generationAtRequest) {
+          safeLogWarn(
+            "[CalComAPIService] refresh completed after auth generation changed; aborting retry",
+            diagnostics
+          );
           throw new ApiRequestError(
             response.status,
             `API Error: ${response.status} ${errorMessage}`
           );
         }
         // Retry the original request with the new token.
+        safeLogInfo("[CalComAPIService] token refresh succeeded; retrying original request", {
+          ...diagnostics,
+          currentGeneration: getAuthGeneration(),
+        });
         return makeRequest<T>(endpoint, options, apiVersion, true);
       }
 
+      safeLogWarn("[CalComAPIService] 401 has no refresh path; clearing auth", diagnostics);
       const onAuthFailure = getAuthFailureCallback();
       clearAuth();
       await onAuthFailure?.();

--- a/apps/mobile/services/calcom/request.ts
+++ b/apps/mobile/services/calcom/request.ts
@@ -156,16 +156,6 @@ export async function makeRequest<T>(
           // Single-flight: concurrent 401s sharing this refresh token coalesce
           // into one network refresh.
           await refreshAuthTokensSingleFlight(refreshToken);
-          // The session changed across the refresh — don't retry under the new
-          // identity.
-          if (getAuthGeneration() !== generationAtRequest) {
-            throw new ApiRequestError(
-              response.status,
-              `API Error: ${response.status} ${errorMessage}`
-            );
-          }
-          // Retry the original request with the new token.
-          return makeRequest<T>(endpoint, options, apiVersion, true);
         } catch (refreshError) {
           // The refresh resolved into a different session (logout/switch) — abort.
           if (refreshError instanceof AuthSessionChangedError) {
@@ -190,6 +180,18 @@ export async function makeRequest<T>(
           await onAuthFailure?.();
           throw new Error("Authentication failed. Please sign in again.");
         }
+        // The session was logged out or switched across the refresh. Abort
+        // WITHOUT logging out — the current session is a new, valid identity
+        // and must not be torn down because this stale request finished late.
+        // (Checked outside the try so it isn't mistaken for a refresh failure.)
+        if (getAuthGeneration() !== generationAtRequest) {
+          throw new ApiRequestError(
+            response.status,
+            `API Error: ${response.status} ${errorMessage}`
+          );
+        }
+        // Retry the original request with the new token.
+        return makeRequest<T>(endpoint, options, apiVersion, true);
       }
 
       const onAuthFailure = getAuthFailureCallback();

--- a/apps/mobile/services/calcom/request.ts
+++ b/apps/mobile/services/calcom/request.ts
@@ -44,6 +44,10 @@ export class ApiRequestError extends Error {
 
 export const REQUEST_TIMEOUT_MS = 30000;
 
+type MakeRequestOptions = {
+  skipAuthFailure?: boolean;
+};
+
 /**
  * Test function for bookings API specifically
  */
@@ -87,7 +91,8 @@ export async function makeRequest<T>(
   endpoint: string,
   options: RequestInit = {},
   apiVersion: string = "2024-08-13",
-  isRetry: boolean = false
+  isRetry: boolean = false,
+  requestOptions: MakeRequestOptions = {}
 ): Promise<T> {
   const url = `${getApiBaseUrl()}${endpoint}`;
   // Capture the access token this request used so that, on a 401, we can tell
@@ -144,7 +149,7 @@ export async function makeRequest<T>(
       // was in flight (same session) — retry with the new token instead of
       // refreshing again.
       if (!isRetry && authConfig.accessToken && authConfig.accessToken !== accessTokenAtRequest) {
-        return makeRequest<T>(endpoint, options, apiVersion, true);
+        return makeRequest<T>(endpoint, options, apiVersion, true, requestOptions);
       }
 
       // We already refreshed once and retried with the fresh token. If the API
@@ -185,7 +190,13 @@ export async function makeRequest<T>(
             getAuthConfig().accessToken &&
             getAuthConfig().accessToken !== accessTokenAtRequest
           ) {
-            return makeRequest<T>(endpoint, options, apiVersion, true);
+            return makeRequest<T>(endpoint, options, apiVersion, true, requestOptions);
+          }
+          if (requestOptions.skipAuthFailure) {
+            throw new ApiRequestError(
+              response.status,
+              `API Error: ${response.status} ${errorMessage}`
+            );
           }
           safeLogError("Token refresh failed:", refreshError);
           const onAuthFailure = getAuthFailureCallback();
@@ -205,7 +216,11 @@ export async function makeRequest<T>(
           );
         }
         // Retry the original request with the new token.
-        return makeRequest<T>(endpoint, options, apiVersion, true);
+        return makeRequest<T>(endpoint, options, apiVersion, true, requestOptions);
+      }
+
+      if (requestOptions.skipAuthFailure) {
+        throw new ApiRequestError(response.status, `API Error: ${response.status} ${errorMessage}`);
       }
 
       const onAuthFailure = getAuthFailureCallback();

--- a/apps/mobile/services/calcom/request.ts
+++ b/apps/mobile/services/calcom/request.ts
@@ -207,6 +207,18 @@ export async function makeRequest<T>(
         return makeRequest<T>(endpoint, options, apiVersion, true);
       }
 
+      // We already refreshed once and retried with the fresh token. If the API
+      // still returns 401, treat it as an endpoint authorization failure instead
+      // of logging out the whole app. This prevents one forbidden booking action
+      // from tearing down an otherwise valid session.
+      if (isRetry) {
+        safeLogWarn(
+          "[CalComAPIService] 401 after refresh retry; preserving auth session",
+          diagnostics
+        );
+        throw new ApiRequestError(response.status, `API Error: ${response.status} ${errorMessage}`);
+      }
+
       const refreshToken = authConfig.refreshToken;
       const refreshTokenFunction = getRefreshTokenFunction();
       const tokenRefreshCallback = getTokenRefreshCallback();

--- a/apps/mobile/services/calcom/request.ts
+++ b/apps/mobile/services/calcom/request.ts
@@ -7,9 +7,11 @@ import { getCalApiUrl } from "@/utils/region";
 import { safeLogError } from "@/utils/safeLogger";
 
 import {
+  AuthSessionChangedError,
   clearAuth,
   getAuthConfig,
   getAuthFailureCallback,
+  getAuthGeneration,
   getAuthHeader,
   getRefreshTokenFunction,
   getTokenRefreshCallback,
@@ -92,6 +94,12 @@ export async function makeRequest<T>(
   // whether a parallel request already refreshed it (in which case we just
   // retry rather than refresh again or tear down a now-valid session).
   const accessTokenAtRequest = getAuthConfig().accessToken;
+  // Capture the auth session generation too. The token string alone can't
+  // distinguish "the same session refreshed" from "this session logged out and
+  // a new one logged in" — both change the token. If the generation changed,
+  // this request belongs to a dead session and must NOT be retried (retrying
+  // would replay it, possibly a mutation, under the new user's credentials).
+  const generationAtRequest = getAuthGeneration();
 
   const response = await fetchWithTimeout(
     url,
@@ -125,8 +133,16 @@ export async function makeRequest<T>(
     if (response.status === 401) {
       const authConfig = getAuthConfig();
 
+      // The session was logged out or switched while this request was in flight.
+      // Abort instead of retrying — a retry would send this request under the
+      // new identity's credentials.
+      if (getAuthGeneration() !== generationAtRequest) {
+        throw new ApiRequestError(response.status, `API Error: ${response.status} ${errorMessage}`);
+      }
+
       // A parallel request already refreshed the access token while this one
-      // was in flight — retry with the new token instead of refreshing again.
+      // was in flight (same session) — retry with the new token instead of
+      // refreshing again.
       if (!isRetry && authConfig.accessToken && authConfig.accessToken !== accessTokenAtRequest) {
         return makeRequest<T>(endpoint, options, apiVersion, true);
       }
@@ -140,12 +156,31 @@ export async function makeRequest<T>(
           // Single-flight: concurrent 401s sharing this refresh token coalesce
           // into one network refresh.
           await refreshAuthTokensSingleFlight(refreshToken);
+          // The session changed across the refresh — don't retry under the new
+          // identity.
+          if (getAuthGeneration() !== generationAtRequest) {
+            throw new ApiRequestError(
+              response.status,
+              `API Error: ${response.status} ${errorMessage}`
+            );
+          }
           // Retry the original request with the new token.
           return makeRequest<T>(endpoint, options, apiVersion, true);
         } catch (refreshError) {
-          // If another request refreshed successfully while ours lost the race,
-          // don't log out a now-valid session — retry instead.
-          if (getAuthConfig().accessToken && getAuthConfig().accessToken !== accessTokenAtRequest) {
+          // The refresh resolved into a different session (logout/switch) — abort.
+          if (refreshError instanceof AuthSessionChangedError) {
+            throw new ApiRequestError(
+              response.status,
+              `API Error: ${response.status} ${errorMessage}`
+            );
+          }
+          // If another request refreshed successfully while ours lost the race
+          // within the SAME session, don't log out a now-valid session — retry.
+          if (
+            getAuthGeneration() === generationAtRequest &&
+            getAuthConfig().accessToken &&
+            getAuthConfig().accessToken !== accessTokenAtRequest
+          ) {
             return makeRequest<T>(endpoint, options, apiVersion, true);
           }
           safeLogError("Token refresh failed:", refreshError);

--- a/apps/mobile/services/calcom/request.ts
+++ b/apps/mobile/services/calcom/request.ts
@@ -4,7 +4,7 @@
 
 import { fetchWithTimeout } from "@/utils/network";
 import { getCalApiUrl } from "@/utils/region";
-import { safeLogError, safeLogInfo, safeLogWarn } from "@/utils/safeLogger";
+import { safeLogError } from "@/utils/safeLogger";
 
 import {
   AuthSessionChangedError,
@@ -43,47 +43,6 @@ export class ApiRequestError extends Error {
 }
 
 export const REQUEST_TIMEOUT_MS = 30000;
-
-function getRequestAuthDiagnostics({
-  endpoint,
-  method,
-  apiVersion,
-  isRetry,
-  responseStatus,
-  generationAtRequest,
-  accessTokenAtRequest,
-}: {
-  endpoint: string;
-  method?: string;
-  apiVersion: string;
-  isRetry: boolean;
-  responseStatus: number;
-  generationAtRequest: number;
-  accessTokenAtRequest?: string;
-}) {
-  const authConfig = getAuthConfig();
-  const currentGeneration = getAuthGeneration();
-
-  return {
-    endpoint,
-    method: method || "GET",
-    apiVersion,
-    isRetry,
-    responseStatus,
-    generationAtRequest,
-    currentGeneration,
-    generationChanged: currentGeneration !== generationAtRequest,
-    hadAccessTokenAtRequest: Boolean(accessTokenAtRequest),
-    hasCurrentAccessToken: Boolean(authConfig.accessToken),
-    accessTokenChanged: Boolean(
-      authConfig.accessToken && authConfig.accessToken !== accessTokenAtRequest
-    ),
-    hasRefreshToken: Boolean(authConfig.refreshToken),
-    hasRefreshTokenFunction: Boolean(getRefreshTokenFunction()),
-    hasTokenRefreshCallback: Boolean(getTokenRefreshCallback()),
-    hasAuthFailureCallback: Boolean(getAuthFailureCallback()),
-  };
-}
 
 /**
  * Test function for bookings API specifically
@@ -173,26 +132,11 @@ export async function makeRequest<T>(
     // Handle specific error cases
     if (response.status === 401) {
       const authConfig = getAuthConfig();
-      const diagnostics = getRequestAuthDiagnostics({
-        endpoint,
-        method: options.method,
-        apiVersion,
-        isRetry,
-        responseStatus: response.status,
-        generationAtRequest,
-        accessTokenAtRequest,
-      });
-
-      safeLogWarn("[CalComAPIService] 401 response", diagnostics);
 
       // The session was logged out or switched while this request was in flight.
       // Abort instead of retrying — a retry would send this request under the
       // new identity's credentials.
       if (getAuthGeneration() !== generationAtRequest) {
-        safeLogWarn(
-          "[CalComAPIService] 401 belongs to stale auth generation; aborting",
-          diagnostics
-        );
         throw new ApiRequestError(response.status, `API Error: ${response.status} ${errorMessage}`);
       }
 
@@ -200,10 +144,6 @@ export async function makeRequest<T>(
       // was in flight (same session) — retry with the new token instead of
       // refreshing again.
       if (!isRetry && authConfig.accessToken && authConfig.accessToken !== accessTokenAtRequest) {
-        safeLogInfo(
-          "[CalComAPIService] 401 retrying with token refreshed by parallel request",
-          diagnostics
-        );
         return makeRequest<T>(endpoint, options, apiVersion, true);
       }
 
@@ -212,10 +152,6 @@ export async function makeRequest<T>(
       // of logging out the whole app. This prevents one forbidden booking action
       // from tearing down an otherwise valid session.
       if (isRetry) {
-        safeLogWarn(
-          "[CalComAPIService] 401 after refresh retry; preserving auth session",
-          diagnostics
-        );
         throw new ApiRequestError(response.status, `API Error: ${response.status} ${errorMessage}`);
       }
 
@@ -225,7 +161,6 @@ export async function makeRequest<T>(
 
       if (!isRetry && refreshToken && refreshTokenFunction && tokenRefreshCallback) {
         try {
-          safeLogInfo("[CalComAPIService] 401 attempting token refresh", diagnostics);
           // Single-flight: concurrent 401s sharing this refresh token coalesce
           // into one network refresh.
           await refreshAuthTokensSingleFlight(refreshToken);
@@ -238,10 +173,6 @@ export async function makeRequest<T>(
             refreshError instanceof AuthSessionChangedError ||
             getAuthGeneration() !== generationAtRequest
           ) {
-            safeLogWarn(
-              "[CalComAPIService] token refresh resolved after auth generation changed; aborting",
-              diagnostics
-            );
             throw new ApiRequestError(
               response.status,
               `API Error: ${response.status} ${errorMessage}`
@@ -254,17 +185,9 @@ export async function makeRequest<T>(
             getAuthConfig().accessToken &&
             getAuthConfig().accessToken !== accessTokenAtRequest
           ) {
-            safeLogInfo(
-              "[CalComAPIService] token refresh race resolved by another request; retrying",
-              diagnostics
-            );
             return makeRequest<T>(endpoint, options, apiVersion, true);
           }
-          safeLogError("[CalComAPIService] token refresh failed", {
-            diagnostics,
-            error: refreshError,
-          });
-          safeLogWarn("[CalComAPIService] clearing auth after failed token refresh", diagnostics);
+          safeLogError("Token refresh failed:", refreshError);
           const onAuthFailure = getAuthFailureCallback();
           clearAuth();
           // Trigger full logout so AuthContext resets isAuthenticated
@@ -276,24 +199,15 @@ export async function makeRequest<T>(
         // and must not be torn down because this stale request finished late.
         // (Checked outside the try so it isn't mistaken for a refresh failure.)
         if (getAuthGeneration() !== generationAtRequest) {
-          safeLogWarn(
-            "[CalComAPIService] refresh completed after auth generation changed; aborting retry",
-            diagnostics
-          );
           throw new ApiRequestError(
             response.status,
             `API Error: ${response.status} ${errorMessage}`
           );
         }
         // Retry the original request with the new token.
-        safeLogInfo("[CalComAPIService] token refresh succeeded; retrying original request", {
-          ...diagnostics,
-          currentGeneration: getAuthGeneration(),
-        });
         return makeRequest<T>(endpoint, options, apiVersion, true);
       }
 
-      safeLogWarn("[CalComAPIService] 401 has no refresh path; clearing auth", diagnostics);
       const onAuthFailure = getAuthFailureCallback();
       clearAuth();
       await onAuthFailure?.();

--- a/apps/mobile/services/calcom/request.ts
+++ b/apps/mobile/services/calcom/request.ts
@@ -25,6 +25,21 @@ export function getApiBaseUrl(): string {
   return `${getCalApiUrl()}/v2`;
 }
 
+/**
+ * Error thrown for non-2xx API responses, carrying the HTTP status so callers
+ * can branch on it (e.g. treat a 404 on unregister as "already deleted")
+ * without brittle message string matching.
+ */
+export class ApiRequestError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.status = status;
+  }
+}
+
 export const REQUEST_TIMEOUT_MS = 30000;
 
 /**
@@ -153,7 +168,7 @@ export async function makeRequest<T>(
     }
 
     // Include status code in error message for graceful error handling downstream
-    throw new Error(`API Error: ${response.status} ${errorMessage}`);
+    throw new ApiRequestError(response.status, `API Error: ${response.status} ${errorMessage}`);
   }
 
   return response.json();

--- a/apps/mobile/utils/queryPersister.ts
+++ b/apps/mobile/utils/queryPersister.ts
@@ -6,9 +6,46 @@
 
 import type { PersistedClient, Persister } from "@tanstack/react-query-persist-client";
 import { CACHE_CONFIG } from "@/config/cache.config";
-import { getRegion, regionPreloaded } from "./region";
+import { type CalRegion, getRegion, regionPreloaded } from "./region";
 import { safeLogWarn } from "./safeLogger";
 import { generalStorage, secureStorage } from "./storage";
+
+/**
+ * The persisted cache is wrapped in an owner envelope so a restore can verify
+ * the cache belongs to the current identity (region + user) before rehydrating
+ * it. This prevents one user's cached data from rendering for another user, or
+ * an EU cache from restoring into a US session.
+ */
+interface CacheOwner {
+  region: CalRegion;
+  userId: number;
+}
+
+interface OwnedCacheEnvelope {
+  owner: CacheOwner;
+  client: PersistedClient;
+}
+
+function isOwnedCacheEnvelope(value: unknown): value is OwnedCacheEnvelope {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<OwnedCacheEnvelope>;
+  const owner = candidate.owner;
+  if (typeof owner !== "object" || owner === null) return false;
+  if (owner.region !== "us" && owner.region !== "eu") return false;
+  if (typeof owner.userId !== "number" || Number.isNaN(owner.userId)) return false;
+  return typeof candidate.client === "object" && candidate.client !== null;
+}
+
+async function getCurrentUserId(): Promise<number | null> {
+  try {
+    const raw = await secureStorage.get(AUTH_USER_ID_KEY);
+    if (!raw) return null;
+    const parsed = Number(raw);
+    return Number.isNaN(parsed) ? null : parsed;
+  } catch {
+    return null;
+  }
+}
 
 function getStorageKey(): string {
   return `${CACHE_CONFIG.persistence.storageKey}-${getRegion()}`;
@@ -29,6 +66,10 @@ const storage = generalStorage;
 // presence of either reliably indicates the user has not logged out.
 const OAUTH_TOKENS_KEY = "cal_oauth_tokens";
 const AUTH_TYPE_KEY = "cal_auth_type";
+// Identity of the cache owner. Written by AuthContext after the user profile
+// resolves; absence means we cannot attribute the cache to a user and must not
+// persist or restore it. Keep in sync with AuthContext.tsx.
+const AUTH_USER_ID_KEY = "cal_auth_user_id";
 
 // Pre-region-suffix key. Removed on every restore so pre-migration cache data
 // doesn't accumulate on disk; `removeItem` is a no-op once the key is gone.
@@ -53,7 +94,18 @@ export const createQueryPersister = (): Persister => {
     persistClient: async (client: PersistedClient): Promise<void> => {
       const storageKey = getStorageKey();
       try {
-        const serialized = JSON.stringify(client);
+        // Never write ownerless cache: without a user id we can't safely
+        // attribute it on restore, so drop any existing cache instead.
+        const userId = await getCurrentUserId();
+        if (userId == null) {
+          await storage.removeItem(storageKey);
+          return;
+        }
+        const envelope: OwnedCacheEnvelope = {
+          owner: { region: getRegion(), userId },
+          client,
+        };
+        const serialized = JSON.stringify(envelope);
         await storage.setItem(storageKey, serialized);
       } catch (error) {
         safeLogWarn("[QueryPersister] Failed to persist client:", error);
@@ -106,7 +158,37 @@ export const createQueryPersister = (): Persister => {
           return undefined;
         }
 
-        const client = JSON.parse(serialized) as PersistedClient;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(serialized);
+        } catch (parseError) {
+          safeLogWarn("[QueryPersister] Invalid cache JSON, discarding", parseError);
+          await storage.removeItem(storageKey);
+          return undefined;
+        }
+
+        // Reject legacy ownerless caches (bare PersistedClient) and any other
+        // malformed shape — we can't attribute them to the current identity.
+        if (!isOwnedCacheEnvelope(parsed)) {
+          safeLogWarn("[QueryPersister] Cache is missing owner metadata, discarding");
+          await storage.removeItem(storageKey);
+          return undefined;
+        }
+
+        // Region must match the active session (EU cache must not load into US).
+        if (parsed.owner.region !== getRegion()) {
+          await storage.removeItem(storageKey);
+          return undefined;
+        }
+
+        // The cache owner must match the authenticated user.
+        const currentUserId = await getCurrentUserId();
+        if (currentUserId == null || parsed.owner.userId !== currentUserId) {
+          await storage.removeItem(storageKey);
+          return undefined;
+        }
+
+        const client = parsed.client;
 
         // Validate timestamp exists and is a valid number
         if (typeof client.timestamp !== "number" || Number.isNaN(client.timestamp)) {
@@ -178,7 +260,14 @@ export const getCacheMetadata = async (): Promise<{
       return { exists: false };
     }
 
-    const client = JSON.parse(serialized) as PersistedClient;
+    const parsed: unknown = JSON.parse(serialized);
+
+    // Only the owner-envelope shape is valid; legacy/ownerless caches are
+    // treated as expired so the status indicator reflects they'll be discarded.
+    if (!isOwnedCacheEnvelope(parsed)) {
+      return { exists: true, isExpired: true };
+    }
+    const client = parsed.client;
 
     // Validate timestamp exists and is a valid number
     if (typeof client.timestamp !== "number" || Number.isNaN(client.timestamp)) {

--- a/apps/mobile/utils/queryPersister.ts
+++ b/apps/mobile/utils/queryPersister.ts
@@ -6,7 +6,7 @@
 
 import type { PersistedClient, Persister } from "@tanstack/react-query-persist-client";
 import { CACHE_CONFIG } from "@/config/cache.config";
-import { type CalRegion, getRegion, regionPreloaded } from "./region";
+import { type CalRegion, getRegion, isValidRegion, regionPreloaded } from "./region";
 import { safeLogWarn } from "./safeLogger";
 import { generalStorage, secureStorage } from "./storage";
 
@@ -31,7 +31,7 @@ function isOwnedCacheEnvelope(value: unknown): value is OwnedCacheEnvelope {
   const candidate = value as Partial<OwnedCacheEnvelope>;
   const owner = candidate.owner;
   if (typeof owner !== "object" || owner === null) return false;
-  if (owner.region !== "us" && owner.region !== "eu") return false;
+  if (!isValidRegion(owner.region as string | null)) return false;
   if (typeof owner.userId !== "number" || Number.isNaN(owner.userId)) return false;
   return typeof candidate.client === "object" && candidate.client !== null;
 }

--- a/apps/mobile/utils/region.ts
+++ b/apps/mobile/utils/region.ts
@@ -26,7 +26,7 @@ const DEFAULT_REGION: CalRegion = "us";
 let currentRegion: CalRegion = DEFAULT_REGION;
 const listeners = new Set<(region: CalRegion) => void>();
 
-function isValidRegion(value: string | null): value is CalRegion {
+export function isValidRegion(value: string | null): value is CalRegion {
   return value === "us" || value === "eu";
 }
 

--- a/apps/mobile/utils/widgetStorage.android.ts
+++ b/apps/mobile/utils/widgetStorage.android.ts
@@ -25,10 +25,6 @@ async function updateAndroidWidget(widgetData: WidgetData): Promise<void> {
 }
 
 export async function updateWidgetBookings(bookings: BookingInput[]): Promise<void> {
-  if (__DEV__) {
-    console.log("[Widget Debug] updateWidgetBookings called with", bookings.length, "bookings");
-  }
-
   try {
     const widgetData = transformBookingsToWidgetData(bookings);
     await updateAndroidWidget(widgetData);

--- a/apps/mobile/utils/widgetStorage.ios.ts
+++ b/apps/mobile/utils/widgetStorage.ios.ts
@@ -12,26 +12,13 @@ const iosStorage = new ExtensionStorage(APP_GROUP_IDENTIFIER);
 async function updateIOSWidget(widgetData: WidgetData): Promise<void> {
   // biome-ignore lint/suspicious/noExplicitAny: ExtensionStorage.set() expects any for the value parameter
   iosStorage.set(WIDGET_BOOKINGS_KEY, widgetData as any);
-  if (__DEV__) {
-    console.log("[Widget Debug] Data written to ExtensionStorage with key:", WIDGET_BOOKINGS_KEY);
-  }
 
   ExtensionStorage.reloadWidget();
-  if (__DEV__) {
-    console.log("[Widget Debug] ExtensionStorage.reloadWidget() called");
-  }
 }
 
 export async function updateWidgetBookings(bookings: BookingInput[]): Promise<void> {
-  if (__DEV__) {
-    console.log("[Widget Debug] updateWidgetBookings called with", bookings.length, "bookings");
-  }
-
   try {
     const widgetData = transformBookingsToWidgetData(bookings);
-    if (__DEV__) {
-      console.log("[Widget Debug] Platform is iOS, calling updateIOSWidget");
-    }
     await updateIOSWidget(widgetData);
   } catch (error) {
     console.warn("Failed to update widget bookings:", error);


### PR DESCRIPTION
## Summary

Mobile release hardening for Companion push notifications, auth/refresh handling, persisted query cache ownership, and notification build setup.

This PR started as push/auth/cache hardening and now also includes the final mobile release fixes found during device/build testing: Android Firebase config loading through EAS secrets, Android notification channel setup, iOS notification handler deprecation cleanup, booking action auth UX, dev-only app-review prompt suppression, and removal of temporary debug logs.

## What Changed

### Push notifications
- Persist successful app-push registration state on device: token, deviceId, platform, region, userId, and timestamp.
- Deregister from persisted state on logout instead of relying only on in-memory refs.
- Handle registration/logout races with auth-generation checks, pending deregistration records, capped pending queue, and best-effort cleanup while the bearer is still valid.
- Create the Android notification channel before requesting/registering for notifications.
- Remove deprecated Expo `shouldShowAlert` usage in favor of `shouldShowBanner` / `shouldShowList`.

### Auth and session safety
- Keep auth refresh/failure callbacks installed across logout and same-session relogin.
- Add single-flight refresh so parallel 401s do not trigger competing refreshes or accidentally log out a valid session.
- Add auth session generation/epoch checks so stale refreshes, stale login flows, and stale requests cannot apply after logout/account switch.
- Add `runAuthTransition()` to serialize short auth-marker storage mutations without holding the lock across network I/O.
- Install the OAuth refresh handler before profile fetch, so a recoverable `/me` 401 can refresh instead of logging the user out.
- Treat booking-action 401 after a refresh retry as endpoint authorization failure, not a whole-app logout.

### Query cache isolation
- Add owner metadata to persisted React Query cache: `{ region, userId }`.
- Restore cache only when the stored owner matches the current authenticated owner.
- Clear in-memory and persisted cache on logout/login/account-switch paths.
- Refuse ownerless cache writes until the current user id is known.

### Booking action UX and logs
- Keep confirm/reject buttons visible, but show user-facing unauthorized messages when the signed-in user is not allowed to confirm/reject the booking.
- Remove temporary booking-action and widget debug logs added during investigation.
- Suppress app-store-review prompt in dev to avoid noisy HMR-related warnings.

### Release/build setup
- Bump mobile app version to `1.0.8`.
- Load Android `google-services.json` from the `GOOGLE_SERVICES_JSON` EAS file secret via `app.config.js`.
- Ignore local `google-services.json` in Git and EAS upload paths so the Firebase config is not committed to the public repo.

## Important Context

- Strong cross-region global revocation is still out of scope because US/EU deployments have separate databases and separate KV/Redis by design. This PR implements best-effort mobile cleanup and same-region/session safety, not new shared global infra.
- A push registration POST that finishes after logout has already cleared the bearer can no longer be deleted from the device immediately because the DELETE would 401. The app parks/drains what it can, and backend same-device dedup/cleanup remains the server-side safety net.
- Android push delivery also depends on EAS credentials being configured with an FCM V1 service account key and the `GOOGLE_SERVICES_JSON` file secret. Those credentials are not committed in this PR.

## Verification

Local checks run on this branch:

- `bun --filter mobile typecheck`
- `bun --filter mobile lint:react-compiler`
- `git diff --check`
- `GOOGLE_SERVICES_JSON=./google-services.json bunx expo config --json`
- `GOOGLE_SERVICES_JSON=./google-services.json bunx expo export --platform android`

Manual/device checks performed during release testing:

- iOS build succeeded after regenerating the iOS provisioning profile with Push Notifications entitlement.
- Android FCM V1 credential was added in EAS credentials.
- Android device push notification registration/delivery was confirmed after Firebase/EAS setup.
- Booking confirm/reject unauthorized-user path was validated and changed to user-facing errors instead of logging the user out.

## Reviewer Checklist

- OAuth login survives app restart and access-token refresh.
- A 401 from a forbidden booking action does not log out the app.
- Logout during in-flight push registration does not leave active local state behind.
- Same-device relogin/account switch does not reuse another user's persisted query cache.
- Android production builds have `GOOGLE_SERVICES_JSON` configured as an EAS file secret and FCM V1 credentials assigned.

Link to Devin session: https://app.devin.ai/sessions/a3bc1b9f3e3845ef8f795f2509c8a72d
Requested by: @dhairyashiil
