### PR TITLE
fix(mcp): align org team pagination with OpenAPI

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -274,8 +274,8 @@ Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specifi
 ### Organizations: Teams (2)
 | Tool | Title | Hint | Description |
 |---|---|---|---|
-| `get_org_teams` | List All Org Teams | Read | List all teams in an organization; requires org admin access |
-| `get_my_teams` | List My Teams | Read | List teams the authenticated user belongs to |
+| `get_org_teams` | List All Org Teams | Read | List all teams in an organization; requires org admin access; supports `take`/`skip` pagination (`take` max 250) |
+| `get_my_teams` | List My Teams | Read | List teams the authenticated user belongs to; supports `take`/`skip` pagination (`take` max 250) |
 
 ### Organizations: Routing Forms (2)
 | Tool | Title | Hint | Description |

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -62,7 +62,12 @@ import {
 import { getAvailabilitySchema, getAvailability } from "./tools/availability.js";
 
 // ── Calendars ──
-import { getConnectedCalendarsSchema, getConnectedCalendars, getBusyTimesSchema, getBusyTimes } from "./tools/calendars.js";
+import {
+  getConnectedCalendarsSchema,
+  getConnectedCalendars,
+  getBusyTimesSchema,
+  getBusyTimes,
+} from "./tools/calendars.js";
 
 // ── Conferencing ──
 import { getConferencingAppsSchema, getConferencingApps } from "./tools/conferencing.js";
@@ -106,7 +111,12 @@ import {
 } from "./tools/organizations/memberships.js";
 
 // ── Organizations: Teams ──
-import { getOrgTeamsSchema, getOrgTeams, getMyTeamsSchema, getMyTeams } from "./tools/organizations/teams.js";
+import {
+  getOrgTeamsSchema,
+  getOrgTeams,
+  getMyTeamsSchema,
+  getMyTeams,
+} from "./tools/organizations/teams.js";
 
 // ── Organizations: Routing Forms ──
 import {
@@ -169,7 +179,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getMeSchema,
       annotations: READ_ONLY,
     },
-    getMe,
+    getMe
   );
   server.registerTool(
     "update_me",
@@ -180,7 +190,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateMeSchema,
       annotations: UPDATE,
     },
-    updateMe,
+    updateMe
   );
 
   // ── Event Types (5) ──
@@ -193,7 +203,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getEventTypesSchema,
       annotations: READ_ONLY,
     },
-    getEventTypes,
+    getEventTypes
   );
   server.registerTool(
     "get_event_type",
@@ -204,7 +214,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getEventTypeSchema,
       annotations: READ_ONLY,
     },
-    getEventType,
+    getEventType
   );
   server.registerTool(
     "create_event_type",
@@ -215,7 +225,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: createEventTypeSchema,
       annotations: CREATE,
     },
-    createEventType,
+    createEventType
   );
   server.registerTool(
     "update_event_type",
@@ -226,7 +236,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateEventTypeSchema,
       annotations: UPDATE,
     },
-    updateEventType,
+    updateEventType
   );
   server.registerTool(
     "delete_event_type",
@@ -237,7 +247,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: deleteEventTypeSchema,
       annotations: DESTRUCTIVE,
     },
-    deleteEventType,
+    deleteEventType
   );
 
   // ── Bookings (10) ──
@@ -250,7 +260,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingsSchema,
       annotations: READ_ONLY,
     },
-    getBookings,
+    getBookings
   );
   server.registerTool(
     "get_booking",
@@ -261,7 +271,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingSchema,
       annotations: READ_ONLY,
     },
-    getBooking,
+    getBooking
   );
   server.registerTool(
     "create_booking",
@@ -272,7 +282,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: createBookingSchema,
       annotations: CREATE,
     },
-    createBooking,
+    createBooking
   );
   server.registerTool(
     "reschedule_booking",
@@ -283,7 +293,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: rescheduleBookingSchema,
       annotations: UPDATE,
     },
-    rescheduleBooking,
+    rescheduleBooking
   );
   server.registerTool(
     "cancel_booking",
@@ -294,17 +304,18 @@ export function registerTools(server: McpServer): void {
       inputSchema: cancelBookingSchema,
       annotations: DESTRUCTIVE,
     },
-    cancelBooking,
+    cancelBooking
   );
   server.registerTool(
     "confirm_booking",
     {
       title: "Confirm Booking",
-      description: "Confirm a pending booking that requires manual confirmation. Only the host can confirm.",
+      description:
+        "Confirm a pending booking that requires manual confirmation. Only the host can confirm.",
       inputSchema: confirmBookingSchema,
       annotations: UPDATE,
     },
-    confirmBooking,
+    confirmBooking
   );
   server.registerTool(
     "mark_booking_absent",
@@ -315,7 +326,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: markBookingAbsentSchema,
       annotations: UPDATE,
     },
-    markBookingAbsent,
+    markBookingAbsent
   );
   server.registerTool(
     "get_booking_attendees",
@@ -325,7 +336,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingAttendeesSchema,
       annotations: READ_ONLY,
     },
-    getBookingAttendees,
+    getBookingAttendees
   );
   server.registerTool(
     "add_booking_attendee",
@@ -336,7 +347,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: addBookingAttendeeSchema,
       annotations: CREATE,
     },
-    addBookingAttendee,
+    addBookingAttendee
   );
   server.registerTool(
     "get_booking_attendee",
@@ -347,7 +358,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingAttendeeSchema,
       annotations: READ_ONLY,
     },
-    getBookingAttendee,
+    getBookingAttendee
   );
 
   // ── Schedules (6) ──
@@ -359,17 +370,18 @@ export function registerTools(server: McpServer): void {
       inputSchema: getSchedulesSchema,
       annotations: READ_ONLY,
     },
-    getSchedules,
+    getSchedules
   );
   server.registerTool(
     "get_schedule",
     {
       title: "Get Schedule",
-      description: "Get a specific schedule by its numeric ID. Returns availability slots and overrides.",
+      description:
+        "Get a specific schedule by its numeric ID. Returns availability slots and overrides.",
       inputSchema: getScheduleSchema,
       annotations: READ_ONLY,
     },
-    getSchedule,
+    getSchedule
   );
   server.registerTool(
     "create_schedule",
@@ -380,17 +392,18 @@ export function registerTools(server: McpServer): void {
       inputSchema: createScheduleSchema,
       annotations: CREATE,
     },
-    createSchedule,
+    createSchedule
   );
   server.registerTool(
     "update_schedule",
     {
       title: "Update Schedule",
-      description: "Update an existing schedule. Array fields (availability, overrides) replace all existing entries.",
+      description:
+        "Update an existing schedule. Array fields (availability, overrides) replace all existing entries.",
       inputSchema: updateScheduleSchema,
       annotations: UPDATE,
     },
-    updateSchedule,
+    updateSchedule
   );
   server.registerTool(
     "delete_schedule",
@@ -401,7 +414,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: deleteScheduleSchema,
       annotations: DESTRUCTIVE,
     },
-    deleteSchedule,
+    deleteSchedule
   );
   server.registerTool(
     "get_default_schedule",
@@ -411,7 +424,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getDefaultScheduleSchema,
       annotations: READ_ONLY,
     },
-    getDefaultSchedule,
+    getDefaultSchedule
   );
 
   // ── Availability / Slots (1) ──
@@ -424,7 +437,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getAvailabilitySchema,
       annotations: READ_ONLY,
     },
-    getAvailability,
+    getAvailability
   );
 
   // ── Calendars (2) ──
@@ -437,7 +450,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getConnectedCalendarsSchema,
       annotations: READ_ONLY,
     },
-    getConnectedCalendars,
+    getConnectedCalendars
   );
   server.registerTool(
     "get_busy_times",
@@ -448,7 +461,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBusyTimesSchema,
       annotations: READ_ONLY,
     },
-    getBusyTimes,
+    getBusyTimes
   );
 
   // ── Conferencing (1) ──
@@ -461,7 +474,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getConferencingAppsSchema,
       annotations: READ_ONLY,
     },
-    getConferencingApps,
+    getConferencingApps
   );
 
   // ── Routing Forms (1) ──
@@ -474,7 +487,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: calculateRoutingFormSlotsSchema,
       annotations: CREATE,
     },
-    calculateRoutingFormSlots,
+    calculateRoutingFormSlots
   );
 
   // ── Organizations: Attributes (7) ──
@@ -487,7 +500,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgAttributesSchema,
       annotations: READ_ONLY,
     },
-    getOrgAttributes,
+    getOrgAttributes
   );
   server.registerTool(
     "get_org_attribute",
@@ -498,7 +511,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgAttributeSchema,
       annotations: READ_ONLY,
     },
-    getOrgAttribute,
+    getOrgAttribute
   );
   server.registerTool(
     "get_attribute_options",
@@ -509,7 +522,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getAttributeOptionsSchema,
       annotations: READ_ONLY,
     },
-    getAttributeOptions,
+    getAttributeOptions
   );
   server.registerTool(
     "get_user_attributes",
@@ -520,7 +533,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getUserAttributesSchema,
       annotations: READ_ONLY,
     },
-    getUserAttributes,
+    getUserAttributes
   );
   server.registerTool(
     "assign_attribute_to_user",
@@ -531,7 +544,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: assignAttributeToUserSchema,
       annotations: CREATE,
     },
-    assignAttributeToUser,
+    assignAttributeToUser
   );
   server.registerTool(
     "update_user_attribute",
@@ -542,7 +555,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateUserAttributeSchema,
       annotations: UPDATE,
     },
-    updateUserAttribute,
+    updateUserAttribute
   );
   server.registerTool(
     "unassign_attribute_from_user",
@@ -553,7 +566,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: unassignAttributeFromUserSchema,
       annotations: DESTRUCTIVE,
     },
-    unassignAttributeFromUser,
+    unassignAttributeFromUser
   );
 
   // ── Organizations: Memberships (5) ──
@@ -565,7 +578,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgMembershipsSchema,
       annotations: READ_ONLY,
     },
-    getOrgMemberships,
+    getOrgMemberships
   );
   server.registerTool(
     "create_org_membership",
@@ -576,7 +589,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: createOrgMembershipSchema,
       annotations: CREATE,
     },
-    createOrgMembership,
+    createOrgMembership
   );
   server.registerTool(
     "get_org_membership",
@@ -586,7 +599,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgMembershipSchema,
       annotations: READ_ONLY,
     },
-    getOrgMembership,
+    getOrgMembership
   );
   server.registerTool(
     "delete_org_membership",
@@ -597,7 +610,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: deleteOrgMembershipSchema,
       annotations: DESTRUCTIVE,
     },
-    deleteOrgMembership,
+    deleteOrgMembership
   );
   server.registerTool(
     "update_org_membership",
@@ -608,7 +621,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateOrgMembershipSchema,
       annotations: UPDATE,
     },
-    updateOrgMembership,
+    updateOrgMembership
   );
 
   // ── Organizations: Teams (2) ──
@@ -617,22 +630,22 @@ export function registerTools(server: McpServer): void {
     {
       title: "List All Org Teams",
       description:
-        "List all teams in an organization. Requires ORG_ADMIN role. Use get_me to obtain your organizationId. Returns team IDs, names, and slugs needed by other team-scoped tools. If this fails with 403, use get_my_teams instead.",
+        "List all teams in an organization. Supports take/skip pagination (take max 250). Requires ORG_ADMIN role. Use get_me to obtain your organizationId. Returns team IDs, names, and slugs needed by other team-scoped tools. If this fails with 403, use get_my_teams instead.",
       inputSchema: getOrgTeamsSchema,
       annotations: READ_ONLY,
     },
-    getOrgTeams,
+    getOrgTeams
   );
   server.registerTool(
     "get_my_teams",
     {
       title: "List My Teams",
       description:
-        "List teams the authenticated user belongs to. Works for any org member (org admins see all teams). Use get_me to obtain your organizationId. Returns team IDs, names, and slugs needed by other team-scoped tools.",
+        "List teams the authenticated user belongs to. Supports take/skip pagination (take max 250). Works for any org member (org admins see all teams). Use get_me to obtain your organizationId. Returns team IDs, names, and slugs needed by other team-scoped tools.",
       inputSchema: getMyTeamsSchema,
       annotations: READ_ONLY,
     },
-    getMyTeams,
+    getMyTeams
   );
 
   // ── Organizations: Routing Forms (2) ──
@@ -645,7 +658,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgRoutingFormsSchema,
       annotations: READ_ONLY,
     },
-    getOrgRoutingForms,
+    getOrgRoutingForms
   );
   server.registerTool(
     "get_org_routing_form_responses",
@@ -656,6 +669,6 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgRoutingFormResponsesSchema,
       annotations: READ_ONLY,
     },
-    getOrgRoutingFormResponses,
+    getOrgRoutingFormResponses
   );
 }

--- a/apps/mcp-server/src/tools/organizations/teams.test.ts
+++ b/apps/mcp-server/src/tools/organizations/teams.test.ts
@@ -17,6 +17,15 @@ describe("getOrgTeams", () => {
     expect(getOrgTeamsSchema).toBeDefined();
   });
 
+  it("enforces OpenAPI pagination bounds", () => {
+    expect(getOrgTeamsSchema.take.safeParse(1.5).success).toBe(false);
+    expect(getOrgTeamsSchema.take.safeParse(0).success).toBe(false);
+    expect(getOrgTeamsSchema.take.safeParse(250).success).toBe(true);
+    expect(getOrgTeamsSchema.take.safeParse(251).success).toBe(false);
+    expect(getOrgTeamsSchema.skip.safeParse(1.5).success).toBe(false);
+    expect(getOrgTeamsSchema.skip.safeParse(-1).success).toBe(false);
+  });
+
   it("calls the admin teams endpoint", async () => {
     mockCalApi.mockResolvedValueOnce({ status: "success", data: [{ id: 1, name: "Engineering" }] });
     const result = await getOrgTeams({ orgId: 1 });
@@ -47,6 +56,15 @@ describe("getOrgTeams", () => {
 describe("getMyTeams", () => {
   it("exports getMyTeamsSchema", () => {
     expect(getMyTeamsSchema).toBeDefined();
+  });
+
+  it("enforces OpenAPI pagination bounds", () => {
+    expect(getMyTeamsSchema.take.safeParse(1.5).success).toBe(false);
+    expect(getMyTeamsSchema.take.safeParse(0).success).toBe(false);
+    expect(getMyTeamsSchema.take.safeParse(250).success).toBe(true);
+    expect(getMyTeamsSchema.take.safeParse(251).success).toBe(false);
+    expect(getMyTeamsSchema.skip.safeParse(1.5).success).toBe(false);
+    expect(getMyTeamsSchema.skip.safeParse(-1).success).toBe(false);
   });
 
   it("calls the /me teams endpoint", async () => {

--- a/apps/mcp-server/src/tools/organizations/teams.ts
+++ b/apps/mcp-server/src/tools/organizations/teams.ts
@@ -7,8 +7,8 @@ export const getOrgTeamsSchema = {
     .number()
     .int()
     .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
-  take: z.number().optional().describe("Max results to return (default 250)"),
-  skip: z.number().optional().describe("Results to skip (offset)"),
+  take: z.number().int().min(1).max(250).optional().describe("Max results to return (1-250)"),
+  skip: z.number().int().min(0).optional().describe("Results to skip (offset, min 0)"),
 };
 
 export async function getOrgTeams(params: { orgId: number; take?: number; skip?: number }) {
@@ -28,8 +28,8 @@ export const getMyTeamsSchema = {
     .number()
     .int()
     .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
-  take: z.number().optional().describe("Max results to return (default 250)"),
-  skip: z.number().optional().describe("Results to skip (offset)"),
+  take: z.number().int().min(1).max(250).optional().describe("Max results to return (1-250)"),
+  skip: z.number().int().min(0).optional().describe("Results to skip (offset, min 0)"),
 };
 
 export async function getMyTeams(params: { orgId: number; take?: number; skip?: number }) {


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #106 (`devin/1780538232-add-get-org-teams`).
- Align `get_org_teams` and `get_my_teams` pagination schemas with the Cal API v2 OpenAPI contract.
- Enforce integer `take` in the documented `1..250` range and integer `skip >= 0`.
- Update MCP tool descriptions and README table to mention the `take` max.

## Validation
- `git diff --check`
- `bun --filter @calcom/mcp-server test`
- `bun --filter @calcom/mcp-server typecheck`
- `bun --filter @calcom/mcp-server lint`
- Local MCP stdio smoke against API v2 on `localhost:5555`: confirmed `get_org_teams`/`get_my_teams` registration, valid `get_my_teams` pagination, and rejection of invalid pagination values.