### PR TITLE
feat: add get_org_team_bookings and get_org_user_bookings MCP tools

### DIFF
--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -73,6 +73,14 @@ import {
   calculateRoutingFormSlots,
 } from "./tools/routing-forms.js";
 
+// ── Organizations: Bookings ──
+import {
+  getOrgTeamBookingsSchema,
+  getOrgTeamBookings,
+  getOrgUserBookingsSchema,
+  getOrgUserBookings,
+} from "./tools/organizations/bookings.js";
+
 // ── Organizations: Memberships ──
 import {
   getOrgMembershipsSchema,
@@ -454,6 +462,30 @@ export function registerTools(server: McpServer): void {
       annotations: CREATE,
     },
     calculateRoutingFormSlots,
+  );
+
+  // ── Organizations: Bookings (2) ──
+  server.registerTool(
+    "get_org_team_bookings",
+    {
+      title: "List Org Team Bookings",
+      description:
+        "List all bookings for a team within an organization. Requires TEAM_ADMIN role. Supports filtering by status (upcoming, recurring, past, cancelled, unconfirmed), attendee email/name, event type, date ranges (afterStart, beforeEnd, afterCreatedAt, beforeCreatedAt, afterUpdatedAt, beforeUpdatedAt), and sorting (sortStart, sortEnd, sortCreated, sortUpdatedAt).",
+      inputSchema: getOrgTeamBookingsSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgTeamBookings,
+  );
+  server.registerTool(
+    "get_org_user_bookings",
+    {
+      title: "List Org User Bookings",
+      description:
+        "List all bookings for a specific user within an organization. Requires ORG_ADMIN role. Use get_org_memberships to find user IDs. Supports filtering by status, attendee email/name, event type, team, date ranges, and sorting.",
+      inputSchema: getOrgUserBookingsSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgUserBookings,
   );
 
   // ── Organizations: Memberships (5) ──

--- a/apps/mcp-server/src/tools/organizations/bookings.test.ts
+++ b/apps/mcp-server/src/tools/organizations/bookings.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CalApiError } from "../../utils/errors.js";
+
+vi.mock("../../utils/api-client.js", () => ({ calApi: vi.fn() }));
+
+import { calApi } from "../../utils/api-client.js";
+import {
+  getOrgTeamBookings,
+  getOrgTeamBookingsSchema,
+  getOrgUserBookings,
+  getOrgUserBookingsSchema,
+} from "./bookings.js";
+
+const mockCalApi = vi.mocked(calApi);
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe("getOrgTeamBookings", () => {
+  it("exports getOrgTeamBookingsSchema", () => { expect(getOrgTeamBookingsSchema).toBeDefined(); });
+
+  it("calls the correct endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
+    await getOrgTeamBookings({ orgId: 1, teamId: 10 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/teams/10/bookings", { params: {} });
+  });
+
+  it("passes filter params as query params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
+    await getOrgTeamBookings({
+      orgId: 1,
+      teamId: 10,
+      attendeeEmail: "test@example.com",
+      status: "upcoming",
+      sortCreated: "desc",
+      take: 50,
+    });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/teams/10/bookings", {
+      params: {
+        attendeeEmail: "test@example.com",
+        status: "upcoming",
+        sortCreated: "desc",
+        take: 50,
+      },
+    });
+  });
+
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getOrgTeamBookings({ orgId: 1, teamId: 10 });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(403, "Forbidden", {}));
+    const result = await getOrgTeamBookings({ orgId: 1, teamId: 10 });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("403");
+  });
+});
+
+describe("getOrgUserBookings", () => {
+  it("exports getOrgUserBookingsSchema", () => { expect(getOrgUserBookingsSchema).toBeDefined(); });
+
+  it("calls the correct endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
+    await getOrgUserBookings({ orgId: 1, userId: 42 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/users/42/bookings", { params: {} });
+  });
+
+  it("passes teamId and teamsIds as query params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
+    await getOrgUserBookings({ orgId: 1, userId: 42, teamId: 10, teamsIds: "10,20" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/users/42/bookings", {
+      params: { teamId: 10, teamsIds: "10,20" },
+    });
+  });
+
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getOrgUserBookings({ orgId: 1, userId: 42 });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(403, "Forbidden", {}));
+    const result = await getOrgUserBookings({ orgId: 1, userId: 42 });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("403");
+  });
+});

--- a/apps/mcp-server/src/tools/organizations/bookings.ts
+++ b/apps/mcp-server/src/tools/organizations/bookings.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+import { calApi } from "../../utils/api-client.js";
+import { handleError, ok } from "../../utils/tool-helpers.js";
+
+const bookingFiltersSchema = {
+  status: z.string().optional().describe("Comma-separated statuses: upcoming, recurring, past, cancelled, unconfirmed"),
+  attendeeEmail: z.string().email().optional().describe("Filter by attendee email"),
+  attendeeName: z.string().optional().describe("Filter by attendee name"),
+  eventTypeId: z.number().int().optional().describe("Filter by event type ID"),
+  eventTypeIds: z.string().optional().describe("Comma-separated event type IDs (e.g. '100,200')"),
+  afterStart: z.string().optional().describe("Filter bookings starting after this ISO 8601 date"),
+  beforeEnd: z.string().optional().describe("Filter bookings ending before this ISO 8601 date"),
+  afterCreatedAt: z.string().optional().describe("Filter bookings created after this ISO 8601 date"),
+  beforeCreatedAt: z.string().optional().describe("Filter bookings created before this ISO 8601 date"),
+  afterUpdatedAt: z.string().optional().describe("Filter bookings updated after this ISO 8601 date"),
+  beforeUpdatedAt: z.string().optional().describe("Filter bookings updated before this ISO 8601 date"),
+  bookingUid: z.string().optional().describe("Filter by booking UID"),
+  sortStart: z.enum(["asc", "desc"]).optional().describe("Sort by start time"),
+  sortEnd: z.enum(["asc", "desc"]).optional().describe("Sort by end time"),
+  sortCreated: z.enum(["asc", "desc"]).optional().describe("Sort by creation time"),
+  sortUpdatedAt: z.enum(["asc", "desc"]).optional().describe("Sort by updated time"),
+  take: z.number().int().optional().describe("Max results to return (default 100, max 250)"),
+  skip: z.number().int().optional().describe("Results to skip (offset)"),
+};
+
+interface BookingFilterParams {
+  status?: string;
+  attendeeEmail?: string;
+  attendeeName?: string;
+  eventTypeId?: number;
+  eventTypeIds?: string;
+  afterStart?: string;
+  beforeEnd?: string;
+  afterCreatedAt?: string;
+  beforeCreatedAt?: string;
+  afterUpdatedAt?: string;
+  beforeUpdatedAt?: string;
+  bookingUid?: string;
+  sortStart?: "asc" | "desc";
+  sortEnd?: "asc" | "desc";
+  sortCreated?: "asc" | "desc";
+  sortUpdatedAt?: "asc" | "desc";
+  take?: number;
+  skip?: number;
+}
+
+function buildBookingQueryParams(params: BookingFilterParams): Record<string, string | number | undefined> {
+  const qp: Record<string, string | number | undefined> = {};
+  if (params.status !== undefined) qp.status = params.status;
+  if (params.attendeeEmail !== undefined) qp.attendeeEmail = params.attendeeEmail;
+  if (params.attendeeName !== undefined) qp.attendeeName = params.attendeeName;
+  if (params.eventTypeId !== undefined) qp.eventTypeId = params.eventTypeId;
+  if (params.eventTypeIds !== undefined) qp.eventTypeIds = params.eventTypeIds;
+  if (params.afterStart !== undefined) qp.afterStart = params.afterStart;
+  if (params.beforeEnd !== undefined) qp.beforeEnd = params.beforeEnd;
+  if (params.afterCreatedAt !== undefined) qp.afterCreatedAt = params.afterCreatedAt;
+  if (params.beforeCreatedAt !== undefined) qp.beforeCreatedAt = params.beforeCreatedAt;
+  if (params.afterUpdatedAt !== undefined) qp.afterUpdatedAt = params.afterUpdatedAt;
+  if (params.beforeUpdatedAt !== undefined) qp.beforeUpdatedAt = params.beforeUpdatedAt;
+  if (params.bookingUid !== undefined) qp.bookingUid = params.bookingUid;
+  if (params.sortStart !== undefined) qp.sortStart = params.sortStart;
+  if (params.sortEnd !== undefined) qp.sortEnd = params.sortEnd;
+  if (params.sortCreated !== undefined) qp.sortCreated = params.sortCreated;
+  if (params.sortUpdatedAt !== undefined) qp.sortUpdatedAt = params.sortUpdatedAt;
+  if (params.take !== undefined) qp.take = params.take;
+  if (params.skip !== undefined) qp.skip = params.skip;
+  return qp;
+}
+
+// ── Org Team Bookings ──
+
+export const getOrgTeamBookingsSchema = {
+  orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  teamId: z.number().int().describe("Team ID within the organization."),
+  ...bookingFiltersSchema,
+};
+
+export async function getOrgTeamBookings(params: { orgId: number; teamId: number } & BookingFilterParams) {
+  try {
+    const qp = buildBookingQueryParams(params);
+    const data = await calApi(`organizations/${params.orgId}/teams/${params.teamId}/bookings`, { params: qp });
+    return ok(data);
+  } catch (err) {
+    return handleError("get_org_team_bookings", err);
+  }
+}
+
+// ── Org User Bookings ──
+
+export const getOrgUserBookingsSchema = {
+  orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  userId: z.number().int().describe("User ID of the organization member whose bookings to retrieve."),
+  teamId: z.number().int().optional().describe("Filter by team ID"),
+  teamsIds: z.string().optional().describe("Comma-separated team IDs (e.g. '50,60')"),
+  ...bookingFiltersSchema,
+};
+
+export async function getOrgUserBookings(params: { orgId: number; userId: number; teamId?: number; teamsIds?: string } & BookingFilterParams) {
+  try {
+    const qp = buildBookingQueryParams(params);
+    if (params.teamId !== undefined) qp.teamId = params.teamId;
+    if (params.teamsIds !== undefined) qp.teamsIds = params.teamsIds;
+    const data = await calApi(`organizations/${params.orgId}/users/${params.userId}/bookings`, { params: qp });
+    return ok(data);
+  } catch (err) {
+    return handleError("get_org_user_bookings", err);
+  }
+}

--- a/apps/mcp-server/src/tools/organizations/index.ts
+++ b/apps/mcp-server/src/tools/organizations/index.ts
@@ -1,2 +1,3 @@
+export * from "./bookings.js";
 export * from "./memberships.js";
 export * from "./routing-forms.js";


### PR DESCRIPTION
## Summary

Adds two new read-only MCP tools for org-level booking queries:

- **`get_org_team_bookings`** — lists all bookings for a team within an org (`GET /v2/organizations/:orgId/teams/:teamId/bookings`). Requires `TEAM_ADMIN` role.
- **`get_org_user_bookings`** — lists all bookings for a specific org member (`GET /v2/organizations/:orgId/users/:userId/bookings`). Requires `ORG_ADMIN` role.

Both tools share a `bookingFiltersSchema` / `buildBookingQueryParams` helper for the full filter set: `status`, `attendeeEmail`, `attendeeName`, `eventTypeId`, `eventTypeIds`, date ranges (`afterStart`, `beforeEnd`, `afterCreatedAt`, `beforeCreatedAt`, `afterUpdatedAt`, `beforeUpdatedAt`), sorting, and pagination.

The `get_org_user_bookings` tool additionally exposes `teamId`/`teamsIds` filters (meaningful when querying a user's bookings across teams), while `get_org_team_bookings` omits them (team is in the URL path).

Companion PR to https://github.com/calcom/cal/pull/3208 which ensures the API endpoint accepts the full filter set.

Link to Devin session: https://app.devin.ai/sessions/0595f15c3b0c497d9f4ab3b202abfaa9
Requested by: @joeauyeung