### PR TITLE
feat(mobile): add Confirm/Decline actions to booking-request push notifications

### DIFF
--- a/apps/mobile/components/PushNotificationProvider.tsx
+++ b/apps/mobile/components/PushNotificationProvider.tsx
@@ -128,9 +128,11 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
   const loadingRef = useRef(loading);
   const routerRef = useRef(router);
   const queryClientRef = useRef(queryClient);
-  // A booking-request action received while auth is still restoring is parked
-  // here and replayed by the drain effect once `loading` settles.
-  const pendingActionRef = useRef<Notifications.NotificationResponse | null>(null);
+  // Booking-request actions received while auth is still restoring are parked
+  // here and replayed by the drain effect once `loading` settles. Keep a queue
+  // so multiple actions cannot overwrite each other after they have already
+  // been claimed in the dedupe set.
+  const pendingActionsRef = useRef<Notifications.NotificationResponse[]>([]);
 
   useEffect(() => {
     isAuthenticatedRef.current = isAuthenticated;
@@ -253,13 +255,13 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
       void (async () => {
         await hydrateHandledActions();
         if (!claimActionKeySync(key)) return;
-        void persistHandledActions();
+        await persistHandledActions();
 
         if (loadingRef.current) {
           // Auth is still restoring; park the action and let the drain effect
           // run it once `loading` settles instead of treating it as
           // unauthenticated.
-          pendingActionRef.current = response;
+          pendingActionsRef.current.push(response);
           return;
         }
 
@@ -273,10 +275,12 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
   // Replay a parked action once auth finishes restoring.
   useEffect(() => {
     if (loading) return;
-    const pending = pendingActionRef.current;
-    if (!pending) return;
-    pendingActionRef.current = null;
-    void executeBookingRequestAction(pending);
+    const pending = pendingActionsRef.current;
+    if (pending.length === 0) return;
+    pendingActionsRef.current = [];
+    for (const response of pending) {
+      void executeBookingRequestAction(response);
+    }
   }, [loading, executeBookingRequestAction]);
 
   // Register token on login. The registration promise is tracked in a ref so
@@ -379,7 +383,7 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
         await hydrateHandledActions();
         const key = actionDedupeKey(id, actionId);
         if (!claimActionKeySync(key)) return;
-        void persistHandledActions();
+        await persistHandledActions();
         try {
           Notifications.clearLastNotificationResponse();
         } catch {

--- a/apps/mobile/components/PushNotificationProvider.tsx
+++ b/apps/mobile/components/PushNotificationProvider.tsx
@@ -17,7 +17,7 @@ import {
   requestAndRegisterPushToken,
 } from "@/hooks/use-push-notifications";
 import { CalComAPIService } from "@/services/calcom";
-import { showErrorAlert, showSilentSuccessAlert } from "@/utils/alerts";
+import { showInfoAlert, showSuccessAlert } from "@/utils/alerts";
 
 // How long the pre-logout callback waits for an in-flight registration to
 // settle before deregistering, so a token that registered moments before
@@ -210,10 +210,10 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
       try {
         if (actionId === CONFIRM_BOOKING_REQUEST_ACTION_ID) {
           await CalComAPIService.confirmBooking(bookingUid);
-          showSilentSuccessAlert("Success", "Booking confirmed successfully");
+          showSuccessAlert("Success", "Booking confirmed successfully");
         } else if (actionId === DECLINE_BOOKING_REQUEST_ACTION_ID) {
           await CalComAPIService.declineBooking(bookingUid);
-          showSilentSuccessAlert("Success", "Booking declined successfully");
+          showSuccessAlert("Success", "Booking declined successfully");
         } else {
           return;
         }
@@ -221,9 +221,11 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
       } catch (error) {
         // Includes the non-idempotent "Booking already confirmed" case — show
         // it as feedback rather than retrying, then refresh so the UI reflects
-        // the booking's true server state.
+        // the booking's true server state. The action was triggered from a
+        // notification (likely outside the app), so feedback must be visible on
+        // native — showInfoAlert always surfaces, unlike the dev-only error alert.
         const message = error instanceof Error ? error.message : "Please try again.";
-        showErrorAlert("Action failed", message);
+        showInfoAlert("Action failed", message);
         await refresh();
       }
     },
@@ -241,21 +243,28 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
       }
 
       const key = actionDedupeKey(response.notification.request.identifier, actionId);
-      // Synchronous claim before any await — guarantees the listener and the
-      // cold-start path can't both submit the same action.
-      if (!claimActionKeySync(key)) {
-        return true;
-      }
-      void persistHandledActions();
+      // Hydrate the persisted set before claiming so a cross-session replay (or
+      // a launch response the listener receives before the cold-start effect
+      // hydrates) is recognised. `claimActionKeySync` stays synchronous, so even
+      // if the listener and cold-start paths both await hydration, whichever
+      // resumes first claims and the other sees it claimed — single-threaded
+      // resume keeps the double-submit guarantee intact. We return true
+      // synchronously below so a plain-tap fallthrough is always suppressed.
+      void (async () => {
+        await hydrateHandledActions();
+        if (!claimActionKeySync(key)) return;
+        void persistHandledActions();
 
-      if (loadingRef.current) {
-        // Auth is still restoring; park the action and let the drain effect run
-        // it once `loading` settles instead of treating it as unauthenticated.
-        pendingActionRef.current = response;
-        return true;
-      }
+        if (loadingRef.current) {
+          // Auth is still restoring; park the action and let the drain effect
+          // run it once `loading` settles instead of treating it as
+          // unauthenticated.
+          pendingActionRef.current = response;
+          return;
+        }
 
-      void executeBookingRequestAction(response);
+        void executeBookingRequestAction(response);
+      })();
       return true;
     },
     [executeBookingRequestAction]

--- a/apps/mobile/components/PushNotificationProvider.tsx
+++ b/apps/mobile/components/PushNotificationProvider.tsx
@@ -1,14 +1,23 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useQueryClient } from "@tanstack/react-query";
 import * as Linking from "expo-linking";
 import * as Notifications from "expo-notifications";
 import { useRouter } from "expo-router";
-import { type ReactNode, useEffect, useRef } from "react";
+import { type ReactNode, useCallback, useEffect, useRef } from "react";
+import { queryKeys } from "@/config/cache.config";
+import {
+  BOOKING_REQUEST_CATEGORY_ID,
+  CONFIRM_BOOKING_REQUEST_ACTION_ID,
+  DECLINE_BOOKING_REQUEST_ACTION_ID,
+} from "@/constants/notifications";
 import { useAuth } from "@/contexts/AuthContext";
 import {
   deregisterPersistedPushRegistration,
   drainPendingDeregistrations,
   requestAndRegisterPushToken,
 } from "@/hooks/use-push-notifications";
+import { CalComAPIService } from "@/services/calcom";
+import { showErrorAlert, showSilentSuccessAlert } from "@/utils/alerts";
 
 // How long the pre-logout callback waits for an in-flight registration to
 // settle before deregistering, so a token that registered moments before
@@ -16,6 +25,72 @@ import {
 const REGISTRATION_SETTLE_TIMEOUT_MS = 3000;
 
 const LAST_HANDLED_NOTIF_KEY = "calcom_last_handled_notification_id";
+
+// Persisted history of handled notification-action responses, keyed by
+// `${notificationId}:${actionIdentifier}`. Survives across cold starts so a
+// tapped Confirm/Decline can't replay when the OS hands us the launching
+// response again. The in-memory mirror below is the synchronous source of
+// truth within a single runtime.
+const HANDLED_ACTIONS_KEY = "calcom_handled_notification_actions";
+
+// Synchronous, runtime-local set of handled action keys. Checked-and-claimed
+// before any `await` so the foreground listener and the cold-start path can
+// never both submit the same Confirm/Decline (confirm is NOT idempotent on the
+// backend — a duplicate throws "Booking already confirmed"). Hydrated from
+// AsyncStorage on mount to also block cross-session replays.
+const handledActionKeys = new Set<string>();
+let handledActionsHydrated = false;
+
+function actionDedupeKey(notificationId: string, actionIdentifier: string): string {
+  return `${notificationId}:${actionIdentifier}`;
+}
+
+// Load persisted handled-action keys into the in-memory set. Idempotent; safe
+// to await from multiple callers. The cold-start path must await this before
+// claiming so a replayed action from a previous session is recognised.
+async function hydrateHandledActions(): Promise<void> {
+  if (handledActionsHydrated) return;
+  try {
+    const raw = await AsyncStorage.getItem(HANDLED_ACTIONS_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as unknown;
+      if (Array.isArray(parsed)) {
+        for (const key of parsed) {
+          if (typeof key === "string") handledActionKeys.add(key);
+        }
+      }
+    }
+  } catch {
+    // Corrupt/unavailable storage — the in-memory set still dedupes within this
+    // runtime, and backend errors on duplicates surface as user feedback.
+  } finally {
+    handledActionsHydrated = true;
+  }
+}
+
+// Synchronously claim an action key. Returns false if it was already handled in
+// this runtime (no submit should happen). Must run with no `await` between the
+// check and the add — that is what makes listener/cold-start races safe.
+function claimActionKeySync(key: string): boolean {
+  if (handledActionKeys.has(key)) return false;
+  handledActionKeys.add(key);
+  return true;
+}
+
+// Persist the claimed key optimistically (before the network call) so a crash
+// or failure mid-mutation can't replay the action on a later cold start.
+async function persistHandledActions(): Promise<void> {
+  try {
+    await AsyncStorage.setItem(HANDLED_ACTIONS_KEY, JSON.stringify([...handledActionKeys]));
+  } catch {
+    // Best-effort persistence; the in-memory set covers the current runtime.
+  }
+}
+
+const BOOKING_REQUEST_ACTION_IDS = new Set<string>([
+  CONFIRM_BOOKING_REQUEST_ACTION_ID,
+  DECLINE_BOOKING_REQUEST_ACTION_ID,
+]);
 
 // Show notifications even when the app is in foreground.
 Notifications.setNotificationHandler({
@@ -44,20 +119,156 @@ function handleNotificationUrl(url: string, router: ReturnType<typeof useRouter>
 }
 
 export function PushNotificationProvider({ children }: PushNotificationProviderProps) {
-  const { isAuthenticated, userInfo, registerPreLogoutCallback } = useAuth();
+  const { isAuthenticated, loading, userInfo, registerPreLogoutCallback } = useAuth();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const registrationInFlightRef = useRef<Promise<unknown> | null>(null);
   const coldStartHandledRef = useRef(false);
   const isAuthenticatedRef = useRef(isAuthenticated);
+  const loadingRef = useRef(loading);
   const routerRef = useRef(router);
+  const queryClientRef = useRef(queryClient);
+  // A booking-request action received while auth is still restoring is parked
+  // here and replayed by the drain effect once `loading` settles.
+  const pendingActionRef = useRef<Notifications.NotificationResponse | null>(null);
 
   useEffect(() => {
     isAuthenticatedRef.current = isAuthenticated;
   }, [isAuthenticated]);
 
   useEffect(() => {
+    loadingRef.current = loading;
+  }, [loading]);
+
+  useEffect(() => {
     routerRef.current = router;
   }, [router]);
+
+  useEffect(() => {
+    queryClientRef.current = queryClient;
+  }, [queryClient]);
+
+  // Register the booking-request notification category so the OS renders the
+  // Confirm/Decline buttons when a categorized push is expanded. Registered on
+  // mount; a push arriving before this runs (e.g. very first launch after
+  // install) may show no buttons until the category exists.
+  useEffect(() => {
+    void Notifications.setNotificationCategoryAsync(BOOKING_REQUEST_CATEGORY_ID, [
+      {
+        identifier: CONFIRM_BOOKING_REQUEST_ACTION_ID,
+        buttonTitle: "Confirm",
+        options: { opensAppToForeground: true, isAuthenticationRequired: true },
+      },
+      {
+        identifier: DECLINE_BOOKING_REQUEST_ACTION_ID,
+        buttonTitle: "Decline",
+        options: {
+          opensAppToForeground: true,
+          isAuthenticationRequired: true,
+          isDestructive: true,
+        },
+      },
+    ]).catch(() => {
+      // Native module unavailable or registration failed — default taps still
+      // work; only the action buttons are affected.
+    });
+  }, []);
+
+  // Run a Confirm/Decline action: open booking detail when we can't mutate
+  // (missing auth or uid), otherwise call the API, surface feedback, and
+  // refresh booking caches. Reads auth/router/queryClient from refs so it stays
+  // stable across renders. Dedupe is the caller's responsibility.
+  const executeBookingRequestAction = useCallback(
+    async (response: Notifications.NotificationResponse): Promise<void> => {
+      const data = response.notification.request.content.data as
+        | Record<string, unknown>
+        | undefined;
+      const bookingUid =
+        typeof data?.bookingUid === "string" && data.bookingUid.length > 0
+          ? data.bookingUid
+          : undefined;
+      const url = typeof data?.url === "string" ? data.url : undefined;
+      const actionId = response.actionIdentifier;
+
+      // Can't mutate without an authenticated session and a target booking —
+      // fall back to opening the booking detail if we have a deep link.
+      if (!isAuthenticatedRef.current || !bookingUid) {
+        if (url) {
+          handleNotificationUrl(url, routerRef.current);
+        }
+        return;
+      }
+
+      const refresh = () =>
+        Promise.all([
+          queryClientRef.current.invalidateQueries({ queryKey: queryKeys.bookings.all }),
+          queryClientRef.current.invalidateQueries({
+            queryKey: queryKeys.bookings.detail(bookingUid),
+          }),
+        ]);
+
+      try {
+        if (actionId === CONFIRM_BOOKING_REQUEST_ACTION_ID) {
+          await CalComAPIService.confirmBooking(bookingUid);
+          showSilentSuccessAlert("Success", "Booking confirmed successfully");
+        } else if (actionId === DECLINE_BOOKING_REQUEST_ACTION_ID) {
+          await CalComAPIService.declineBooking(bookingUid);
+          showSilentSuccessAlert("Success", "Booking declined successfully");
+        } else {
+          return;
+        }
+        await refresh();
+      } catch (error) {
+        // Includes the non-idempotent "Booking already confirmed" case — show
+        // it as feedback rather than retrying, then refresh so the UI reflects
+        // the booking's true server state.
+        const message = error instanceof Error ? error.message : "Please try again.";
+        showErrorAlert("Action failed", message);
+        await refresh();
+      }
+    },
+    []
+  );
+
+  // Claim and dispatch a notification-action response. Returns true when the
+  // response is a booking-request action (handled or deduped), false for a
+  // plain tap so the caller can fall through to deep-link navigation.
+  const dispatchActionResponse = useCallback(
+    (response: Notifications.NotificationResponse): boolean => {
+      const actionId = response.actionIdentifier;
+      if (!BOOKING_REQUEST_ACTION_IDS.has(actionId)) {
+        return false;
+      }
+
+      const key = actionDedupeKey(response.notification.request.identifier, actionId);
+      // Synchronous claim before any await — guarantees the listener and the
+      // cold-start path can't both submit the same action.
+      if (!claimActionKeySync(key)) {
+        return true;
+      }
+      void persistHandledActions();
+
+      if (loadingRef.current) {
+        // Auth is still restoring; park the action and let the drain effect run
+        // it once `loading` settles instead of treating it as unauthenticated.
+        pendingActionRef.current = response;
+        return true;
+      }
+
+      void executeBookingRequestAction(response);
+      return true;
+    },
+    [executeBookingRequestAction]
+  );
+
+  // Replay a parked action once auth finishes restoring.
+  useEffect(() => {
+    if (loading) return;
+    const pending = pendingActionRef.current;
+    if (!pending) return;
+    pendingActionRef.current = null;
+    void executeBookingRequestAction(pending);
+  }, [loading, executeBookingRequestAction]);
 
   // Register token on login. The registration promise is tracked in a ref so
   // the pre-logout callback can wait for an in-flight registration before
@@ -117,6 +328,12 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
   // Registered once — reads auth and router from refs to avoid teardown gaps.
   useEffect(() => {
     const subscription = Notifications.addNotificationResponseReceivedListener((response) => {
+      // Action responses are read and dispatched before the auth gate so a
+      // Confirm/Decline tapped while auth is restoring can be deferred rather
+      // than dropped.
+      if (dispatchActionResponse(response)) return;
+
+      // Plain tap — existing deep-link behavior, only when authenticated.
       if (!isAuthenticatedRef.current) return;
       const data = response.notification.request.content.data as
         | Record<string, unknown>
@@ -128,7 +345,7 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
     });
 
     return () => subscription.remove();
-  }, []);
+  }, [dispatchActionResponse]);
 
   // Handle cold-start: app was killed, user tapped notification to launch.
   // Wait for auth so the authenticated Stack is mounted before navigating.
@@ -142,12 +359,33 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
       const lastResponse = Notifications.getLastNotificationResponse();
       if (!lastResponse) return;
 
-      // Two-layer guard against re-navigating to an already-handled notification:
+      const id = lastResponse.notification.request.identifier;
+      const actionId = lastResponse.actionIdentifier;
+
+      // Cold-start via a Confirm/Decline button. Hydrate the persisted
+      // handled-action set first so an action handled in a previous session
+      // isn't replayed, then claim synchronously so the foreground listener
+      // (which may also receive this launching response) can't double-submit.
+      if (BOOKING_REQUEST_ACTION_IDS.has(actionId)) {
+        await hydrateHandledActions();
+        const key = actionDedupeKey(id, actionId);
+        if (!claimActionKeySync(key)) return;
+        void persistHandledActions();
+        try {
+          Notifications.clearLastNotificationResponse();
+        } catch {
+          // Native module unavailable — the dedupe set above still guards replay.
+        }
+        await executeBookingRequestAction(lastResponse);
+        return;
+      }
+
+      // Plain tap. Two-layer guard against re-navigating to an already-handled
+      // notification:
       // 1. AsyncStorage dedup — persists the handled ID across sessions so a
       //    previously-tapped notification can't replay on a fresh cold start.
       // 2. clearLastNotificationResponse() — clears the native cache so
       //    subsequent cold starts receive null rather than the old response.
-      const id = lastResponse.notification.request.identifier;
       const lastHandledId = await AsyncStorage.getItem(LAST_HANDLED_NOTIF_KEY);
       if (lastHandledId === id) return;
       await AsyncStorage.setItem(LAST_HANDLED_NOTIF_KEY, id);
@@ -165,7 +403,7 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
         handleNotificationUrl(url, router);
       }
     })();
-  }, [isAuthenticated, router]);
+  }, [isAuthenticated, router, executeBookingRequestAction]);
 
   return <>{children}</>;
 }

--- a/apps/mobile/constants/notifications.ts
+++ b/apps/mobile/constants/notifications.ts
@@ -1,0 +1,15 @@
+/**
+ * Push-notification category and action identifiers.
+ *
+ * The Cal.com backend sets `categoryId` to {@link BOOKING_REQUEST_CATEGORY_ID}
+ * on booking-request push payloads. Expo/the OS then renders the Confirm and
+ * Decline action buttons defined for that category, and the response handler in
+ * `PushNotificationProvider` dispatches on the action identifiers below.
+ *
+ * Identifiers intentionally avoid `:` and `-`: the dedupe scheme keys handled
+ * responses by `${notificationId}:${actionIdentifier}`, so a `:` in an action
+ * id would corrupt that key.
+ */
+export const BOOKING_REQUEST_CATEGORY_ID = "calcom_booking_request_actions";
+export const CONFIRM_BOOKING_REQUEST_ACTION_ID = "confirm_booking_request";
+export const DECLINE_BOOKING_REQUEST_ACTION_ID = "decline_booking_request";


### PR DESCRIPTION
## Summary
Adds **Confirm** and **Decline** action buttons to booking-request push notifications on the mobile app (iOS/Android). Tapping an action uses the **reliable-wake** flow: the OS opens/resumes the app, the app waits for auth to restore if needed, calls the existing booking API, refreshes booking caches, and shows success/error feedback. Only booking-request pushes get buttons — confirmed/cancelled/rejected/rescheduled pushes are unchanged.

This is the **mobile half**. The backend half (setting `categoryId: "calcom_booking_request_actions"` on `BOOKING_REQUESTED` payloads in `calcom/cal`) is in calcom/cal#3282; without it, no push carries the category and the app behaves exactly as before.

## Key changes
- New `apps/mobile/constants/notifications.ts` — shared category/action identifiers:
  - category `calcom_booking_request_actions`, actions `confirm_booking_request` / `decline_booking_request` (no `:`/`-`, since the dedupe key is `${notificationId}:${actionId}`).
- `apps/mobile/components/PushNotificationProvider.tsx`:
  - Registers the category on mount via `setNotificationCategoryAsync` — both actions `opensAppToForeground` + `isAuthenticationRequired`; Decline also `isDestructive`.
  - Extends the response listener and cold-start path to dispatch on `response.actionIdentifier` **before** the auth gate. Plain taps keep their existing `data.url` deep-link behavior.
  - On an action: `confirmBooking(uid)` / `declineBooking(uid)`, then invalidate `queryKeys.bookings.all` (+ `detail(uid)`).

## Visible native feedback
The action is initiated from a notification (often with the app backgrounded/killed), so the user may not land on the bookings screen — silent cache refresh alone isn't enough. Feedback uses the always-on native helpers, not the web/dev-only ones:
- success → `showSuccessAlert` ("Booking confirmed/declined successfully")
- failure → `showInfoAlert` (always shows on native; `showErrorAlert` is `__DEV__`-only and would be invisible in production)

## Duplicate safety & auth race (the subtle parts)
Confirm is **not** idempotent server-side (a duplicate throws `Booking already confirmed`), and the foreground listener and cold-start path can both receive the *same* launching response. Dedupe is a synchronous in-memory `Set` mirrored to AsyncStorage. **Both** paths now hydrate the persisted set before claiming, so a cross-session replay (or a launch response the listener gets before the cold-start effect hydrates) is recognised:

```ts
function claimActionKeySync(key) {        // key = `${notifId}:${actionId}`
  if (handledActionKeys.has(key)) return false;
  handledActionKeys.add(key);             // claim with no await in between
  return true;
}
// listener/cold-start: await hydrate -> claimSync -> persist (optimistic)
//   -> if loading, park; else execute
// dispatchActionResponse returns `true` synchronously so plain-tap fallthrough
// is always suppressed; the claim happens in an async IIFE.
```

`claimActionKeySync` stays synchronous, so even if both paths await hydration, whichever resumes first claims and the other sees it claimed — single-threaded resume keeps the double-submit guarantee. If an action arrives while auth is still restoring (`loading === true`), the response is parked in a ref and replayed by an effect once `loading` settles. Already-actioned errors surface as feedback (no retry loop) and still trigger a cache refresh so the UI reflects true server state.

## Test plan
- `bun --filter mobile typecheck` — passes.
- `bunx biome check` on changed files + `bun --filter mobile lint:react-compiler` — pass.
- Manual device QA (requires the `calcom/cal` backend change to emit `categoryId`):
  - Pending request → expanded notification shows Confirm/Decline.
  - Confirm → app wakes, booking accepted, list/detail refresh, success alert.
  - Decline → app wakes, booking rejected (no reason), refresh, success alert.
  - Plain tap still opens booking detail; other lifecycle pushes show no buttons.
  - Note v1 limitation: a push arriving before the category is ever registered (e.g. first launch after install) may show no buttons.

## Out of scope
Backend payload changes and their unit tests live in `calcom/cal` (calcom/cal#3282). No DB / OpenAPI / preference / feature-flag changes.

Link to Devin session: https://app.devin.ai/sessions/d4f390442b554b7c9e6e1ba9d8bd6aeb
Requested by: @dhairyashiil