### PR TITLE
feat(mcp): add organization attribute tools for reading and editing user attributes

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -4,7 +4,7 @@ A **Model Context Protocol (MCP)** server that wraps the [Cal.com Platform API v
 
 ## Features
 
-- **35 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Routing Forms, Organizations, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- **42 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Routing Forms, Organizations, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
 - **Dual transport** — stdio for local dev tooling, StreamableHTTP for remote/production
 - **Dual auth** — API key for stdio (local dev), OAuth 2.1 Authorization Code + PKCE for HTTP (production)
 - **Per-user token storage** — encrypted at rest with AES-256-GCM in SQLite
@@ -178,7 +178,7 @@ The server acts as an intermediary: it issues its own access tokens to MCP clien
 - Expired tokens are cleaned up automatically every 5 minutes
 - In-process rate limiting on all OAuth endpoints (token bucket per IP, configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX`)
 
-## Tools (35)
+## Tools (42)
 
 Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specification/draft/server/tools#tool-annotations) — a human-readable `title` plus behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so MCP clients can render them appropriately and apply safety policies.
 
@@ -250,6 +250,17 @@ Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specifi
 | Tool | Title | Hint | Description |
 |---|---|---|---|
 | `calculate_routing_form_slots` | Calculate Routing Form Slots | Create | Submit a routing form response and get available slots |
+
+### Organizations: Attributes (7)
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_org_attributes` | List Org Attributes | Read | List attributes defined for an organization |
+| `get_org_attribute` | Get Org Attribute | Read | Get a single organization attribute by ID |
+| `get_attribute_options` | List Attribute Options | Read | List available options for a select attribute |
+| `get_user_attributes` | Get User Attributes | Read | Get attribute options assigned to a user |
+| `assign_attribute_to_user` | Assign Attribute to User | Create | Assign an attribute option or value to a user |
+| `update_user_attribute` | Update User Attribute Assignment | Update | Update an existing user attribute assignment |
+| `unassign_attribute_from_user` | Unassign Attribute from User | Destructive | Remove an attribute option assignment from a user |
 
 ### Organizations: Memberships (5)
 | Tool | Title | Hint | Description |

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -79,6 +79,8 @@ import {
   getOrgAttributes,
   getOrgAttributeSchema,
   getOrgAttribute,
+  getAttributeOptionsSchema,
+  getAttributeOptions,
   getUserAttributesSchema,
   getUserAttributes,
   assignAttributeToUserSchema,
@@ -472,7 +474,7 @@ export function registerTools(server: McpServer): void {
     calculateRoutingFormSlots,
   );
 
-  // ── Organizations: Attributes (6) ──
+  // ── Organizations: Attributes (7) ──
   server.registerTool(
     "get_org_attributes",
     {
@@ -496,6 +498,17 @@ export function registerTools(server: McpServer): void {
     getOrgAttribute,
   );
   server.registerTool(
+    "get_attribute_options",
+    {
+      title: "List Attribute Options",
+      description:
+        "List all available options for a SINGLE_SELECT or MULTI_SELECT attribute. Returns option IDs and values needed when assigning attributes to users via assign_attribute_to_user.",
+      inputSchema: getAttributeOptionsSchema,
+      annotations: READ_ONLY,
+    },
+    getAttributeOptions,
+  );
+  server.registerTool(
     "get_user_attributes",
     {
       title: "Get User Attributes",
@@ -511,7 +524,7 @@ export function registerTools(server: McpServer): void {
     {
       title: "Assign Attribute to User",
       description:
-        "Assign an attribute option to a user. For SINGLE_SELECT/MULTI_SELECT attributes, pass attributeOptionId (use get_org_attributes to find option IDs). For TEXT/NUMBER attributes, pass value instead to create an option on the fly. Optionally set a weight for round-robin routing.",
+        "Assign an attribute option to a user. For SINGLE_SELECT/MULTI_SELECT attributes, pass attributeOptionId (use get_attribute_options to list available options). For TEXT/NUMBER attributes, pass value instead to create an option on the fly. Optionally set a weight for round-robin routing.",
       inputSchema: assignAttributeToUserSchema,
       annotations: CREATE,
     },

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -491,7 +491,7 @@ export function registerTools(server: McpServer): void {
     {
       title: "Get Org Attribute",
       description:
-        "Get a single organization attribute by ID, including its options. Use get_org_attributes to find attribute IDs.",
+        "Get a single organization attribute by ID. Use get_org_attributes to find attribute IDs and get_attribute_options to list available options.",
       inputSchema: getOrgAttributeSchema,
       annotations: READ_ONLY,
     },

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -73,6 +73,22 @@ import {
   calculateRoutingFormSlots,
 } from "./tools/routing-forms.js";
 
+// ── Organizations: Attributes ──
+import {
+  getOrgAttributesSchema,
+  getOrgAttributes,
+  getOrgAttributeSchema,
+  getOrgAttribute,
+  getUserAttributesSchema,
+  getUserAttributes,
+  assignAttributeToUserSchema,
+  assignAttributeToUser,
+  updateUserAttributeSchema,
+  updateUserAttribute,
+  unassignAttributeFromUserSchema,
+  unassignAttributeFromUser,
+} from "./tools/organizations/attributes.js";
+
 // ── Organizations: Memberships ──
 import {
   getOrgMembershipsSchema,
@@ -454,6 +470,74 @@ export function registerTools(server: McpServer): void {
       annotations: CREATE,
     },
     calculateRoutingFormSlots,
+  );
+
+  // ── Organizations: Attributes (6) ──
+  server.registerTool(
+    "get_org_attributes",
+    {
+      title: "List Org Attributes",
+      description:
+        "List all attributes defined for an organization. Attributes are custom fields (TEXT, NUMBER, SINGLE_SELECT, MULTI_SELECT) used to tag members for routing and round-robin. Supports pagination with skip/take.",
+      inputSchema: getOrgAttributesSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgAttributes,
+  );
+  server.registerTool(
+    "get_org_attribute",
+    {
+      title: "Get Org Attribute",
+      description:
+        "Get a single organization attribute by ID, including its options. Use get_org_attributes to find attribute IDs.",
+      inputSchema: getOrgAttributeSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgAttribute,
+  );
+  server.registerTool(
+    "get_user_attributes",
+    {
+      title: "Get User Attributes",
+      description:
+        "Get all attribute options assigned to a specific user within an organization. Returns grouped attributes with their assigned option values and weights.",
+      inputSchema: getUserAttributesSchema,
+      annotations: READ_ONLY,
+    },
+    getUserAttributes,
+  );
+  server.registerTool(
+    "assign_attribute_to_user",
+    {
+      title: "Assign Attribute to User",
+      description:
+        "Assign an attribute option to a user. For SINGLE_SELECT/MULTI_SELECT attributes, pass attributeOptionId (use get_org_attributes to find option IDs). For TEXT/NUMBER attributes, pass value instead to create an option on the fly. Optionally set a weight for round-robin routing.",
+      inputSchema: assignAttributeToUserSchema,
+      annotations: CREATE,
+    },
+    assignAttributeToUser,
+  );
+  server.registerTool(
+    "update_user_attribute",
+    {
+      title: "Update User Attribute Assignment",
+      description:
+        "Update an existing attribute assignment for a user (e.g. change the weight). Use get_user_attributes to find the attributeOptionId.",
+      inputSchema: updateUserAttributeSchema,
+      annotations: UPDATE,
+    },
+    updateUserAttribute,
+  );
+  server.registerTool(
+    "unassign_attribute_from_user",
+    {
+      title: "Unassign Attribute from User",
+      description:
+        "Remove an attribute option assignment from a user. Use get_user_attributes to find the attributeOptionId. Confirm with the user before proceeding.",
+      inputSchema: unassignAttributeFromUserSchema,
+      annotations: DESTRUCTIVE,
+    },
+    unassignAttributeFromUser,
   );
 
   // ── Organizations: Memberships (5) ──

--- a/apps/mcp-server/src/server-instructions.ts
+++ b/apps/mcp-server/src/server-instructions.ts
@@ -16,6 +16,7 @@ CAPABILITIES — what you CAN do with the available tools:
 - List connected conferencing apps
 - Work with routing forms and their responses (organization-level)
 - Manage organization memberships
+- Read organization attributes, list attribute options, and manage user attribute assignments
 
 LIMITATIONS — what you CANNOT do (do NOT attempt to use other tools for these):
 - Delete or remove attendees from a booking
@@ -29,7 +30,7 @@ LIMITATIONS — what you CANNOT do (do NOT attempt to use other tools for these)
 
 RULES:
 1. If a user asks for something not listed under CAPABILITIES, tell them clearly: "The Cal.com integration doesn't support [action] yet." Do NOT call a different tool hoping it might work.
-2. NEVER guess or fabricate IDs, emails, names, phone numbers, or time zones. If you don't have a value, either use the appropriate discovery tool (e.g., get_me, get_event_types, get_bookings, get_org_memberships) or ask the user.
+2. NEVER guess or fabricate IDs, emails, names, phone numbers, or time zones. If you don't have a value, either use the appropriate discovery tool (e.g., get_me, get_event_types, get_bookings, get_org_memberships, get_org_attributes, get_attribute_options, get_user_attributes) or ask the user.
 3. Before creating or rescheduling a booking, ALWAYS check availability first using get_availability.
-4. For destructive actions (delete event type, cancel booking, delete schedule, delete membership), confirm with the user before proceeding.
+4. For destructive actions (delete event type, cancel booking, delete schedule, delete membership, unassign attribute from user), confirm with the user before proceeding.
 5. All date/time values sent to the API must be in UTC ISO 8601 format.`;

--- a/apps/mcp-server/src/tools/organizations/attributes.test.ts
+++ b/apps/mcp-server/src/tools/organizations/attributes.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CalApiError } from "../../utils/errors.js";
+
+vi.mock("../../utils/api-client.js", () => ({ calApi: vi.fn() }));
+
+import { calApi } from "../../utils/api-client.js";
+import {
+  getOrgAttributes,
+  getOrgAttributesSchema,
+  getOrgAttribute,
+  getOrgAttributeSchema,
+  getUserAttributes,
+  getUserAttributesSchema,
+  assignAttributeToUser,
+  assignAttributeToUserSchema,
+  updateUserAttribute,
+  updateUserAttributeSchema,
+  unassignAttributeFromUser,
+  unassignAttributeFromUserSchema,
+} from "./attributes.js";
+
+const mockCalApi = vi.mocked(calApi);
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe("getOrgAttributes", () => {
+  it("exports getOrgAttributesSchema", () => { expect(getOrgAttributesSchema).toBeDefined(); });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getOrgAttributes({ orgId: 1 });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("passes pagination params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await getOrgAttributes({ orgId: 1, skip: 10, take: 5 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes", { params: { skip: 10, take: 5 } });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await getOrgAttributes({ orgId: 1 });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+describe("getOrgAttribute", () => {
+  it("exports getOrgAttributeSchema", () => { expect(getOrgAttributeSchema).toBeDefined(); });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getOrgAttribute({ orgId: 1, attributeId: "abc" });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("calls correct endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await getOrgAttribute({ orgId: 1, attributeId: "abc" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/abc");
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(404, "Not found", {}));
+    const result = await getOrgAttribute({ orgId: 1, attributeId: "abc" });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("404");
+  });
+});
+
+describe("getUserAttributes", () => {
+  it("exports getUserAttributesSchema", () => { expect(getUserAttributesSchema).toBeDefined(); });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getUserAttributes({ orgId: 1, userId: 42 });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("calls correct endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await getUserAttributes({ orgId: 1, userId: 42 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/options/42");
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(403, "Forbidden", {}));
+    const result = await getUserAttributes({ orgId: 1, userId: 42 });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("403");
+  });
+});
+
+describe("assignAttributeToUser", () => {
+  it("exports assignAttributeToUserSchema", () => { expect(assignAttributeToUserSchema).toBeDefined(); });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await assignAttributeToUser({ orgId: 1, userId: 42, attributeId: "abc" });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("sends correct body with attributeOptionId", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await assignAttributeToUser({ orgId: 1, userId: 42, attributeId: "abc", attributeOptionId: "opt1", weight: 100 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/options/42", {
+      method: "POST",
+      body: { attributeId: "abc", attributeOptionId: "opt1", weight: 100 },
+    });
+  });
+  it("sends correct body with value", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await assignAttributeToUser({ orgId: 1, userId: 42, attributeId: "abc", value: "Engineering" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/options/42", {
+      method: "POST",
+      body: { attributeId: "abc", value: "Engineering" },
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await assignAttributeToUser({ orgId: 1, userId: 42, attributeId: "abc" });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+describe("updateUserAttribute", () => {
+  it("exports updateUserAttributeSchema", () => { expect(updateUserAttributeSchema).toBeDefined(); });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await updateUserAttribute({ orgId: 1, userId: 42, attributeOptionId: "opt1" });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("sends weight in body", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await updateUserAttribute({ orgId: 1, userId: 42, attributeOptionId: "opt1", weight: 50 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/options/42/opt1", {
+      method: "PATCH",
+      body: { weight: 50 },
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await updateUserAttribute({ orgId: 1, userId: 42, attributeOptionId: "opt1" });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+describe("unassignAttributeFromUser", () => {
+  it("exports unassignAttributeFromUserSchema", () => { expect(unassignAttributeFromUserSchema).toBeDefined(); });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await unassignAttributeFromUser({ orgId: 1, userId: 42, attributeOptionId: "opt1" });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("calls correct endpoint with DELETE", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await unassignAttributeFromUser({ orgId: 1, userId: 42, attributeOptionId: "opt1" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/options/42/opt1", { method: "DELETE" });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await unassignAttributeFromUser({ orgId: 1, userId: 42, attributeOptionId: "opt1" });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});

--- a/apps/mcp-server/src/tools/organizations/attributes.test.ts
+++ b/apps/mcp-server/src/tools/organizations/attributes.test.ts
@@ -9,6 +9,8 @@ import {
   getOrgAttributesSchema,
   getOrgAttribute,
   getOrgAttributeSchema,
+  getAttributeOptions,
+  getAttributeOptionsSchema,
   getUserAttributes,
   getUserAttributesSchema,
   assignAttributeToUser,
@@ -60,6 +62,27 @@ describe("getOrgAttribute", () => {
   it("handles API errors", async () => {
     mockCalApi.mockRejectedValueOnce(new CalApiError(404, "Not found", {}));
     const result = await getOrgAttribute({ orgId: 1, attributeId: "abc" });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("404");
+  });
+});
+
+describe("getAttributeOptions", () => {
+  it("exports getAttributeOptionsSchema", () => { expect(getAttributeOptionsSchema).toBeDefined(); });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [{ id: "opt1", value: "Engineering" }] });
+    const result = await getAttributeOptions({ orgId: 1, attributeId: "abc" });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success", data: [{ id: "opt1", value: "Engineering" }] });
+  });
+  it("calls correct endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await getAttributeOptions({ orgId: 1, attributeId: "abc" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/abc/options");
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(404, "Not found", {}));
+    const result = await getAttributeOptions({ orgId: 1, attributeId: "abc" });
     expect(result).toHaveProperty("isError", true);
     expect(result.content[0].text).toContain("404");
   });

--- a/apps/mcp-server/src/tools/organizations/attributes.ts
+++ b/apps/mcp-server/src/tools/organizations/attributes.ts
@@ -43,6 +43,27 @@ export async function getOrgAttribute(params: {
   }
 }
 
+// ── Read: Attribute Options ──
+
+export const getAttributeOptionsSchema = {
+  orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  attributeId: z.string().describe("Attribute ID. Use get_org_attributes to find this."),
+};
+
+export async function getAttributeOptions(params: {
+  orgId: number;
+  attributeId: string;
+}) {
+  try {
+    const data = await calApi(
+      `organizations/${params.orgId}/attributes/${params.attributeId}/options`,
+    );
+    return ok(data);
+  } catch (err) {
+    return handleError("get_attribute_options", err);
+  }
+}
+
 // ── Read: User Attributes ──
 
 export const getUserAttributesSchema = {
@@ -68,7 +89,7 @@ export const assignAttributeToUserSchema = {
   orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
   userId: z.number().int().describe("User ID to assign the attribute to."),
   attributeId: z.string().describe("Attribute ID. Use get_org_attributes to find this."),
-  attributeOptionId: z.string().optional().describe("Existing attribute option ID to assign. Use get_org_attributes to find option IDs. Provide this OR value, not both."),
+  attributeOptionId: z.string().optional().describe("Existing attribute option ID to assign. Use get_attribute_options to list available options for SINGLE_SELECT/MULTI_SELECT attributes. Provide this OR value, not both."),
   value: z.string().optional().describe("Value for TEXT/NUMBER attributes (creates an option on the fly). Provide this OR attributeOptionId, not both."),
   weight: z.number().int().min(0).optional().describe("Weight of this attribute assignment for the user (used in round-robin)."),
 };

--- a/apps/mcp-server/src/tools/organizations/attributes.ts
+++ b/apps/mcp-server/src/tools/organizations/attributes.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { calApi } from "../../utils/api-client.js";
+import { sanitizePathSegment } from "../../utils/path-sanitizer.js";
 import { handleError, ok } from "../../utils/tool-helpers.js";
 
 // ── Read: Org Attributes ──
@@ -36,7 +37,8 @@ export async function getOrgAttribute(params: {
   attributeId: string;
 }) {
   try {
-    const data = await calApi(`organizations/${params.orgId}/attributes/${params.attributeId}`);
+    const attrId = sanitizePathSegment(params.attributeId);
+    const data = await calApi(`organizations/${params.orgId}/attributes/${attrId}`);
     return ok(data);
   } catch (err) {
     return handleError("get_org_attribute", err);
@@ -55,8 +57,9 @@ export async function getAttributeOptions(params: {
   attributeId: string;
 }) {
   try {
+    const attrId = sanitizePathSegment(params.attributeId);
     const data = await calApi(
-      `organizations/${params.orgId}/attributes/${params.attributeId}/options`,
+      `organizations/${params.orgId}/attributes/${attrId}/options`,
     );
     return ok(data);
   } catch (err) {
@@ -133,8 +136,9 @@ export async function updateUserAttribute(params: {
   try {
     const body: Record<string, unknown> = {};
     if (params.weight !== undefined) body.weight = params.weight;
+    const optId = sanitizePathSegment(params.attributeOptionId);
     const data = await calApi(
-      `organizations/${params.orgId}/attributes/options/${params.userId}/${params.attributeOptionId}`,
+      `organizations/${params.orgId}/attributes/options/${params.userId}/${optId}`,
       { method: "PATCH", body },
     );
     return ok(data);
@@ -155,8 +159,9 @@ export async function unassignAttributeFromUser(params: {
   attributeOptionId: string;
 }) {
   try {
+    const optId = sanitizePathSegment(params.attributeOptionId);
     const data = await calApi(
-      `organizations/${params.orgId}/attributes/options/${params.userId}/${params.attributeOptionId}`,
+      `organizations/${params.orgId}/attributes/options/${params.userId}/${optId}`,
       { method: "DELETE" },
     );
     return ok(data);

--- a/apps/mcp-server/src/tools/organizations/attributes.ts
+++ b/apps/mcp-server/src/tools/organizations/attributes.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+import { calApi } from "../../utils/api-client.js";
+import { handleError, ok } from "../../utils/tool-helpers.js";
+
+// ── Read: Org Attributes ──
+
+export const getOrgAttributesSchema = {
+  orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  skip: z.number().int().optional().describe("Results to skip (offset)"),
+  take: z.number().int().optional().describe("Max results to return"),
+};
+
+export async function getOrgAttributes(params: {
+  orgId: number;
+  skip?: number;
+  take?: number;
+}) {
+  try {
+    const qp: Record<string, string | number | boolean | undefined> = {};
+    if (params.skip !== undefined) qp.skip = params.skip;
+    if (params.take !== undefined) qp.take = params.take;
+    const data = await calApi(`organizations/${params.orgId}/attributes`, { params: qp });
+    return ok(data);
+  } catch (err) {
+    return handleError("get_org_attributes", err);
+  }
+}
+
+export const getOrgAttributeSchema = {
+  orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  attributeId: z.string().describe("Attribute ID. Use get_org_attributes to find this."),
+};
+
+export async function getOrgAttribute(params: {
+  orgId: number;
+  attributeId: string;
+}) {
+  try {
+    const data = await calApi(`organizations/${params.orgId}/attributes/${params.attributeId}`);
+    return ok(data);
+  } catch (err) {
+    return handleError("get_org_attribute", err);
+  }
+}
+
+// ── Read: User Attributes ──
+
+export const getUserAttributesSchema = {
+  orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  userId: z.number().int().describe("User ID whose attributes to retrieve."),
+};
+
+export async function getUserAttributes(params: {
+  orgId: number;
+  userId: number;
+}) {
+  try {
+    const data = await calApi(`organizations/${params.orgId}/attributes/options/${params.userId}`);
+    return ok(data);
+  } catch (err) {
+    return handleError("get_user_attributes", err);
+  }
+}
+
+// ── Write: Assign / Update / Unassign ──
+
+export const assignAttributeToUserSchema = {
+  orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  userId: z.number().int().describe("User ID to assign the attribute to."),
+  attributeId: z.string().describe("Attribute ID. Use get_org_attributes to find this."),
+  attributeOptionId: z.string().optional().describe("Existing attribute option ID to assign. Use get_org_attributes to find option IDs. Provide this OR value, not both."),
+  value: z.string().optional().describe("Value for TEXT/NUMBER attributes (creates an option on the fly). Provide this OR attributeOptionId, not both."),
+  weight: z.number().int().min(0).optional().describe("Weight of this attribute assignment for the user (used in round-robin)."),
+};
+
+export async function assignAttributeToUser(params: {
+  orgId: number;
+  userId: number;
+  attributeId: string;
+  attributeOptionId?: string;
+  value?: string;
+  weight?: number;
+}) {
+  try {
+    const body: Record<string, unknown> = { attributeId: params.attributeId };
+    if (params.attributeOptionId !== undefined) body.attributeOptionId = params.attributeOptionId;
+    if (params.value !== undefined) body.value = params.value;
+    if (params.weight !== undefined) body.weight = params.weight;
+    const data = await calApi(`organizations/${params.orgId}/attributes/options/${params.userId}`, {
+      method: "POST",
+      body,
+    });
+    return ok(data);
+  } catch (err) {
+    return handleError("assign_attribute_to_user", err);
+  }
+}
+
+export const updateUserAttributeSchema = {
+  orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  userId: z.number().int().describe("User ID whose attribute assignment to update."),
+  attributeOptionId: z.string().describe("Attribute option ID of the assignment to update. Use get_user_attributes to find this."),
+  weight: z.number().int().min(0).optional().describe("New weight for this attribute assignment."),
+};
+
+export async function updateUserAttribute(params: {
+  orgId: number;
+  userId: number;
+  attributeOptionId: string;
+  weight?: number;
+}) {
+  try {
+    const body: Record<string, unknown> = {};
+    if (params.weight !== undefined) body.weight = params.weight;
+    const data = await calApi(
+      `organizations/${params.orgId}/attributes/options/${params.userId}/${params.attributeOptionId}`,
+      { method: "PATCH", body },
+    );
+    return ok(data);
+  } catch (err) {
+    return handleError("update_user_attribute", err);
+  }
+}
+
+export const unassignAttributeFromUserSchema = {
+  orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  userId: z.number().int().describe("User ID to unassign the attribute from."),
+  attributeOptionId: z.string().describe("Attribute option ID to unassign. Use get_user_attributes to find this."),
+};
+
+export async function unassignAttributeFromUser(params: {
+  orgId: number;
+  userId: number;
+  attributeOptionId: string;
+}) {
+  try {
+    const data = await calApi(
+      `organizations/${params.orgId}/attributes/options/${params.userId}/${params.attributeOptionId}`,
+      { method: "DELETE" },
+    );
+    return ok(data);
+  } catch (err) {
+    return handleError("unassign_attribute_from_user", err);
+  }
+}

--- a/apps/mcp-server/src/tools/organizations/index.ts
+++ b/apps/mcp-server/src/tools/organizations/index.ts
@@ -1,2 +1,3 @@
+export * from "./attributes.js";
 export * from "./memberships.js";
 export * from "./routing-forms.js";


### PR DESCRIPTION
## Summary

Adds 7 MCP tools wrapping existing Cal.com API v2 attribute endpoints so MCP clients can read org attributes, discover options for SELECT attributes, and assign/update/unassign attributes on users.

| Tool | Endpoint | Annotation |
|------|----------|------------|
| `get_org_attributes` | `GET /organizations/:orgId/attributes` | READ_ONLY |
| `get_org_attribute` | `GET /organizations/:orgId/attributes/:attributeId` | READ_ONLY |
| `get_attribute_options` | `GET /organizations/:orgId/attributes/:attributeId/options` | READ_ONLY |
| `get_user_attributes` | `GET /organizations/:orgId/attributes/options/:userId` | READ_ONLY |
| `assign_attribute_to_user` | `POST /organizations/:orgId/attributes/options/:userId` | CREATE |
| `update_user_attribute` | `PATCH /organizations/:orgId/attributes/options/:userId/:optionId` | UPDATE |
| `unassign_attribute_from_user` | `DELETE /organizations/:orgId/attributes/options/:userId/:optionId` | DESTRUCTIVE |

Tool descriptions include explicit hints for discoverability (e.g. `attributeOptionId` says "Use `get_attribute_options` to list available options") so LLM callers know the correct query order.

No backend changes — all API v2 endpoints already exist. 29 unit tests covering schema exports, endpoint URLs, body payloads, and error handling.

Link to Devin session: https://app.devin.ai/sessions/9c670e2014bf487088223c81e962f19b
Requested by: @joeauyeung