### PR TITLE
feat(mcp-server): add get_booking_routing_trace tool

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -4,7 +4,7 @@ A **Model Context Protocol (MCP)** server that wraps the [Cal.com Platform API v
 
 ## Features
 
-- **42 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Routing Forms, Organizations, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- **43 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Routing Forms, Organizations, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
 - **Dual transport** — stdio for local dev tooling, StreamableHTTP for remote/production
 - **Dual auth** — API key for stdio (local dev), OAuth 2.1 Authorization Code + PKCE for HTTP (production)
 - **Per-user token storage** — encrypted at rest with AES-256-GCM in SQLite
@@ -178,7 +178,7 @@ The server acts as an intermediary: it issues its own access tokens to MCP clien
 - Expired tokens are cleaned up automatically every 5 minutes
 - In-process rate limiting on all OAuth endpoints (token bucket per IP, configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX`)
 
-## Tools (42)
+## Tools (43)
 
 Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specification/draft/server/tools#tool-annotations) — a human-readable `title` plus behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so MCP clients can render them appropriately and apply safety policies.
 
@@ -245,6 +245,11 @@ Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specifi
 | Tool | Title | Hint | Description |
 |---|---|---|---|
 | `get_conferencing_apps` | List Conferencing Apps | Read | List conferencing applications |
+
+### Booking Routing Trace (1)
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_booking_routing_trace` | Get Booking Routing Trace | Read | Get the step-by-step routing decision path for a booking (routing form evaluation, CRM lookups, host selection). Only for bookings that completed routing. |
 
 ### Routing Forms (1)
 | Tool | Title | Hint | Description |

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -73,6 +73,12 @@ import {
   calculateRoutingFormSlots,
 } from "./tools/routing-forms.js";
 
+// ── Booking Routing Trace ──
+import {
+  getBookingRoutingTraceSchema,
+  getBookingRoutingTrace,
+} from "./tools/booking-routing-trace.js";
+
 // ── Organizations: Memberships ──
 import {
   getOrgMembershipsSchema,
@@ -441,6 +447,19 @@ export function registerTools(server: McpServer): void {
       annotations: READ_ONLY,
     },
     getConferencingApps,
+  );
+
+  // ── Booking Routing Trace (1) ──
+  server.registerTool(
+    "get_booking_routing_trace",
+    {
+      title: "Get Booking Routing Trace",
+      description:
+        "Get the routing trace for a booking — the step-by-step decision path showing how the booking was routed (routing form evaluation, CRM lookups, host selection). Returns human-readable steps grouped by round, plus the routing form submission answers. Only available for bookings that completed routing (permanent traces). Use get_bookings to find booking UIDs.",
+      inputSchema: getBookingRoutingTraceSchema,
+      annotations: READ_ONLY,
+    },
+    getBookingRoutingTrace,
   );
 
   // ── Routing Forms (1) ──

--- a/apps/mcp-server/src/server-instructions.ts
+++ b/apps/mcp-server/src/server-instructions.ts
@@ -15,6 +15,7 @@ CAPABILITIES — what you CAN do with the available tools:
 - View connected calendars and busy times
 - List connected conferencing apps
 - Work with routing forms and their responses (organization-level)
+- View the routing trace for a booking — how it was routed (get_booking_routing_trace)
 - Manage organization memberships
 - Read organization attributes, list attribute options, and manage user attribute assignments
 

--- a/apps/mcp-server/src/tools/booking-routing-trace.test.ts
+++ b/apps/mcp-server/src/tools/booking-routing-trace.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CalApiError } from "../utils/errors.js";
+
+vi.mock("../utils/api-client.js", () => ({
+  calApi: vi.fn(),
+}));
+
+import { calApi } from "../utils/api-client.js";
+import { getBookingRoutingTraceSchema, getBookingRoutingTrace } from "./booking-routing-trace.js";
+
+const mockCalApi = vi.mocked(calApi);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getBookingRoutingTraceSchema", () => {
+  it("exports schema with bookingUid", () => {
+    expect(getBookingRoutingTraceSchema.bookingUid).toBeDefined();
+  });
+});
+
+describe("getBookingRoutingTrace", () => {
+  it("calls correct endpoint with bookingUid", async () => {
+    const mockData = {
+      steps: [{ message: "Route matched: 'Enterprise'", round: 1, domain: "routing-form" }],
+      groups: [{ round: 1, domain: "routing-form", steps: [] }],
+      formSubmission: { form: { name: "Lead Router" }, responses: [] },
+    };
+    mockCalApi.mockResolvedValueOnce(mockData);
+
+    const result = await getBookingRoutingTrace({ bookingUid: "booking-abc123" });
+
+    expect(mockCalApi).toHaveBeenCalledWith("bookings/booking-abc123/routing-trace");
+    expect(JSON.parse(result.content[0].text)).toEqual(mockData);
+  });
+
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(404, "Not found", {}));
+
+    const result = await getBookingRoutingTrace({ bookingUid: "nonexistent" });
+
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("404");
+  });
+
+  it("rethrows non-CalApiError errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new TypeError("Network error"));
+
+    await expect(getBookingRoutingTrace({ bookingUid: "abc" })).rejects.toThrow(TypeError);
+  });
+
+  it("rejects path traversal in bookingUid", async () => {
+    await expect(getBookingRoutingTrace({ bookingUid: "../etc/passwd" })).rejects.toThrow(
+      "Invalid path segment",
+    );
+  });
+});

--- a/apps/mcp-server/src/tools/booking-routing-trace.ts
+++ b/apps/mcp-server/src/tools/booking-routing-trace.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { calApi } from "../utils/api-client.js";
+import { sanitizePathSegment } from "../utils/path-sanitizer.js";
+import { handleError, ok } from "../utils/tool-helpers.js";
+
+export const getBookingRoutingTraceSchema = {
+  bookingUid: z.string().describe("Booking UID to get the routing trace for. Use get_bookings to find UIDs."),
+};
+
+export async function getBookingRoutingTrace(params: { bookingUid: string }) {
+  try {
+    const uid = sanitizePathSegment(params.bookingUid);
+    const data = await calApi(`bookings/${uid}/routing-trace`);
+    return ok(data);
+  } catch (err) {
+    return handleError("get_booking_routing_trace", err);
+  }
+}


### PR DESCRIPTION
## Summary

Adds `get_booking_routing_trace` MCP tool that calls `GET /v2/bookings/:bookingUid/routing-trace` (shipped in calcom/cal#3160).

Returns the human-readable routing decision path for a booking — routing form evaluation, CRM lookups, host selection steps grouped by round, plus the form submission answers. Only works for bookings with permanent (finalized) routing traces.

**New files:**
- `apps/mcp-server/src/tools/booking-routing-trace.ts` — schema + handler
- `apps/mcp-server/src/tools/booking-routing-trace.test.ts` — 5 unit tests

**Modified:**
- `apps/mcp-server/src/register-tools.ts` — import + `server.registerTool("get_booking_routing_trace", ...)` with `READ_ONLY` annotations

The API v2 endpoint needs to be deployed before this tool will function end-to-end.

Link to Devin session: https://app.devin.ai/sessions/b4d631b8dcd548c195a96f40505a86b9
Requested by: @joeauyeung