### PR TITLE
feat(mcp): add routing attribute MCP tools for organizations

### DIFF
--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -1,99 +1,127 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
-
-// ── Users ──
-import { getMeSchema, getMe, updateMeSchema, updateMe } from "./tools/users.js";
-
-// ── Event Types ──
-import {
-  getEventTypesSchema,
-  getEventTypes,
-  getEventTypeSchema,
-  getEventType,
-  createEventTypeSchema,
-  createEventType,
-  updateEventTypeSchema,
-  updateEventType,
-  deleteEventTypeSchema,
-  deleteEventType,
-} from "./tools/event-types.js";
-
+// ── Availability / Slots ──
+import { getAvailability, getAvailabilitySchema } from "./tools/availability.js";
 // ── Bookings ──
 import {
-  getBookingsSchema,
-  getBookings,
-  getBookingSchema,
-  getBooking,
-  createBookingSchema,
-  createBooking,
-  rescheduleBookingSchema,
-  rescheduleBooking,
-  cancelBookingSchema,
-  cancelBooking,
-  confirmBookingSchema,
-  confirmBooking,
-  markBookingAbsentSchema,
-  markBookingAbsent,
-  getBookingAttendeesSchema,
-  getBookingAttendees,
-  addBookingAttendeeSchema,
   addBookingAttendee,
-  getBookingAttendeeSchema,
+  addBookingAttendeeSchema,
+  cancelBooking,
+  cancelBookingSchema,
+  confirmBooking,
+  confirmBookingSchema,
+  createBooking,
+  createBookingSchema,
+  getBooking,
   getBookingAttendee,
+  getBookingAttendeeSchema,
+  getBookingAttendees,
+  getBookingAttendeesSchema,
+  getBookingSchema,
+  getBookings,
+  getBookingsSchema,
+  markBookingAbsent,
+  markBookingAbsentSchema,
+  rescheduleBooking,
+  rescheduleBookingSchema,
 } from "./tools/bookings.js";
-
-// ── Schedules ──
-import {
-  getSchedulesSchema,
-  getSchedules,
-  getScheduleSchema,
-  getSchedule,
-  createScheduleSchema,
-  createSchedule,
-  updateScheduleSchema,
-  updateSchedule,
-  deleteScheduleSchema,
-  deleteSchedule,
-  getDefaultScheduleSchema,
-  getDefaultSchedule,
-} from "./tools/schedules.js";
-
-// ── Availability / Slots ──
-import { getAvailabilitySchema, getAvailability } from "./tools/availability.js";
-
 // ── Calendars ──
-import { getConnectedCalendarsSchema, getConnectedCalendars, getBusyTimesSchema, getBusyTimes } from "./tools/calendars.js";
-
-// ── Conferencing ──
-import { getConferencingAppsSchema, getConferencingApps } from "./tools/conferencing.js";
-
-// ── Routing Forms ──
 import {
-  calculateRoutingFormSlotsSchema,
-  calculateRoutingFormSlots,
-} from "./tools/routing-forms.js";
-
+  getBusyTimes,
+  getBusyTimesSchema,
+  getConnectedCalendars,
+  getConnectedCalendarsSchema,
+} from "./tools/calendars.js";
+// ── Conferencing ──
+import { getConferencingApps, getConferencingAppsSchema } from "./tools/conferencing.js";
+// ── Event Types ──
+import {
+  createEventType,
+  createEventTypeSchema,
+  deleteEventType,
+  deleteEventTypeSchema,
+  getEventType,
+  getEventTypeSchema,
+  getEventTypes,
+  getEventTypesSchema,
+  updateEventType,
+  updateEventTypeSchema,
+} from "./tools/event-types.js";
+// ── Organizations: Attributes ──
+import {
+  assignAttributeToUser,
+  assignAttributeToUserSchema,
+  createOrgAttribute,
+  createOrgAttributeOption,
+  createOrgAttributeOptionSchema,
+  createOrgAttributeSchema,
+  deleteOrgAttribute,
+  deleteOrgAttributeOption,
+  deleteOrgAttributeOptionSchema,
+  deleteOrgAttributeSchema,
+  getAssignedAttributeOptions,
+  getAssignedAttributeOptionsBySlug,
+  getAssignedAttributeOptionsBySlugSchema,
+  getAssignedAttributeOptionsSchema,
+  getOrgAttribute,
+  getOrgAttributeOptions,
+  getOrgAttributeOptionsSchema,
+  getOrgAttributeSchema,
+  getOrgAttributes,
+  getOrgAttributesSchema,
+  getUserAttributeOptions,
+  getUserAttributeOptionsSchema,
+  removeAttributeFromUser,
+  removeAttributeFromUserSchema,
+  updateOrgAttribute,
+  updateOrgAttributeOption,
+  updateOrgAttributeOptionSchema,
+  updateOrgAttributeSchema,
+  updateUserAttributeAssignment,
+  updateUserAttributeAssignmentSchema,
+} from "./tools/organizations/attributes.js";
 // ── Organizations: Memberships ──
 import {
-  getOrgMembershipsSchema,
-  getOrgMemberships,
-  createOrgMembershipSchema,
   createOrgMembership,
-  getOrgMembershipSchema,
-  getOrgMembership,
-  deleteOrgMembershipSchema,
+  createOrgMembershipSchema,
   deleteOrgMembership,
-  updateOrgMembershipSchema,
+  deleteOrgMembershipSchema,
+  getOrgMembership,
+  getOrgMembershipSchema,
+  getOrgMemberships,
+  getOrgMembershipsSchema,
   updateOrgMembership,
+  updateOrgMembershipSchema,
 } from "./tools/organizations/memberships.js";
-
 // ── Organizations: Routing Forms ──
 import {
-  getOrgRoutingFormsSchema,
-  getOrgRoutingForms,
-  getOrgRoutingFormResponsesSchema,
   getOrgRoutingFormResponses,
+  getOrgRoutingFormResponsesSchema,
+  getOrgRoutingForms,
+  getOrgRoutingFormsSchema,
 } from "./tools/organizations/routing-forms.js";
+// ── Routing Forms ──
+import {
+  calculateRoutingFormSlots,
+  calculateRoutingFormSlotsSchema,
+} from "./tools/routing-forms.js";
+// ── Schedules ──
+import {
+  createSchedule,
+  createScheduleSchema,
+  deleteSchedule,
+  deleteScheduleSchema,
+  getDefaultSchedule,
+  getDefaultScheduleSchema,
+  getSchedule,
+  getScheduleSchema,
+  getSchedules,
+  getSchedulesSchema,
+  updateSchedule,
+  updateScheduleSchema,
+} from "./tools/schedules.js";
+// ── Users ──
+import { getMe, getMeSchema, updateMe, updateMeSchema } from "./tools/users.js";
 
 /**
  * Tool annotation presets matching MCP behaviour hints.
@@ -148,7 +176,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getMeSchema,
       annotations: READ_ONLY,
     },
-    getMe,
+    getMe
   );
   server.registerTool(
     "update_me",
@@ -159,7 +187,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateMeSchema,
       annotations: UPDATE,
     },
-    updateMe,
+    updateMe
   );
 
   // ── Event Types (5) ──
@@ -172,7 +200,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getEventTypesSchema,
       annotations: READ_ONLY,
     },
-    getEventTypes,
+    getEventTypes
   );
   server.registerTool(
     "get_event_type",
@@ -183,7 +211,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getEventTypeSchema,
       annotations: READ_ONLY,
     },
-    getEventType,
+    getEventType
   );
   server.registerTool(
     "create_event_type",
@@ -194,7 +222,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: createEventTypeSchema,
       annotations: CREATE,
     },
-    createEventType,
+    createEventType
   );
   server.registerTool(
     "update_event_type",
@@ -205,7 +233,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateEventTypeSchema,
       annotations: UPDATE,
     },
-    updateEventType,
+    updateEventType
   );
   server.registerTool(
     "delete_event_type",
@@ -216,7 +244,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: deleteEventTypeSchema,
       annotations: DESTRUCTIVE,
     },
-    deleteEventType,
+    deleteEventType
   );
 
   // ── Bookings (10) ──
@@ -229,7 +257,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingsSchema,
       annotations: READ_ONLY,
     },
-    getBookings,
+    getBookings
   );
   server.registerTool(
     "get_booking",
@@ -240,7 +268,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingSchema,
       annotations: READ_ONLY,
     },
-    getBooking,
+    getBooking
   );
   server.registerTool(
     "create_booking",
@@ -251,7 +279,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: createBookingSchema,
       annotations: CREATE,
     },
-    createBooking,
+    createBooking
   );
   server.registerTool(
     "reschedule_booking",
@@ -262,7 +290,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: rescheduleBookingSchema,
       annotations: UPDATE,
     },
-    rescheduleBooking,
+    rescheduleBooking
   );
   server.registerTool(
     "cancel_booking",
@@ -273,17 +301,18 @@ export function registerTools(server: McpServer): void {
       inputSchema: cancelBookingSchema,
       annotations: DESTRUCTIVE,
     },
-    cancelBooking,
+    cancelBooking
   );
   server.registerTool(
     "confirm_booking",
     {
       title: "Confirm Booking",
-      description: "Confirm a pending booking that requires manual confirmation. Only the host can confirm.",
+      description:
+        "Confirm a pending booking that requires manual confirmation. Only the host can confirm.",
       inputSchema: confirmBookingSchema,
       annotations: UPDATE,
     },
-    confirmBooking,
+    confirmBooking
   );
   server.registerTool(
     "mark_booking_absent",
@@ -294,7 +323,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: markBookingAbsentSchema,
       annotations: UPDATE,
     },
-    markBookingAbsent,
+    markBookingAbsent
   );
   server.registerTool(
     "get_booking_attendees",
@@ -304,7 +333,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingAttendeesSchema,
       annotations: READ_ONLY,
     },
-    getBookingAttendees,
+    getBookingAttendees
   );
   server.registerTool(
     "add_booking_attendee",
@@ -315,7 +344,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: addBookingAttendeeSchema,
       annotations: CREATE,
     },
-    addBookingAttendee,
+    addBookingAttendee
   );
   server.registerTool(
     "get_booking_attendee",
@@ -326,7 +355,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingAttendeeSchema,
       annotations: READ_ONLY,
     },
-    getBookingAttendee,
+    getBookingAttendee
   );
 
   // ── Schedules (6) ──
@@ -338,17 +367,18 @@ export function registerTools(server: McpServer): void {
       inputSchema: getSchedulesSchema,
       annotations: READ_ONLY,
     },
-    getSchedules,
+    getSchedules
   );
   server.registerTool(
     "get_schedule",
     {
       title: "Get Schedule",
-      description: "Get a specific schedule by its numeric ID. Returns availability slots and overrides.",
+      description:
+        "Get a specific schedule by its numeric ID. Returns availability slots and overrides.",
       inputSchema: getScheduleSchema,
       annotations: READ_ONLY,
     },
-    getSchedule,
+    getSchedule
   );
   server.registerTool(
     "create_schedule",
@@ -359,17 +389,18 @@ export function registerTools(server: McpServer): void {
       inputSchema: createScheduleSchema,
       annotations: CREATE,
     },
-    createSchedule,
+    createSchedule
   );
   server.registerTool(
     "update_schedule",
     {
       title: "Update Schedule",
-      description: "Update an existing schedule. Array fields (availability, overrides) replace all existing entries.",
+      description:
+        "Update an existing schedule. Array fields (availability, overrides) replace all existing entries.",
       inputSchema: updateScheduleSchema,
       annotations: UPDATE,
     },
-    updateSchedule,
+    updateSchedule
   );
   server.registerTool(
     "delete_schedule",
@@ -380,7 +411,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: deleteScheduleSchema,
       annotations: DESTRUCTIVE,
     },
-    deleteSchedule,
+    deleteSchedule
   );
   server.registerTool(
     "get_default_schedule",
@@ -390,7 +421,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getDefaultScheduleSchema,
       annotations: READ_ONLY,
     },
-    getDefaultSchedule,
+    getDefaultSchedule
   );
 
   // ── Availability / Slots (1) ──
@@ -403,7 +434,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getAvailabilitySchema,
       annotations: READ_ONLY,
     },
-    getAvailability,
+    getAvailability
   );
 
   // ── Calendars (2) ──
@@ -416,7 +447,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getConnectedCalendarsSchema,
       annotations: READ_ONLY,
     },
-    getConnectedCalendars,
+    getConnectedCalendars
   );
   server.registerTool(
     "get_busy_times",
@@ -427,7 +458,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBusyTimesSchema,
       annotations: READ_ONLY,
     },
-    getBusyTimes,
+    getBusyTimes
   );
 
   // ── Conferencing (1) ──
@@ -440,7 +471,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getConferencingAppsSchema,
       annotations: READ_ONLY,
     },
-    getConferencingApps,
+    getConferencingApps
   );
 
   // ── Routing Forms (1) ──
@@ -453,7 +484,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: calculateRoutingFormSlotsSchema,
       annotations: CREATE,
     },
-    calculateRoutingFormSlots,
+    calculateRoutingFormSlots
   );
 
   // ── Organizations: Memberships (5) ──
@@ -465,7 +496,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgMembershipsSchema,
       annotations: READ_ONLY,
     },
-    getOrgMemberships,
+    getOrgMemberships
   );
   server.registerTool(
     "create_org_membership",
@@ -476,7 +507,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: createOrgMembershipSchema,
       annotations: CREATE,
     },
-    createOrgMembership,
+    createOrgMembership
   );
   server.registerTool(
     "get_org_membership",
@@ -486,7 +517,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgMembershipSchema,
       annotations: READ_ONLY,
     },
-    getOrgMembership,
+    getOrgMembership
   );
   server.registerTool(
     "delete_org_membership",
@@ -497,7 +528,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: deleteOrgMembershipSchema,
       annotations: DESTRUCTIVE,
     },
-    deleteOrgMembership,
+    deleteOrgMembership
   );
   server.registerTool(
     "update_org_membership",
@@ -508,7 +539,172 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateOrgMembershipSchema,
       annotations: UPDATE,
     },
-    updateOrgMembership,
+    updateOrgMembership
+  );
+
+  // ── Organizations: Attributes (15) ──
+  server.registerTool(
+    "get_org_attributes",
+    {
+      title: "List Org Attributes",
+      description:
+        "List all routing attributes for an organization. These attributes are used to tag members for routing form logic. Supports pagination with take/skip.",
+      inputSchema: getOrgAttributesSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgAttributes
+  );
+  server.registerTool(
+    "get_org_attribute",
+    {
+      title: "Get Org Attribute",
+      description:
+        "Get a single routing attribute by its ID. Use get_org_attributes to find attribute IDs.",
+      inputSchema: getOrgAttributeSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgAttribute
+  );
+  server.registerTool(
+    "create_org_attribute",
+    {
+      title: "Create Org Attribute",
+      description:
+        "Create a new routing attribute for the organization. Required: name, slug, type. For SELECT types, provide options with value and optional slug.",
+      inputSchema: createOrgAttributeSchema,
+      annotations: CREATE,
+    },
+    createOrgAttribute
+  );
+  server.registerTool(
+    "update_org_attribute",
+    {
+      title: "Update Org Attribute",
+      description: "Update a routing attribute's name, slug, type, or enabled status.",
+      inputSchema: updateOrgAttributeSchema,
+      annotations: UPDATE,
+    },
+    updateOrgAttribute
+  );
+  server.registerTool(
+    "delete_org_attribute",
+    {
+      title: "Delete Org Attribute",
+      description:
+        "Permanently delete a routing attribute. This action is irreversible — confirm with the user before proceeding.",
+      inputSchema: deleteOrgAttributeSchema,
+      annotations: DESTRUCTIVE,
+    },
+    deleteOrgAttribute
+  );
+  server.registerTool(
+    "get_org_attribute_options",
+    {
+      title: "List Attribute Options",
+      description:
+        "List all options for a routing attribute. Use this to discover option IDs before assigning them to users.",
+      inputSchema: getOrgAttributeOptionsSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgAttributeOptions
+  );
+  server.registerTool(
+    "get_assigned_attribute_options",
+    {
+      title: "List Assigned Attribute Options",
+      description:
+        "List which options of a specific attribute are currently assigned to org members.",
+      inputSchema: getAssignedAttributeOptionsSchema,
+      annotations: READ_ONLY,
+    },
+    getAssignedAttributeOptions
+  );
+  server.registerTool(
+    "get_assigned_attribute_options_by_slug",
+    {
+      title: "List Assigned Attribute Options by Slug",
+      description:
+        "List assigned options for an attribute identified by its slug instead of ID. Convenient when you know the slug but not the ID.",
+      inputSchema: getAssignedAttributeOptionsBySlugSchema,
+      annotations: READ_ONLY,
+    },
+    getAssignedAttributeOptionsBySlug
+  );
+  server.registerTool(
+    "create_org_attribute_option",
+    {
+      title: "Create Attribute Option",
+      description:
+        "Create a new option for a routing attribute. Required: value. The option can then be assigned to users via assign_attribute_to_user.",
+      inputSchema: createOrgAttributeOptionSchema,
+      annotations: CREATE,
+    },
+    createOrgAttributeOption
+  );
+  server.registerTool(
+    "update_org_attribute_option",
+    {
+      title: "Update Attribute Option",
+      description: "Update an attribute option's value or slug.",
+      inputSchema: updateOrgAttributeOptionSchema,
+      annotations: UPDATE,
+    },
+    updateOrgAttributeOption
+  );
+  server.registerTool(
+    "delete_org_attribute_option",
+    {
+      title: "Delete Attribute Option",
+      description:
+        "Permanently delete an attribute option. This action is irreversible — confirm with the user before proceeding.",
+      inputSchema: deleteOrgAttributeOptionSchema,
+      annotations: DESTRUCTIVE,
+    },
+    deleteOrgAttributeOption
+  );
+  server.registerTool(
+    "get_user_attribute_options",
+    {
+      title: "Get User Attributes",
+      description:
+        "Get all routing attributes assigned to a specific user. Use get_org_memberships or get_me to find the userId.",
+      inputSchema: getUserAttributeOptionsSchema,
+      annotations: READ_ONLY,
+    },
+    getUserAttributeOptions
+  );
+  server.registerTool(
+    "assign_attribute_to_user",
+    {
+      title: "Assign Attribute to User",
+      description:
+        "Assign a routing attribute option to a user. Use get_org_attribute_options to find the attributeOptionId. For TEXT/NUMBER attributes, also provide a value.",
+      inputSchema: assignAttributeToUserSchema,
+      annotations: CREATE,
+    },
+    assignAttributeToUser
+  );
+  server.registerTool(
+    "update_user_attribute_assignment",
+    {
+      title: "Update User Attribute Assignment",
+      description:
+        "Update an attribute assignment for a user (e.g. change the weight for round-robin routing). Use get_user_attribute_options to find the attributeOptionId.",
+      inputSchema: updateUserAttributeAssignmentSchema,
+      annotations: UPDATE,
+    },
+    updateUserAttributeAssignment
+  );
+  server.registerTool(
+    "remove_attribute_from_user",
+    {
+      title: "Remove Attribute from User",
+      description:
+        "Remove an assigned routing attribute from a user. Use get_user_attribute_options to find the attributeOptionId. Confirm with the user before proceeding.",
+      inputSchema: removeAttributeFromUserSchema,
+      annotations: DESTRUCTIVE,
+    },
+    removeAttributeFromUser
   );
 
   // ── Organizations: Routing Forms (2) ──
@@ -521,7 +717,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgRoutingFormsSchema,
       annotations: READ_ONLY,
     },
-    getOrgRoutingForms,
+    getOrgRoutingForms
   );
   server.registerTool(
     "get_org_routing_form_responses",
@@ -532,6 +728,6 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgRoutingFormResponsesSchema,
       annotations: READ_ONLY,
     },
-    getOrgRoutingFormResponses,
+    getOrgRoutingFormResponses
   );
 }

--- a/apps/mcp-server/src/tools/organizations/attributes.test.ts
+++ b/apps/mcp-server/src/tools/organizations/attributes.test.ts
@@ -1,0 +1,530 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CalApiError } from "../../utils/errors.js";
+
+vi.mock("../../utils/api-client.js", () => ({ calApi: vi.fn() }));
+
+import { calApi } from "../../utils/api-client.js";
+import {
+  assignAttributeToUser,
+  assignAttributeToUserSchema,
+  createOrgAttribute,
+  createOrgAttributeOption,
+  createOrgAttributeOptionSchema,
+  createOrgAttributeSchema,
+  deleteOrgAttribute,
+  deleteOrgAttributeOption,
+  deleteOrgAttributeOptionSchema,
+  deleteOrgAttributeSchema,
+  getAssignedAttributeOptions,
+  getAssignedAttributeOptionsBySlug,
+  getAssignedAttributeOptionsBySlugSchema,
+  getAssignedAttributeOptionsSchema,
+  getOrgAttribute,
+  getOrgAttributeOptions,
+  getOrgAttributeOptionsSchema,
+  getOrgAttributeSchema,
+  getOrgAttributes,
+  getOrgAttributesSchema,
+  getUserAttributeOptions,
+  getUserAttributeOptionsSchema,
+  removeAttributeFromUser,
+  removeAttributeFromUserSchema,
+  updateOrgAttribute,
+  updateOrgAttributeOption,
+  updateOrgAttributeOptionSchema,
+  updateOrgAttributeSchema,
+  updateUserAttributeAssignment,
+  updateUserAttributeAssignmentSchema,
+} from "./attributes.js";
+
+const mockCalApi = vi.mocked(calApi);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── getOrgAttributes ──
+
+describe("getOrgAttributes", () => {
+  it("exports getOrgAttributesSchema", () => {
+    expect(getOrgAttributesSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getOrgAttributes({ orgId: 1 });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("passes pagination params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await getOrgAttributes({ orgId: 1, take: 10, skip: 5 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes", {
+      params: { take: 10, skip: 5 },
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await getOrgAttributes({ orgId: 1 });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── getOrgAttribute ──
+
+describe("getOrgAttribute", () => {
+  it("exports getOrgAttributeSchema", () => {
+    expect(getOrgAttributeSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getOrgAttribute({ orgId: 1, attributeId: "attr-1" });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("calls correct endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await getOrgAttribute({ orgId: 1, attributeId: "attr-1" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/attr-1");
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(404, "Not found", {}));
+    const result = await getOrgAttribute({ orgId: 1, attributeId: "attr-1" });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("404");
+  });
+});
+
+// ── createOrgAttribute ──
+
+describe("createOrgAttribute", () => {
+  it("exports createOrgAttributeSchema", () => {
+    expect(createOrgAttributeSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await createOrgAttribute({
+      orgId: 1,
+      name: "Region",
+      slug: "region",
+      type: "SINGLE_SELECT",
+    });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("sends body with options", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await createOrgAttribute({
+      orgId: 1,
+      name: "Region",
+      slug: "region",
+      type: "SINGLE_SELECT",
+      options: [{ value: "US", slug: "us" }],
+      enabled: true,
+    });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes", {
+      method: "POST",
+      body: {
+        name: "Region",
+        slug: "region",
+        type: "SINGLE_SELECT",
+        options: [{ value: "US", slug: "us" }],
+        enabled: true,
+      },
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await createOrgAttribute({
+      orgId: 1,
+      name: "Region",
+      slug: "region",
+      type: "TEXT",
+    });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── updateOrgAttribute ──
+
+describe("updateOrgAttribute", () => {
+  it("exports updateOrgAttributeSchema", () => {
+    expect(updateOrgAttributeSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await updateOrgAttribute({ orgId: 1, attributeId: "attr-1", name: "Updated" });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("sends only provided fields in body", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await updateOrgAttribute({ orgId: 1, attributeId: "attr-1", name: "Updated" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/attr-1", {
+      method: "PATCH",
+      body: { name: "Updated" },
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await updateOrgAttribute({ orgId: 1, attributeId: "attr-1" });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── deleteOrgAttribute ──
+
+describe("deleteOrgAttribute", () => {
+  it("exports deleteOrgAttributeSchema", () => {
+    expect(deleteOrgAttributeSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await deleteOrgAttribute({ orgId: 1, attributeId: "attr-1" });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("calls DELETE on correct endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await deleteOrgAttribute({ orgId: 1, attributeId: "attr-1" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/attr-1", {
+      method: "DELETE",
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await deleteOrgAttribute({ orgId: 1, attributeId: "attr-1" });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── getOrgAttributeOptions ──
+
+describe("getOrgAttributeOptions", () => {
+  it("exports getOrgAttributeOptionsSchema", () => {
+    expect(getOrgAttributeOptionsSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getOrgAttributeOptions({ orgId: 1, attributeId: "attr-1" });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("passes pagination params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await getOrgAttributeOptions({ orgId: 1, attributeId: "attr-1", take: 5, skip: 0 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/attr-1/options", {
+      params: { take: 5, skip: 0 },
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await getOrgAttributeOptions({ orgId: 1, attributeId: "attr-1" });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── getAssignedAttributeOptions ──
+
+describe("getAssignedAttributeOptions", () => {
+  it("exports getAssignedAttributeOptionsSchema", () => {
+    expect(getAssignedAttributeOptionsSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getAssignedAttributeOptions({ orgId: 1, attributeId: "attr-1" });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("calls correct endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await getAssignedAttributeOptions({ orgId: 1, attributeId: "attr-1" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/attr-1/options/assigned");
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await getAssignedAttributeOptions({ orgId: 1, attributeId: "attr-1" });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── getAssignedAttributeOptionsBySlug ──
+
+describe("getAssignedAttributeOptionsBySlug", () => {
+  it("exports getAssignedAttributeOptionsBySlugSchema", () => {
+    expect(getAssignedAttributeOptionsBySlugSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getAssignedAttributeOptionsBySlug({ orgId: 1, attributeSlug: "region" });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("calls correct endpoint with slug", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await getAssignedAttributeOptionsBySlug({ orgId: 1, attributeSlug: "region" });
+    expect(mockCalApi).toHaveBeenCalledWith(
+      "organizations/1/attributes/slugs/region/options/assigned"
+    );
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await getAssignedAttributeOptionsBySlug({ orgId: 1, attributeSlug: "region" });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── createOrgAttributeOption ──
+
+describe("createOrgAttributeOption", () => {
+  it("exports createOrgAttributeOptionSchema", () => {
+    expect(createOrgAttributeOptionSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await createOrgAttributeOption({ orgId: 1, attributeId: "attr-1", value: "US" });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("sends body with optional slug", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await createOrgAttributeOption({ orgId: 1, attributeId: "attr-1", value: "US", slug: "us" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/attr-1/options", {
+      method: "POST",
+      body: { value: "US", slug: "us" },
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await createOrgAttributeOption({ orgId: 1, attributeId: "attr-1", value: "US" });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── updateOrgAttributeOption ──
+
+describe("updateOrgAttributeOption", () => {
+  it("exports updateOrgAttributeOptionSchema", () => {
+    expect(updateOrgAttributeOptionSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await updateOrgAttributeOption({
+      orgId: 1,
+      attributeId: "attr-1",
+      optionId: "opt-1",
+      value: "EU",
+    });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("sends PATCH with provided fields", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await updateOrgAttributeOption({
+      orgId: 1,
+      attributeId: "attr-1",
+      optionId: "opt-1",
+      value: "EU",
+      slug: "eu",
+    });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/attr-1/options/opt-1", {
+      method: "PATCH",
+      body: { value: "EU", slug: "eu" },
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await updateOrgAttributeOption({
+      orgId: 1,
+      attributeId: "attr-1",
+      optionId: "opt-1",
+    });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── deleteOrgAttributeOption ──
+
+describe("deleteOrgAttributeOption", () => {
+  it("exports deleteOrgAttributeOptionSchema", () => {
+    expect(deleteOrgAttributeOptionSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await deleteOrgAttributeOption({
+      orgId: 1,
+      attributeId: "attr-1",
+      optionId: "opt-1",
+    });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("calls DELETE on correct endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await deleteOrgAttributeOption({ orgId: 1, attributeId: "attr-1", optionId: "opt-1" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/attr-1/options/opt-1", {
+      method: "DELETE",
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await deleteOrgAttributeOption({
+      orgId: 1,
+      attributeId: "attr-1",
+      optionId: "opt-1",
+    });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── getUserAttributeOptions ──
+
+describe("getUserAttributeOptions", () => {
+  it("exports getUserAttributeOptionsSchema", () => {
+    expect(getUserAttributeOptionsSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getUserAttributeOptions({ orgId: 1, userId: 42 });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("calls correct endpoint with userId", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await getUserAttributeOptions({ orgId: 1, userId: 42 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/options/42");
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await getUserAttributeOptions({ orgId: 1, userId: 42 });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── assignAttributeToUser ──
+
+describe("assignAttributeToUser", () => {
+  it("exports assignAttributeToUserSchema", () => {
+    expect(assignAttributeToUserSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await assignAttributeToUser({
+      orgId: 1,
+      userId: 42,
+      attributeOptionId: "opt-1",
+    });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("sends body with optional value", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await assignAttributeToUser({
+      orgId: 1,
+      userId: 42,
+      attributeOptionId: "opt-1",
+      value: "custom",
+    });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/options/42", {
+      method: "POST",
+      body: { attributeOptionId: "opt-1", value: "custom" },
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await assignAttributeToUser({
+      orgId: 1,
+      userId: 42,
+      attributeOptionId: "opt-1",
+    });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── updateUserAttributeAssignment ──
+
+describe("updateUserAttributeAssignment", () => {
+  it("exports updateUserAttributeAssignmentSchema", () => {
+    expect(updateUserAttributeAssignmentSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await updateUserAttributeAssignment({
+      orgId: 1,
+      userId: 42,
+      attributeOptionId: "opt-1",
+      weight: 50,
+    });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("sends PATCH with weight", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await updateUserAttributeAssignment({
+      orgId: 1,
+      userId: 42,
+      attributeOptionId: "opt-1",
+      weight: 75,
+    });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/options/42/opt-1", {
+      method: "PATCH",
+      body: { weight: 75 },
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await updateUserAttributeAssignment({
+      orgId: 1,
+      userId: 42,
+      attributeOptionId: "opt-1",
+    });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});
+
+// ── removeAttributeFromUser ──
+
+describe("removeAttributeFromUser", () => {
+  it("exports removeAttributeFromUserSchema", () => {
+    expect(removeAttributeFromUserSchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await removeAttributeFromUser({
+      orgId: 1,
+      userId: 42,
+      attributeOptionId: "opt-1",
+    });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+  it("calls DELETE on correct endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await removeAttributeFromUser({ orgId: 1, userId: 42, attributeOptionId: "opt-1" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/options/42/opt-1", {
+      method: "DELETE",
+    });
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(400, "Bad request", {}));
+    const result = await removeAttributeFromUser({
+      orgId: 1,
+      userId: 42,
+      attributeOptionId: "opt-1",
+    });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("400");
+  });
+});

--- a/apps/mcp-server/src/tools/organizations/attributes.ts
+++ b/apps/mcp-server/src/tools/organizations/attributes.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { calApi } from "../../utils/api-client.js";
+import { sanitizePathSegment } from "../../utils/path-sanitizer.js";
 import { handleError, ok } from "../../utils/tool-helpers.js";
 
 // ── List all attributes ──
@@ -39,7 +40,8 @@ export const getOrgAttributeSchema = {
 
 export async function getOrgAttribute(params: { orgId: number; attributeId: string }) {
   try {
-    const data = await calApi(`organizations/${params.orgId}/attributes/${params.attributeId}`);
+    const attrId = sanitizePathSegment(params.attributeId);
+    const data = await calApi(`organizations/${params.orgId}/attributes/${attrId}`);
     return ok(data);
   } catch (err) {
     return handleError("get_org_attribute", err);
@@ -123,7 +125,8 @@ export async function updateOrgAttribute(params: {
     if (params.slug !== undefined) body.slug = params.slug;
     if (params.type !== undefined) body.type = params.type;
     if (params.enabled !== undefined) body.enabled = params.enabled;
-    const data = await calApi(`organizations/${params.orgId}/attributes/${params.attributeId}`, {
+    const attrId = sanitizePathSegment(params.attributeId);
+    const data = await calApi(`organizations/${params.orgId}/attributes/${attrId}`, {
       method: "PATCH",
       body,
     });
@@ -147,7 +150,8 @@ export const deleteOrgAttributeSchema = {
 
 export async function deleteOrgAttribute(params: { orgId: number; attributeId: string }) {
   try {
-    const data = await calApi(`organizations/${params.orgId}/attributes/${params.attributeId}`, {
+    const attrId = sanitizePathSegment(params.attributeId);
+    const data = await calApi(`organizations/${params.orgId}/attributes/${attrId}`, {
       method: "DELETE",
     });
     return ok(data);
@@ -180,10 +184,10 @@ export async function getOrgAttributeOptions(params: {
     const qp: Record<string, string | number | boolean | undefined> = {};
     if (params.take !== undefined) qp.take = params.take;
     if (params.skip !== undefined) qp.skip = params.skip;
-    const data = await calApi(
-      `organizations/${params.orgId}/attributes/${params.attributeId}/options`,
-      { params: qp }
-    );
+    const attrId = sanitizePathSegment(params.attributeId);
+    const data = await calApi(`organizations/${params.orgId}/attributes/${attrId}/options`, {
+      params: qp,
+    });
     return ok(data);
   } catch (err) {
     return handleError("get_org_attribute_options", err);
@@ -204,8 +208,9 @@ export const getAssignedAttributeOptionsSchema = {
 
 export async function getAssignedAttributeOptions(params: { orgId: number; attributeId: string }) {
   try {
+    const attrId = sanitizePathSegment(params.attributeId);
     const data = await calApi(
-      `organizations/${params.orgId}/attributes/${params.attributeId}/options/assigned`
+      `organizations/${params.orgId}/attributes/${attrId}/options/assigned`
     );
     return ok(data);
   } catch (err) {
@@ -230,8 +235,9 @@ export async function getAssignedAttributeOptionsBySlug(params: {
   attributeSlug: string;
 }) {
   try {
+    const slug = sanitizePathSegment(params.attributeSlug);
     const data = await calApi(
-      `organizations/${params.orgId}/attributes/slugs/${params.attributeSlug}/options/assigned`
+      `organizations/${params.orgId}/attributes/slugs/${slug}/options/assigned`
     );
     return ok(data);
   } catch (err) {
@@ -263,10 +269,11 @@ export async function createOrgAttributeOption(params: {
     const body: Record<string, unknown> = {};
     body.value = params.value;
     if (params.slug !== undefined) body.slug = params.slug;
-    const data = await calApi(
-      `organizations/${params.orgId}/attributes/${params.attributeId}/options`,
-      { method: "POST", body }
-    );
+    const attrId = sanitizePathSegment(params.attributeId);
+    const data = await calApi(`organizations/${params.orgId}/attributes/${attrId}/options`, {
+      method: "POST",
+      body,
+    });
     return ok(data);
   } catch (err) {
     return handleError("create_org_attribute_option", err);
@@ -301,8 +308,10 @@ export async function updateOrgAttributeOption(params: {
     const body: Record<string, unknown> = {};
     if (params.value !== undefined) body.value = params.value;
     if (params.slug !== undefined) body.slug = params.slug;
+    const attrId = sanitizePathSegment(params.attributeId);
+    const optId = sanitizePathSegment(params.optionId);
     const data = await calApi(
-      `organizations/${params.orgId}/attributes/${params.attributeId}/options/${params.optionId}`,
+      `organizations/${params.orgId}/attributes/${attrId}/options/${optId}`,
       {
         method: "PATCH",
         body,
@@ -335,8 +344,10 @@ export async function deleteOrgAttributeOption(params: {
   optionId: string;
 }) {
   try {
+    const attrId = sanitizePathSegment(params.attributeId);
+    const optId = sanitizePathSegment(params.optionId);
     const data = await calApi(
-      `organizations/${params.orgId}/attributes/${params.attributeId}/options/${params.optionId}`,
+      `organizations/${params.orgId}/attributes/${attrId}/options/${optId}`,
       {
         method: "DELETE",
       }
@@ -436,8 +447,9 @@ export async function updateUserAttributeAssignment(params: {
   try {
     const body: Record<string, unknown> = {};
     if (params.weight !== undefined) body.weight = params.weight;
+    const optId = sanitizePathSegment(params.attributeOptionId);
     const data = await calApi(
-      `organizations/${params.orgId}/attributes/options/${params.userId}/${params.attributeOptionId}`,
+      `organizations/${params.orgId}/attributes/options/${params.userId}/${optId}`,
       {
         method: "PATCH",
         body,
@@ -473,8 +485,9 @@ export async function removeAttributeFromUser(params: {
   attributeOptionId: string;
 }) {
   try {
+    const optId = sanitizePathSegment(params.attributeOptionId);
     const data = await calApi(
-      `organizations/${params.orgId}/attributes/options/${params.userId}/${params.attributeOptionId}`,
+      `organizations/${params.orgId}/attributes/options/${params.userId}/${optId}`,
       {
         method: "DELETE",
       }

--- a/apps/mcp-server/src/tools/organizations/attributes.ts
+++ b/apps/mcp-server/src/tools/organizations/attributes.ts
@@ -1,0 +1,486 @@
+import { z } from "zod";
+import { calApi } from "../../utils/api-client.js";
+import { handleError, ok } from "../../utils/tool-helpers.js";
+
+// ── List all attributes ──
+
+export const getOrgAttributesSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  take: z.number().optional().describe("Max results to return"),
+  skip: z.number().optional().describe("Results to skip (offset)"),
+};
+
+export async function getOrgAttributes(params: { orgId: number; take?: number; skip?: number }) {
+  try {
+    const qp: Record<string, string | number | boolean | undefined> = {};
+    if (params.take !== undefined) qp.take = params.take;
+    if (params.skip !== undefined) qp.skip = params.skip;
+    const data = await calApi(`organizations/${params.orgId}/attributes`, { params: qp });
+    return ok(data);
+  } catch (err) {
+    return handleError("get_org_attributes", err);
+  }
+}
+
+// ── Get single attribute ──
+
+export const getOrgAttributeSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  attributeId: z
+    .string()
+    .describe("Attribute ID. Use get_org_attributes to find this — never guess."),
+};
+
+export async function getOrgAttribute(params: { orgId: number; attributeId: string }) {
+  try {
+    const data = await calApi(`organizations/${params.orgId}/attributes/${params.attributeId}`);
+    return ok(data);
+  } catch (err) {
+    return handleError("get_org_attribute", err);
+  }
+}
+
+// ── Create attribute ──
+
+export const createOrgAttributeSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  name: z.string().describe("Name of the attribute"),
+  slug: z.string().describe("URL-friendly slug for the attribute"),
+  type: z.enum(["TEXT", "NUMBER", "SINGLE_SELECT", "MULTI_SELECT"]).describe("Attribute type"),
+  options: z
+    .array(
+      z.object({
+        value: z.string().describe("Option value"),
+        slug: z.string().optional().describe("Option slug"),
+      })
+    )
+    .optional()
+    .describe("Options for SELECT-type attributes"),
+  enabled: z.boolean().optional().describe("Whether the attribute is enabled"),
+};
+
+export async function createOrgAttribute(params: {
+  orgId: number;
+  name: string;
+  slug: string;
+  type: "TEXT" | "NUMBER" | "SINGLE_SELECT" | "MULTI_SELECT";
+  options?: { value: string; slug?: string }[];
+  enabled?: boolean;
+}) {
+  try {
+    const body: Record<string, unknown> = {};
+    body.name = params.name;
+    body.slug = params.slug;
+    body.type = params.type;
+    if (params.options !== undefined) body.options = params.options;
+    if (params.enabled !== undefined) body.enabled = params.enabled;
+    const data = await calApi(`organizations/${params.orgId}/attributes`, { method: "POST", body });
+    return ok(data);
+  } catch (err) {
+    return handleError("create_org_attribute", err);
+  }
+}
+
+// ── Update attribute ──
+
+export const updateOrgAttributeSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  attributeId: z
+    .string()
+    .describe("Attribute ID. Use get_org_attributes to find this — never guess."),
+  name: z.string().optional().describe("Updated name"),
+  slug: z.string().optional().describe("Updated slug"),
+  type: z
+    .enum(["TEXT", "NUMBER", "SINGLE_SELECT", "MULTI_SELECT"])
+    .optional()
+    .describe("Updated attribute type"),
+  enabled: z.boolean().optional().describe("Whether the attribute is enabled"),
+};
+
+export async function updateOrgAttribute(params: {
+  orgId: number;
+  attributeId: string;
+  name?: string;
+  slug?: string;
+  type?: "TEXT" | "NUMBER" | "SINGLE_SELECT" | "MULTI_SELECT";
+  enabled?: boolean;
+}) {
+  try {
+    const body: Record<string, unknown> = {};
+    if (params.name !== undefined) body.name = params.name;
+    if (params.slug !== undefined) body.slug = params.slug;
+    if (params.type !== undefined) body.type = params.type;
+    if (params.enabled !== undefined) body.enabled = params.enabled;
+    const data = await calApi(`organizations/${params.orgId}/attributes/${params.attributeId}`, {
+      method: "PATCH",
+      body,
+    });
+    return ok(data);
+  } catch (err) {
+    return handleError("update_org_attribute", err);
+  }
+}
+
+// ── Delete attribute ──
+
+export const deleteOrgAttributeSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  attributeId: z
+    .string()
+    .describe("Attribute ID. Use get_org_attributes to find this — never guess."),
+};
+
+export async function deleteOrgAttribute(params: { orgId: number; attributeId: string }) {
+  try {
+    const data = await calApi(`organizations/${params.orgId}/attributes/${params.attributeId}`, {
+      method: "DELETE",
+    });
+    return ok(data);
+  } catch (err) {
+    return handleError("delete_org_attribute", err);
+  }
+}
+
+// ── List options for an attribute ──
+
+export const getOrgAttributeOptionsSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  attributeId: z
+    .string()
+    .describe("Attribute ID. Use get_org_attributes to find this — never guess."),
+  take: z.number().optional().describe("Max results to return"),
+  skip: z.number().optional().describe("Results to skip (offset)"),
+};
+
+export async function getOrgAttributeOptions(params: {
+  orgId: number;
+  attributeId: string;
+  take?: number;
+  skip?: number;
+}) {
+  try {
+    const qp: Record<string, string | number | boolean | undefined> = {};
+    if (params.take !== undefined) qp.take = params.take;
+    if (params.skip !== undefined) qp.skip = params.skip;
+    const data = await calApi(
+      `organizations/${params.orgId}/attributes/${params.attributeId}/options`,
+      { params: qp }
+    );
+    return ok(data);
+  } catch (err) {
+    return handleError("get_org_attribute_options", err);
+  }
+}
+
+// ── List assigned options for an attribute ──
+
+export const getAssignedAttributeOptionsSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  attributeId: z
+    .string()
+    .describe("Attribute ID. Use get_org_attributes to find this — never guess."),
+};
+
+export async function getAssignedAttributeOptions(params: { orgId: number; attributeId: string }) {
+  try {
+    const data = await calApi(
+      `organizations/${params.orgId}/attributes/${params.attributeId}/options/assigned`
+    );
+    return ok(data);
+  } catch (err) {
+    return handleError("get_assigned_attribute_options", err);
+  }
+}
+
+// ── List assigned options by attribute slug ──
+
+export const getAssignedAttributeOptionsBySlugSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  attributeSlug: z
+    .string()
+    .describe("Attribute slug. Use get_org_attributes to find this — never guess."),
+};
+
+export async function getAssignedAttributeOptionsBySlug(params: {
+  orgId: number;
+  attributeSlug: string;
+}) {
+  try {
+    const data = await calApi(
+      `organizations/${params.orgId}/attributes/slugs/${params.attributeSlug}/options/assigned`
+    );
+    return ok(data);
+  } catch (err) {
+    return handleError("get_assigned_attribute_options_by_slug", err);
+  }
+}
+
+// ── Create attribute option ──
+
+export const createOrgAttributeOptionSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  attributeId: z
+    .string()
+    .describe("Attribute ID. Use get_org_attributes to find this — never guess."),
+  value: z.string().describe("Value for the new option"),
+  slug: z.string().optional().describe("URL-friendly slug for the option"),
+};
+
+export async function createOrgAttributeOption(params: {
+  orgId: number;
+  attributeId: string;
+  value: string;
+  slug?: string;
+}) {
+  try {
+    const body: Record<string, unknown> = {};
+    body.value = params.value;
+    if (params.slug !== undefined) body.slug = params.slug;
+    const data = await calApi(
+      `organizations/${params.orgId}/attributes/${params.attributeId}/options`,
+      { method: "POST", body }
+    );
+    return ok(data);
+  } catch (err) {
+    return handleError("create_org_attribute_option", err);
+  }
+}
+
+// ── Update attribute option ──
+
+export const updateOrgAttributeOptionSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  attributeId: z
+    .string()
+    .describe("Attribute ID. Use get_org_attributes to find this — never guess."),
+  optionId: z
+    .string()
+    .describe("Option ID. Use get_org_attribute_options to find this — never guess."),
+  value: z.string().optional().describe("Updated option value"),
+  slug: z.string().optional().describe("Updated option slug"),
+};
+
+export async function updateOrgAttributeOption(params: {
+  orgId: number;
+  attributeId: string;
+  optionId: string;
+  value?: string;
+  slug?: string;
+}) {
+  try {
+    const body: Record<string, unknown> = {};
+    if (params.value !== undefined) body.value = params.value;
+    if (params.slug !== undefined) body.slug = params.slug;
+    const data = await calApi(
+      `organizations/${params.orgId}/attributes/${params.attributeId}/options/${params.optionId}`,
+      {
+        method: "PATCH",
+        body,
+      }
+    );
+    return ok(data);
+  } catch (err) {
+    return handleError("update_org_attribute_option", err);
+  }
+}
+
+// ── Delete attribute option ──
+
+export const deleteOrgAttributeOptionSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  attributeId: z
+    .string()
+    .describe("Attribute ID. Use get_org_attributes to find this — never guess."),
+  optionId: z
+    .string()
+    .describe("Option ID. Use get_org_attribute_options to find this — never guess."),
+};
+
+export async function deleteOrgAttributeOption(params: {
+  orgId: number;
+  attributeId: string;
+  optionId: string;
+}) {
+  try {
+    const data = await calApi(
+      `organizations/${params.orgId}/attributes/${params.attributeId}/options/${params.optionId}`,
+      {
+        method: "DELETE",
+      }
+    );
+    return ok(data);
+  } catch (err) {
+    return handleError("delete_org_attribute_option", err);
+  }
+}
+
+// ── Get attributes assigned to a user ──
+
+export const getUserAttributeOptionsSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  userId: z
+    .number()
+    .int()
+    .describe("User ID. Use get_org_memberships or get_me to find this — never guess."),
+};
+
+export async function getUserAttributeOptions(params: { orgId: number; userId: number }) {
+  try {
+    const data = await calApi(`organizations/${params.orgId}/attributes/options/${params.userId}`);
+    return ok(data);
+  } catch (err) {
+    return handleError("get_user_attribute_options", err);
+  }
+}
+
+// ── Assign attribute option to user ──
+
+export const assignAttributeToUserSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  userId: z
+    .number()
+    .int()
+    .describe("User ID. Use get_org_memberships or get_me to find this — never guess."),
+  attributeOptionId: z
+    .string()
+    .describe(
+      "Attribute option ID to assign. Use get_org_attribute_options to find this — never guess."
+    ),
+  value: z.string().optional().describe("Value for TEXT/NUMBER attributes"),
+};
+
+export async function assignAttributeToUser(params: {
+  orgId: number;
+  userId: number;
+  attributeOptionId: string;
+  value?: string;
+}) {
+  try {
+    const body: Record<string, unknown> = {};
+    body.attributeOptionId = params.attributeOptionId;
+    if (params.value !== undefined) body.value = params.value;
+    const data = await calApi(`organizations/${params.orgId}/attributes/options/${params.userId}`, {
+      method: "POST",
+      body,
+    });
+    return ok(data);
+  } catch (err) {
+    return handleError("assign_attribute_to_user", err);
+  }
+}
+
+// ── Update user attribute assignment ──
+
+export const updateUserAttributeAssignmentSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  userId: z
+    .number()
+    .int()
+    .describe("User ID. Use get_org_memberships or get_me to find this — never guess."),
+  attributeOptionId: z
+    .string()
+    .describe(
+      "Attribute option ID of the assignment to update. Use get_user_attribute_options to find this — never guess."
+    ),
+  weight: z.number().optional().describe("New weight for round-robin routing"),
+};
+
+export async function updateUserAttributeAssignment(params: {
+  orgId: number;
+  userId: number;
+  attributeOptionId: string;
+  weight?: number;
+}) {
+  try {
+    const body: Record<string, unknown> = {};
+    if (params.weight !== undefined) body.weight = params.weight;
+    const data = await calApi(
+      `organizations/${params.orgId}/attributes/options/${params.userId}/${params.attributeOptionId}`,
+      {
+        method: "PATCH",
+        body,
+      }
+    );
+    return ok(data);
+  } catch (err) {
+    return handleError("update_user_attribute_assignment", err);
+  }
+}
+
+// ── Remove attribute from user ──
+
+export const removeAttributeFromUserSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  userId: z
+    .number()
+    .int()
+    .describe("User ID. Use get_org_memberships or get_me to find this — never guess."),
+  attributeOptionId: z
+    .string()
+    .describe(
+      "Attribute option ID to remove. Use get_user_attribute_options to find this — never guess."
+    ),
+};
+
+export async function removeAttributeFromUser(params: {
+  orgId: number;
+  userId: number;
+  attributeOptionId: string;
+}) {
+  try {
+    const data = await calApi(
+      `organizations/${params.orgId}/attributes/options/${params.userId}/${params.attributeOptionId}`,
+      {
+        method: "DELETE",
+      }
+    );
+    return ok(data);
+  } catch (err) {
+    return handleError("remove_attribute_from_user", err);
+  }
+}

--- a/apps/mcp-server/src/tools/organizations/index.ts
+++ b/apps/mcp-server/src/tools/organizations/index.ts
@@ -1,2 +1,3 @@
+export * from "./attributes.js";
 export * from "./memberships.js";
 export * from "./routing-forms.js";


### PR DESCRIPTION
## Summary

Adds 15 MCP tools wrapping the Cal.com API v2 organization attributes endpoints for reading and writing routing attributes per user.

New file `src/tools/organizations/attributes.ts` following existing patterns from `memberships.ts` / `routing-forms.ts`:

**Attribute CRUD** — `get_org_attributes`, `get_org_attribute`, `create_org_attribute`, `update_org_attribute`, `delete_org_attribute`

**Attribute option management** — `get_org_attribute_options`, `get_assigned_attribute_options`, `get_assigned_attribute_options_by_slug`, `create_org_attribute_option`, `update_org_attribute_option`, `delete_org_attribute_option`

**User attribute assignments** — `get_user_attribute_options`, `assign_attribute_to_user`, `update_user_attribute_assignment`, `remove_attribute_from_user`

All tools registered in `register-tools.ts` with appropriate MCP annotations (`READ_ONLY`, `CREATE`, `UPDATE`, `DESTRUCTIVE`). Descriptions follow existing style with hints like "Use get_me to obtain your organizationId — never guess." Unit tests cover success + error paths for every handler (60 tests).

Link to Devin session: https://app.devin.ai/sessions/8b5a7ba58d3241f5a2e23cc52155d1eb
Requested by: @joeauyeung