### PR TITLE
feat(mcp-server): add get_org_teams tool for team discovery

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -4,7 +4,7 @@ A **Model Context Protocol (MCP)** server that wraps the [Cal.com Platform API v
 
 ## Features
 
-- **42 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Routing Forms, Organizations, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- **44 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Routing Forms, Organizations, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
 - **Dual transport** — stdio for local dev tooling, StreamableHTTP for remote/production
 - **Dual auth** — API key for stdio (local dev), OAuth 2.1 Authorization Code + PKCE for HTTP (production)
 - **Per-user token storage** — encrypted at rest with AES-256-GCM in SQLite
@@ -178,7 +178,7 @@ The server acts as an intermediary: it issues its own access tokens to MCP clien
 - Expired tokens are cleaned up automatically every 5 minutes
 - In-process rate limiting on all OAuth endpoints (token bucket per IP, configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX`)
 
-## Tools (42)
+## Tools (44)
 
 Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specification/draft/server/tools#tool-annotations) — a human-readable `title` plus behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so MCP clients can render them appropriately and apply safety policies.
 
@@ -270,6 +270,12 @@ Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specifi
 | `get_org_membership` | Get Org Membership | Read | Get an organization membership |
 | `update_org_membership` | Update Org Membership | Update | Update an organization membership (role, accepted, impersonation) |
 | `delete_org_membership` | Delete Org Membership | Destructive | Delete an organization membership |
+
+### Organizations: Teams (2)
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_org_teams` | List All Org Teams | Read | List all teams in an organization; requires org admin access |
+| `get_my_teams` | List My Teams | Read | List teams the authenticated user belongs to |
 
 ### Organizations: Routing Forms (2)
 | Tool | Title | Hint | Description |

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -105,6 +105,9 @@ import {
   updateOrgMembership,
 } from "./tools/organizations/memberships.js";
 
+// ── Organizations: Teams ──
+import { getOrgTeamsSchema, getOrgTeams } from "./tools/organizations/teams.js";
+
 // ── Organizations: Routing Forms ──
 import {
   getOrgRoutingFormsSchema,
@@ -606,6 +609,19 @@ export function registerTools(server: McpServer): void {
       annotations: UPDATE,
     },
     updateOrgMembership,
+  );
+
+  // ── Organizations: Teams (1) ──
+  server.registerTool(
+    "get_org_teams",
+    {
+      title: "List Org Teams",
+      description:
+        "List teams in an organization that the authenticated user belongs to (org admins see all teams). Use get_me to obtain your organizationId. Returns team IDs, names, and slugs needed by other team-scoped tools.",
+      inputSchema: getOrgTeamsSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgTeams,
   );
 
   // ── Organizations: Routing Forms (2) ──

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -106,7 +106,7 @@ import {
 } from "./tools/organizations/memberships.js";
 
 // ── Organizations: Teams ──
-import { getOrgTeamsSchema, getOrgTeams } from "./tools/organizations/teams.js";
+import { getOrgTeamsSchema, getOrgTeams, getMyTeamsSchema, getMyTeams } from "./tools/organizations/teams.js";
 
 // ── Organizations: Routing Forms ──
 import {
@@ -611,17 +611,28 @@ export function registerTools(server: McpServer): void {
     updateOrgMembership,
   );
 
-  // ── Organizations: Teams (1) ──
+  // ── Organizations: Teams (2) ──
   server.registerTool(
     "get_org_teams",
     {
-      title: "List Org Teams",
+      title: "List All Org Teams",
       description:
-        "List teams in an organization that the authenticated user belongs to (org admins see all teams). Use get_me to obtain your organizationId. Returns team IDs, names, and slugs needed by other team-scoped tools.",
+        "List all teams in an organization. Requires ORG_ADMIN role. Use get_me to obtain your organizationId. Returns team IDs, names, and slugs needed by other team-scoped tools. If this fails with 403, use get_my_teams instead.",
       inputSchema: getOrgTeamsSchema,
       annotations: READ_ONLY,
     },
     getOrgTeams,
+  );
+  server.registerTool(
+    "get_my_teams",
+    {
+      title: "List My Teams",
+      description:
+        "List teams the authenticated user belongs to. Works for any org member (org admins see all teams). Use get_me to obtain your organizationId. Returns team IDs, names, and slugs needed by other team-scoped tools.",
+      inputSchema: getMyTeamsSchema,
+      annotations: READ_ONLY,
+    },
+    getMyTeams,
   );
 
   // ── Organizations: Routing Forms (2) ──

--- a/apps/mcp-server/src/server-instructions.ts
+++ b/apps/mcp-server/src/server-instructions.ts
@@ -16,6 +16,7 @@ CAPABILITIES — what you CAN do with the available tools:
 - List connected conferencing apps
 - Work with routing forms and their responses (organization-level)
 - Manage organization memberships
+- List organization teams and list teams the authenticated user belongs to
 - Read organization attributes, list attribute options, and manage user attribute assignments
 
 LIMITATIONS — what you CANNOT do (do NOT attempt to use other tools for these):
@@ -23,14 +24,15 @@ LIMITATIONS — what you CANNOT do (do NOT attempt to use other tools for these)
 - Create, update, or delete teams
 - Manage webhooks or integrations
 - Manage apps or connected calendar settings
-- Manage organization-level event types or teams
+- Manage organization-level event types
+- Create, update, or delete organization teams
 - Send emails or messages to attendees
 - Access or modify payment/billing settings
 - Create or manage workflows/automations
 
 RULES:
 1. If a user asks for something not listed under CAPABILITIES, tell them clearly: "The Cal.com integration doesn't support [action] yet." Do NOT call a different tool hoping it might work.
-2. NEVER guess or fabricate IDs, emails, names, phone numbers, or time zones. If you don't have a value, either use the appropriate discovery tool (e.g., get_me, get_event_types, get_bookings, get_org_memberships, get_org_attributes, get_attribute_options, get_user_attributes) or ask the user.
+2. NEVER guess or fabricate IDs, emails, names, phone numbers, or time zones. If you don't have a value, either use the appropriate discovery tool (e.g., get_me, get_event_types, get_bookings, get_org_memberships, get_org_teams, get_my_teams, get_org_attributes, get_attribute_options, get_user_attributes) or ask the user.
 3. Before creating or rescheduling a booking, ALWAYS check availability first using get_availability.
 4. For destructive actions (delete event type, cancel booking, delete schedule, delete membership, unassign attribute from user), confirm with the user before proceeding.
 5. All date/time values sent to the API must be in UTC ISO 8601 format.`;

--- a/apps/mcp-server/src/tools/organizations/index.ts
+++ b/apps/mcp-server/src/tools/organizations/index.ts
@@ -1,3 +1,4 @@
 export * from "./attributes.js";
 export * from "./memberships.js";
 export * from "./routing-forms.js";
+export * from "./teams.js";

--- a/apps/mcp-server/src/tools/organizations/teams.test.ts
+++ b/apps/mcp-server/src/tools/organizations/teams.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CalApiError } from "../../utils/errors.js";
+
+vi.mock("../../utils/api-client.js", () => ({ calApi: vi.fn() }));
+
+import { calApi } from "../../utils/api-client.js";
+import { getOrgTeams, getOrgTeamsSchema } from "./teams.js";
+
+const mockCalApi = vi.mocked(calApi);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getOrgTeams", () => {
+  it("exports getOrgTeamsSchema", () => {
+    expect(getOrgTeamsSchema).toBeDefined();
+  });
+
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [{ id: 1, name: "Engineering" }] });
+    const result = await getOrgTeams({ orgId: 1 });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({
+      status: "success",
+      data: [{ id: 1, name: "Engineering" }],
+    });
+  });
+
+  it("passes pagination params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
+    await getOrgTeams({ orgId: 5, take: 10, skip: 20 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/5/teams/me", {
+      params: { take: 10, skip: 20 },
+    });
+  });
+
+  it("omits undefined pagination params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
+    await getOrgTeams({ orgId: 3 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/3/teams/me", { params: {} });
+  });
+
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(403, "Forbidden", {}));
+    const result = await getOrgTeams({ orgId: 1 });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("403");
+  });
+});

--- a/apps/mcp-server/src/tools/organizations/teams.test.ts
+++ b/apps/mcp-server/src/tools/organizations/teams.test.ts
@@ -4,7 +4,7 @@ import { CalApiError } from "../../utils/errors.js";
 vi.mock("../../utils/api-client.js", () => ({ calApi: vi.fn() }));
 
 import { calApi } from "../../utils/api-client.js";
-import { getOrgTeams, getOrgTeamsSchema } from "./teams.js";
+import { getMyTeams, getMyTeamsSchema, getOrgTeams, getOrgTeamsSchema } from "./teams.js";
 
 const mockCalApi = vi.mocked(calApi);
 
@@ -17,9 +17,10 @@ describe("getOrgTeams", () => {
     expect(getOrgTeamsSchema).toBeDefined();
   });
 
-  it("returns data on success", async () => {
+  it("calls the admin teams endpoint", async () => {
     mockCalApi.mockResolvedValueOnce({ status: "success", data: [{ id: 1, name: "Engineering" }] });
     const result = await getOrgTeams({ orgId: 1 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/teams", { params: {} });
     expect(result.content[0].type).toBe("text");
     expect(JSON.parse(result.content[0].text)).toEqual({
       status: "success",
@@ -30,15 +31,9 @@ describe("getOrgTeams", () => {
   it("passes pagination params", async () => {
     mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
     await getOrgTeams({ orgId: 5, take: 10, skip: 20 });
-    expect(mockCalApi).toHaveBeenCalledWith("organizations/5/teams/me", {
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/5/teams", {
       params: { take: 10, skip: 20 },
     });
-  });
-
-  it("omits undefined pagination params", async () => {
-    mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
-    await getOrgTeams({ orgId: 3 });
-    expect(mockCalApi).toHaveBeenCalledWith("organizations/3/teams/me", { params: {} });
   });
 
   it("handles API errors", async () => {
@@ -46,5 +41,37 @@ describe("getOrgTeams", () => {
     const result = await getOrgTeams({ orgId: 1 });
     expect(result).toHaveProperty("isError", true);
     expect(result.content[0].text).toContain("403");
+  });
+});
+
+describe("getMyTeams", () => {
+  it("exports getMyTeamsSchema", () => {
+    expect(getMyTeamsSchema).toBeDefined();
+  });
+
+  it("calls the /me teams endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [{ id: 2, name: "Sales" }] });
+    const result = await getMyTeams({ orgId: 1 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/teams/me", { params: {} });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({
+      status: "success",
+      data: [{ id: 2, name: "Sales" }],
+    });
+  });
+
+  it("passes pagination params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
+    await getMyTeams({ orgId: 3, take: 5, skip: 0 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/3/teams/me", {
+      params: { take: 5, skip: 0 },
+    });
+  });
+
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(401, "Unauthorized", {}));
+    const result = await getMyTeams({ orgId: 1 });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("401");
   });
 });

--- a/apps/mcp-server/src/tools/organizations/teams.ts
+++ b/apps/mcp-server/src/tools/organizations/teams.ts
@@ -16,9 +16,30 @@ export async function getOrgTeams(params: { orgId: number; take?: number; skip?:
     const qp: Record<string, string | number | boolean | undefined> = {};
     if (params.take !== undefined) qp.take = params.take;
     if (params.skip !== undefined) qp.skip = params.skip;
-    const data = await calApi(`organizations/${params.orgId}/teams/me`, { params: qp });
+    const data = await calApi(`organizations/${params.orgId}/teams`, { params: qp });
     return ok(data);
   } catch (err) {
     return handleError("get_org_teams", err);
+  }
+}
+
+export const getMyTeamsSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  take: z.number().optional().describe("Max results to return (default 250)"),
+  skip: z.number().optional().describe("Results to skip (offset)"),
+};
+
+export async function getMyTeams(params: { orgId: number; take?: number; skip?: number }) {
+  try {
+    const qp: Record<string, string | number | boolean | undefined> = {};
+    if (params.take !== undefined) qp.take = params.take;
+    if (params.skip !== undefined) qp.skip = params.skip;
+    const data = await calApi(`organizations/${params.orgId}/teams/me`, { params: qp });
+    return ok(data);
+  } catch (err) {
+    return handleError("get_my_teams", err);
   }
 }

--- a/apps/mcp-server/src/tools/organizations/teams.ts
+++ b/apps/mcp-server/src/tools/organizations/teams.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { calApi } from "../../utils/api-client.js";
+import { handleError, ok } from "../../utils/tool-helpers.js";
+
+export const getOrgTeamsSchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  take: z.number().optional().describe("Max results to return (default 250)"),
+  skip: z.number().optional().describe("Results to skip (offset)"),
+};
+
+export async function getOrgTeams(params: { orgId: number; take?: number; skip?: number }) {
+  try {
+    const qp: Record<string, string | number | boolean | undefined> = {};
+    if (params.take !== undefined) qp.take = params.take;
+    if (params.skip !== undefined) qp.skip = params.skip;
+    const data = await calApi(`organizations/${params.orgId}/teams/me`, { params: qp });
+    return ok(data);
+  } catch (err) {
+    return handleError("get_org_teams", err);
+  }
+}


### PR DESCRIPTION
## Summary

Adds two MCP tools for team discovery within an organization:

- **`get_org_teams`** — `GET /v2/organizations/:orgId/teams` (requires ORG_ADMIN). Lists all teams.
- **`get_my_teams`** — `GET /v2/organizations/:orgId/teams/me` (any ORG_MEMBER). Lists teams the user belongs to.

These enable the LLM to discover team IDs needed by other team-scoped tools (e.g. team memberships from PR #100, future team event types). The discovery flow is: `get_me` → `organizationId` → `get_org_teams` / `get_my_teams` → use `teamId`.

Both support `take`/`skip` pagination. 8 unit tests covering endpoint routing, pagination passthrough, and error handling.

Link to Devin session: https://app.devin.ai/sessions/4bbd04af274044beb62c14832a64d296
Requested by: @joeauyeung