### PR TITLE
refactor(mcp): document attribute tools

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -4,7 +4,7 @@ A **Model Context Protocol (MCP)** server that wraps the [Cal.com Platform API v
 
 ## Features
 
-- **35 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Routing Forms, Organizations, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- **42 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Routing Forms, Organizations, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
 - **Dual transport** — stdio for local dev tooling, StreamableHTTP for remote/production
 - **Dual auth** — API key for stdio (local dev), OAuth 2.1 Authorization Code + PKCE for HTTP (production)
 - **Per-user token storage** — encrypted at rest with AES-256-GCM in SQLite
@@ -178,7 +178,7 @@ The server acts as an intermediary: it issues its own access tokens to MCP clien
 - Expired tokens are cleaned up automatically every 5 minutes
 - In-process rate limiting on all OAuth endpoints (token bucket per IP, configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX`)
 
-## Tools (35)
+## Tools (42)
 
 Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specification/draft/server/tools#tool-annotations) — a human-readable `title` plus behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so MCP clients can render them appropriately and apply safety policies.
 
@@ -250,6 +250,17 @@ Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specifi
 | Tool | Title | Hint | Description |
 |---|---|---|---|
 | `calculate_routing_form_slots` | Calculate Routing Form Slots | Create | Submit a routing form response and get available slots |
+
+### Organizations: Attributes (7)
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_org_attributes` | List Org Attributes | Read | List attributes defined for an organization |
+| `get_org_attribute` | Get Org Attribute | Read | Get a single organization attribute by ID |
+| `get_attribute_options` | List Attribute Options | Read | List available options for a select attribute |
+| `get_user_attributes` | Get User Attributes | Read | Get attribute options assigned to a user |
+| `assign_attribute_to_user` | Assign Attribute to User | Create | Assign an attribute option or value to a user |
+| `update_user_attribute` | Update User Attribute Assignment | Update | Update an existing user attribute assignment |
+| `unassign_attribute_from_user` | Unassign Attribute from User | Destructive | Remove an attribute option assignment from a user |
 
 ### Organizations: Memberships (5)
 | Tool | Title | Hint | Description |

--- a/apps/mcp-server/src/server-instructions.ts
+++ b/apps/mcp-server/src/server-instructions.ts
@@ -16,6 +16,7 @@ CAPABILITIES — what you CAN do with the available tools:
 - List connected conferencing apps
 - Work with routing forms and their responses (organization-level)
 - Manage organization memberships
+- Read organization attributes, list attribute options, and manage user attribute assignments
 
 LIMITATIONS — what you CANNOT do (do NOT attempt to use other tools for these):
 - Delete or remove attendees from a booking
@@ -29,7 +30,7 @@ LIMITATIONS — what you CANNOT do (do NOT attempt to use other tools for these)
 
 RULES:
 1. If a user asks for something not listed under CAPABILITIES, tell them clearly: "The Cal.com integration doesn't support [action] yet." Do NOT call a different tool hoping it might work.
-2. NEVER guess or fabricate IDs, emails, names, phone numbers, or time zones. If you don't have a value, either use the appropriate discovery tool (e.g., get_me, get_event_types, get_bookings, get_org_memberships) or ask the user.
+2. NEVER guess or fabricate IDs, emails, names, phone numbers, or time zones. If you don't have a value, either use the appropriate discovery tool (e.g., get_me, get_event_types, get_bookings, get_org_memberships, get_org_attributes, get_attribute_options, get_user_attributes) or ask the user.
 3. Before creating or rescheduling a booking, ALWAYS check availability first using get_availability.
-4. For destructive actions (delete event type, cancel booking, delete schedule, delete membership), confirm with the user before proceeding.
+4. For destructive actions (delete event type, cancel booking, delete schedule, delete membership, unassign attribute from user), confirm with the user before proceeding.
 5. All date/time values sent to the API must be in UTC ISO 8601 format.`;


### PR DESCRIPTION
## Summary
- Add PR #99 attribute tools to MCP server initialization instructions.
- Update the MCP README inventory from 35 to 42 tools.
- Document the seven organization attribute tools with their hint categories.
- Align `get_org_attribute` tool metadata with the live API response shape; options are listed through `get_attribute_options`.

## Test Plan
- git diff --check
- bun --filter @calcom/mcp-server test
- bun --filter @calcom/mcp-server typecheck
- bun --filter @calcom/mcp-server lint
- Local API v2 smoke: `NODE_OPTIONS="--max_old_space_size=8192" yarn dev` in `/Users/dhairyashilshinde/work/calcom/cal/apps/api/v2`
- Direct REST smoke against local Docker DB: `GET /v2/organizations/5/attributes?take=1` using `owner1-acme@example.com` API key
- MCP stdio smoke via `/tmp/mcp-pr99-full-smoke.mjs`: tools/list returned 42 tools and all seven attribute tools; verified get/list/options/get-user/assign/update/unassign flow against Acme org data

Stacked on #99.