### PR TITLE
feat: add org booking tools

### DIFF
--- a/apps/mcp-server/.env.example
+++ b/apps/mcp-server/.env.example
@@ -18,6 +18,10 @@ CAL_API_KEY=cal_live_xxxx
 # CAL_OAUTH_CLIENT_ID=your_client_id
 # CAL_OAUTH_CLIENT_SECRET=your_client_secret
 
+# Optional: override requested Cal.com OAuth scopes.
+# Defaults include core tool scopes plus ORG_BOOKING_READ and TEAM_BOOKING_READ.
+# CAL_OAUTH_SCOPES="EVENT_TYPE_READ EVENT_TYPE_WRITE BOOKING_READ BOOKING_WRITE SCHEDULE_READ SCHEDULE_WRITE APPS_READ APPS_WRITE PROFILE_READ PROFILE_WRITE ORG_BOOKING_READ TEAM_BOOKING_READ"
+
 # Public URL of this MCP server (used for OAuth redirect URIs)
 # MCP_SERVER_URL=https://your-host.com
 

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -4,7 +4,7 @@ A **Model Context Protocol (MCP)** server that wraps the [Cal.com Platform API v
 
 ## Features
 
-- **42 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Routing Forms, Organizations, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- **44 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Routing Forms, Organizations, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
 - **Dual transport** — stdio for local dev tooling, StreamableHTTP for remote/production
 - **Dual auth** — API key for stdio (local dev), OAuth 2.1 Authorization Code + PKCE for HTTP (production)
 - **Per-user token storage** — encrypted at rest with AES-256-GCM in SQLite
@@ -57,6 +57,7 @@ cp apps/mcp-server/.env.example apps/mcp-server/.env
 | `CAL_OAUTH_CLIENT_SECRET` | Yes | — | Cal.com OAuth client secret |
 | `TOKEN_ENCRYPTION_KEY` | Yes | — | 64-char hex string (32 bytes) for AES-256-GCM token encryption |
 | `MCP_SERVER_URL` | Yes | — | Public URL of this server (e.g. `https://mcp.example.com`) |
+| `CAL_OAUTH_SCOPES` | No | Core scopes plus `ORG_BOOKING_READ TEAM_BOOKING_READ` | Space-separated Cal.com OAuth scopes requested during authorization |
 | `DATABASE_PATH` | No | `mcp-server.db` | SQLite database file path |
 | `RATE_LIMIT_WINDOW_MS` | No | `60000` | Rate limit window in ms (per IP) |
 | `RATE_LIMIT_MAX` | No | `30` | Max OAuth requests per window per IP |
@@ -178,7 +179,7 @@ The server acts as an intermediary: it issues its own access tokens to MCP clien
 - Expired tokens are cleaned up automatically every 5 minutes
 - In-process rate limiting on all OAuth endpoints (token bucket per IP, configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX`)
 
-## Tools (42)
+## Tools (44)
 
 Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specification/draft/server/tools#tool-annotations) — a human-readable `title` plus behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so MCP clients can render them appropriately and apply safety policies.
 
@@ -261,6 +262,12 @@ Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specifi
 | `assign_attribute_to_user` | Assign Attribute to User | Create | Assign an attribute option or value to a user |
 | `update_user_attribute` | Update User Attribute Assignment | Update | Update an existing user attribute assignment |
 | `unassign_attribute_from_user` | Unassign Attribute from User | Destructive | Remove an attribute option assignment from a user |
+
+### Organizations: Bookings (2)
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_org_team_bookings` | List Org Team Bookings | Read | List bookings for a team within an organization |
+| `get_org_user_bookings` | List Org User Bookings | Read | List bookings for a specific user within an organization |
 
 ### Organizations: Memberships (5)
 | Tool | Title | Hint | Description |

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -53,12 +53,16 @@ const httpSchema = baseSchema.extend({
   calOAuthScopes: z
     .string()
     .default(
-      "EVENT_TYPE_READ EVENT_TYPE_WRITE BOOKING_READ BOOKING_WRITE SCHEDULE_READ SCHEDULE_WRITE APPS_READ APPS_WRITE PROFILE_READ PROFILE_WRITE",
+      "EVENT_TYPE_READ EVENT_TYPE_WRITE BOOKING_READ BOOKING_WRITE SCHEDULE_READ SCHEDULE_WRITE APPS_READ APPS_WRITE PROFILE_READ PROFILE_WRITE ORG_BOOKING_READ TEAM_BOOKING_READ"
     ),
   rateLimitWindowMs: z.coerce.number().int().positive().default(60_000),
   rateLimitMax: z.coerce.number().int().positive().default(30),
   maxSessions: z.coerce.number().int().positive().default(10_000),
-  sessionIdleTimeoutMs: z.coerce.number().int().positive().default(30 * 60 * 1000),
+  sessionIdleTimeoutMs: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(30 * 60 * 1000),
   maxRegisteredClients: z.coerce.number().int().positive().default(10_000),
   trustProxy: z
     .enum(["true", "false", "1", "0"])
@@ -123,7 +127,9 @@ export function loadConfig(): AppConfig {
   if (transport === "http") {
     const result = httpSchema.safeParse(raw);
     if (!result.success) {
-      const issues = result.error.issues.map((i) => `  ${i.path.join(".")}: ${i.message}`).join("\n");
+      const issues = result.error.issues
+        .map((i) => `  ${i.path.join(".")}: ${i.message}`)
+        .join("\n");
       throw new Error(`Invalid HTTP mode configuration:\n${issues}`);
     }
     return result.data;

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -73,6 +73,14 @@ import {
   calculateRoutingFormSlots,
 } from "./tools/routing-forms.js";
 
+// ── Organizations: Bookings ──
+import {
+  getOrgTeamBookingsSchema,
+  getOrgTeamBookings,
+  getOrgUserBookingsSchema,
+  getOrgUserBookings,
+} from "./tools/organizations/bookings.js";
+
 // ── Organizations: Memberships ──
 import {
   getOrgMembershipsSchema,
@@ -454,6 +462,30 @@ export function registerTools(server: McpServer): void {
       annotations: CREATE,
     },
     calculateRoutingFormSlots,
+  );
+
+  // ── Organizations: Bookings (2) ──
+  server.registerTool(
+    "get_org_team_bookings",
+    {
+      title: "List Org Team Bookings",
+      description:
+        "List all bookings for a team within an organization. Requires TEAM_ADMIN role. Supports filtering by status (upcoming, recurring, past, cancelled, unconfirmed), attendee email/name, event type, date ranges (afterStart, beforeEnd, afterCreatedAt, beforeCreatedAt, afterUpdatedAt, beforeUpdatedAt), and sorting (sortStart, sortEnd, sortCreated, sortUpdatedAt).",
+      inputSchema: getOrgTeamBookingsSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgTeamBookings,
+  );
+  server.registerTool(
+    "get_org_user_bookings",
+    {
+      title: "List Org User Bookings",
+      description:
+        "List all bookings for a specific user within an organization. Requires ORG_ADMIN role. Use get_org_memberships to find user IDs. Supports filtering by status, attendee email/name, event type, team, date ranges, and sorting.",
+      inputSchema: getOrgUserBookingsSchema,
+      annotations: READ_ONLY,
+    },
+    getOrgUserBookings,
   );
 
   // ── Organizations: Memberships (5) ──

--- a/apps/mcp-server/src/server-instructions.ts
+++ b/apps/mcp-server/src/server-instructions.ts
@@ -15,6 +15,7 @@ CAPABILITIES — what you CAN do with the available tools:
 - View connected calendars and busy times
 - List connected conferencing apps
 - Work with routing forms and their responses (organization-level)
+- List organization team bookings and organization user bookings
 - Manage organization memberships
 - Read organization attributes, list attribute options, and manage user attribute assignments
 
@@ -30,7 +31,7 @@ LIMITATIONS — what you CANNOT do (do NOT attempt to use other tools for these)
 
 RULES:
 1. If a user asks for something not listed under CAPABILITIES, tell them clearly: "The Cal.com integration doesn't support [action] yet." Do NOT call a different tool hoping it might work.
-2. NEVER guess or fabricate IDs, emails, names, phone numbers, or time zones. If you don't have a value, either use the appropriate discovery tool (e.g., get_me, get_event_types, get_bookings, get_org_memberships, get_org_attributes, get_attribute_options, get_user_attributes) or ask the user.
+2. NEVER guess or fabricate IDs, emails, names, phone numbers, or time zones. If you don't have a value, either use the appropriate discovery tool (e.g., get_me, get_event_types, get_bookings, get_org_team_bookings, get_org_user_bookings, get_org_memberships, get_org_attributes, get_attribute_options, get_user_attributes) or ask the user.
 3. Before creating or rescheduling a booking, ALWAYS check availability first using get_availability.
 4. For destructive actions (delete event type, cancel booking, delete schedule, delete membership, unassign attribute from user), confirm with the user before proceeding.
 5. All date/time values sent to the API must be in UTC ISO 8601 format.`;

--- a/apps/mcp-server/src/tools/booking-filters.ts
+++ b/apps/mcp-server/src/tools/booking-filters.ts
@@ -32,8 +32,8 @@ export const bookingFiltersSchema = {
   sortEnd: z.enum(["asc", "desc"]).optional().describe("Sort by end time"),
   sortCreated: z.enum(["asc", "desc"]).optional().describe("Sort by creation time"),
   sortUpdatedAt: z.enum(["asc", "desc"]).optional().describe("Sort by updated time"),
-  take: z.number().int().optional().describe("Max results to return (default 100, max 250)"),
-  skip: z.number().int().optional().describe("Results to skip (offset)"),
+  take: z.number().int().min(1).max(250).optional().describe("Max results to return (1-250)"),
+  skip: z.number().int().min(0).optional().describe("Results to skip (offset, min 0)"),
 };
 
 export const bookingTeamFiltersSchema = {

--- a/apps/mcp-server/src/tools/booking-filters.ts
+++ b/apps/mcp-server/src/tools/booking-filters.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+
+export const bookingFiltersSchema = {
+  status: z
+    .string()
+    .optional()
+    .describe("Comma-separated statuses: upcoming, recurring, past, cancelled, unconfirmed"),
+  attendeeEmail: z.string().email().optional().describe("Filter by attendee email"),
+  attendeeName: z.string().optional().describe("Filter by attendee name"),
+  eventTypeId: z.number().int().optional().describe("Filter by event type ID"),
+  eventTypeIds: z.string().optional().describe("Comma-separated event type IDs (e.g. '100,200')"),
+  afterStart: z.string().optional().describe("Filter bookings starting after this ISO 8601 date"),
+  beforeEnd: z.string().optional().describe("Filter bookings ending before this ISO 8601 date"),
+  afterCreatedAt: z
+    .string()
+    .optional()
+    .describe("Filter bookings created after this ISO 8601 date"),
+  beforeCreatedAt: z
+    .string()
+    .optional()
+    .describe("Filter bookings created before this ISO 8601 date"),
+  afterUpdatedAt: z
+    .string()
+    .optional()
+    .describe("Filter bookings updated after this ISO 8601 date"),
+  beforeUpdatedAt: z
+    .string()
+    .optional()
+    .describe("Filter bookings updated before this ISO 8601 date"),
+  bookingUid: z.string().optional().describe("Filter by booking UID"),
+  sortStart: z.enum(["asc", "desc"]).optional().describe("Sort by start time"),
+  sortEnd: z.enum(["asc", "desc"]).optional().describe("Sort by end time"),
+  sortCreated: z.enum(["asc", "desc"]).optional().describe("Sort by creation time"),
+  sortUpdatedAt: z.enum(["asc", "desc"]).optional().describe("Sort by updated time"),
+  take: z.number().int().optional().describe("Max results to return (default 100, max 250)"),
+  skip: z.number().int().optional().describe("Results to skip (offset)"),
+};
+
+export const bookingTeamFiltersSchema = {
+  teamId: z.number().int().optional().describe("Filter by team ID"),
+  teamsIds: z.string().optional().describe("Comma-separated team IDs (e.g. '50,60')"),
+};
+
+const bookingFiltersZodObject = z.object(bookingFiltersSchema);
+const bookingTeamFiltersZodObject = z.object(bookingTeamFiltersSchema);
+
+export type BookingFilterParams = z.infer<typeof bookingFiltersZodObject>;
+export type BookingTeamFilterParams = z.infer<typeof bookingTeamFiltersZodObject>;
+
+type BookingQueryParamValue = string | number;
+type BookingQueryParams = Record<string, BookingQueryParamValue | undefined>;
+
+const bookingFilterParamKeys = Object.keys(bookingFiltersSchema) as (keyof BookingFilterParams)[];
+const bookingTeamFilterParamKeys = Object.keys(
+  bookingTeamFiltersSchema
+) as (keyof BookingTeamFilterParams)[];
+
+export function buildBookingQueryParams(
+  params: BookingFilterParams & Partial<BookingTeamFilterParams>,
+  options: { includeTeamFilters?: boolean } = {}
+): BookingQueryParams {
+  const qp: BookingQueryParams = {};
+
+  for (const key of bookingFilterParamKeys) {
+    const value = params[key];
+    if (value !== undefined) qp[key] = value;
+  }
+
+  if (options.includeTeamFilters) {
+    for (const key of bookingTeamFilterParamKeys) {
+      const value = params[key];
+      if (value !== undefined) qp[key] = value;
+    }
+  }
+
+  return qp;
+}

--- a/apps/mcp-server/src/tools/bookings.ts
+++ b/apps/mcp-server/src/tools/bookings.ts
@@ -1,75 +1,23 @@
 import { z } from "zod";
+import {
+  type BookingFilterParams,
+  type BookingTeamFilterParams,
+  bookingFiltersSchema,
+  bookingTeamFiltersSchema,
+  buildBookingQueryParams,
+} from "./booking-filters.js";
 import { calApi } from "../utils/api-client.js";
 import { sanitizePathSegment } from "../utils/path-sanitizer.js";
 import { handleError, ok } from "../utils/tool-helpers.js";
 
 export const getBookingsSchema = {
-  status: z.string().optional().describe("Comma-separated statuses: upcoming, recurring, past, cancelled, unconfirmed"),
-  attendeeEmail: z.string().email().optional().describe("Filter by attendee email"),
-  attendeeName: z.string().optional().describe("Filter by attendee name"),
-  eventTypeId: z.number().int().optional().describe("Filter by event type ID"),
-  eventTypeIds: z.string().optional().describe("Comma-separated event type IDs (e.g. '100,200')"),
-  teamId: z.number().int().optional().describe("Filter by team ID"),
-  teamsIds: z.string().optional().describe("Comma-separated team IDs (e.g. '50,60')"),
-  afterStart: z.string().optional().describe("Filter bookings starting after this ISO 8601 date"),
-  beforeEnd: z.string().optional().describe("Filter bookings ending before this ISO 8601 date"),
-  afterCreatedAt: z.string().optional().describe("Filter bookings created after this ISO 8601 date"),
-  beforeCreatedAt: z.string().optional().describe("Filter bookings created before this ISO 8601 date"),
-  afterUpdatedAt: z.string().optional().describe("Filter bookings updated after this ISO 8601 date"),
-  beforeUpdatedAt: z.string().optional().describe("Filter bookings updated before this ISO 8601 date"),
-  bookingUid: z.string().optional().describe("Filter by booking UID"),
-  sortStart: z.enum(["asc", "desc"]).optional().describe("Sort by start time"),
-  sortEnd: z.enum(["asc", "desc"]).optional().describe("Sort by end time"),
-  sortCreated: z.enum(["asc", "desc"]).optional().describe("Sort by creation time"),
-  sortUpdatedAt: z.enum(["asc", "desc"]).optional().describe("Sort by updated time"),
-  take: z.number().int().optional().describe("Max results to return (default 100, max 250)"),
-  skip: z.number().int().optional().describe("Results to skip (offset)"),
+  ...bookingFiltersSchema,
+  ...bookingTeamFiltersSchema,
 };
 
-export async function getBookings(params: {
-  status?: string;
-  attendeeEmail?: string;
-  attendeeName?: string;
-  eventTypeId?: number;
-  eventTypeIds?: string;
-  teamId?: number;
-  teamsIds?: string;
-  afterStart?: string;
-  beforeEnd?: string;
-  afterCreatedAt?: string;
-  beforeCreatedAt?: string;
-  afterUpdatedAt?: string;
-  beforeUpdatedAt?: string;
-  bookingUid?: string;
-  sortStart?: "asc" | "desc";
-  sortEnd?: "asc" | "desc";
-  sortCreated?: "asc" | "desc";
-  sortUpdatedAt?: "asc" | "desc";
-  take?: number;
-  skip?: number;
-}) {
+export async function getBookings(params: BookingFilterParams & BookingTeamFilterParams) {
   try {
-    const qp: Record<string, string | number | undefined> = {};
-    if (params.status !== undefined) qp.status = params.status;
-    if (params.attendeeEmail !== undefined) qp.attendeeEmail = params.attendeeEmail;
-    if (params.attendeeName !== undefined) qp.attendeeName = params.attendeeName;
-    if (params.eventTypeId !== undefined) qp.eventTypeId = params.eventTypeId;
-    if (params.eventTypeIds !== undefined) qp.eventTypeIds = params.eventTypeIds;
-    if (params.teamId !== undefined) qp.teamId = params.teamId;
-    if (params.teamsIds !== undefined) qp.teamsIds = params.teamsIds;
-    if (params.afterStart !== undefined) qp.afterStart = params.afterStart;
-    if (params.beforeEnd !== undefined) qp.beforeEnd = params.beforeEnd;
-    if (params.afterCreatedAt !== undefined) qp.afterCreatedAt = params.afterCreatedAt;
-    if (params.beforeCreatedAt !== undefined) qp.beforeCreatedAt = params.beforeCreatedAt;
-    if (params.afterUpdatedAt !== undefined) qp.afterUpdatedAt = params.afterUpdatedAt;
-    if (params.beforeUpdatedAt !== undefined) qp.beforeUpdatedAt = params.beforeUpdatedAt;
-    if (params.bookingUid !== undefined) qp.bookingUid = params.bookingUid;
-    if (params.sortStart !== undefined) qp.sortStart = params.sortStart;
-    if (params.sortEnd !== undefined) qp.sortEnd = params.sortEnd;
-    if (params.sortCreated !== undefined) qp.sortCreated = params.sortCreated;
-    if (params.sortUpdatedAt !== undefined) qp.sortUpdatedAt = params.sortUpdatedAt;
-    if (params.take !== undefined) qp.take = params.take;
-    if (params.skip !== undefined) qp.skip = params.skip;
+    const qp = buildBookingQueryParams(params, { includeTeamFilters: true });
     const data = await calApi("bookings", { params: qp });
     return ok(data);
   } catch (err) {

--- a/apps/mcp-server/src/tools/organizations/bookings.test.ts
+++ b/apps/mcp-server/src/tools/organizations/bookings.test.ts
@@ -13,10 +13,21 @@ import {
 
 const mockCalApi = vi.mocked(calApi);
 
-beforeEach(() => { vi.clearAllMocks(); });
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("getOrgTeamBookings", () => {
-  it("exports getOrgTeamBookingsSchema", () => { expect(getOrgTeamBookingsSchema).toBeDefined(); });
+  it("exports getOrgTeamBookingsSchema", () => {
+    expect(getOrgTeamBookingsSchema).toBeDefined();
+  });
+
+  it("enforces OpenAPI pagination bounds", () => {
+    expect(getOrgTeamBookingsSchema.take.safeParse(0).success).toBe(false);
+    expect(getOrgTeamBookingsSchema.take.safeParse(250).success).toBe(true);
+    expect(getOrgTeamBookingsSchema.take.safeParse(251).success).toBe(false);
+    expect(getOrgTeamBookingsSchema.skip.safeParse(-1).success).toBe(false);
+  });
 
   it("calls the correct endpoint", async () => {
     mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
@@ -60,7 +71,16 @@ describe("getOrgTeamBookings", () => {
 });
 
 describe("getOrgUserBookings", () => {
-  it("exports getOrgUserBookingsSchema", () => { expect(getOrgUserBookingsSchema).toBeDefined(); });
+  it("exports getOrgUserBookingsSchema", () => {
+    expect(getOrgUserBookingsSchema).toBeDefined();
+  });
+
+  it("enforces OpenAPI pagination bounds", () => {
+    expect(getOrgUserBookingsSchema.take.safeParse(0).success).toBe(false);
+    expect(getOrgUserBookingsSchema.take.safeParse(250).success).toBe(true);
+    expect(getOrgUserBookingsSchema.take.safeParse(251).success).toBe(false);
+    expect(getOrgUserBookingsSchema.skip.safeParse(-1).success).toBe(false);
+  });
 
   it("calls the correct endpoint", async () => {
     mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });

--- a/apps/mcp-server/src/tools/organizations/bookings.test.ts
+++ b/apps/mcp-server/src/tools/organizations/bookings.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CalApiError } from "../../utils/errors.js";
+
+vi.mock("../../utils/api-client.js", () => ({ calApi: vi.fn() }));
+
+import { calApi } from "../../utils/api-client.js";
+import {
+  getOrgTeamBookings,
+  getOrgTeamBookingsSchema,
+  getOrgUserBookings,
+  getOrgUserBookingsSchema,
+} from "./bookings.js";
+
+const mockCalApi = vi.mocked(calApi);
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe("getOrgTeamBookings", () => {
+  it("exports getOrgTeamBookingsSchema", () => { expect(getOrgTeamBookingsSchema).toBeDefined(); });
+
+  it("calls the correct endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
+    await getOrgTeamBookings({ orgId: 1, teamId: 10 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/teams/10/bookings", { params: {} });
+  });
+
+  it("passes filter params as query params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
+    await getOrgTeamBookings({
+      orgId: 1,
+      teamId: 10,
+      attendeeEmail: "test@example.com",
+      status: "upcoming",
+      sortCreated: "desc",
+      take: 50,
+    });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/teams/10/bookings", {
+      params: {
+        attendeeEmail: "test@example.com",
+        status: "upcoming",
+        sortCreated: "desc",
+        take: 50,
+      },
+    });
+  });
+
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getOrgTeamBookings({ orgId: 1, teamId: 10 });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(403, "Forbidden", {}));
+    const result = await getOrgTeamBookings({ orgId: 1, teamId: 10 });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("403");
+  });
+});
+
+describe("getOrgUserBookings", () => {
+  it("exports getOrgUserBookingsSchema", () => { expect(getOrgUserBookingsSchema).toBeDefined(); });
+
+  it("calls the correct endpoint", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
+    await getOrgUserBookings({ orgId: 1, userId: 42 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/users/42/bookings", { params: {} });
+  });
+
+  it("passes teamId and teamsIds as query params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [] });
+    await getOrgUserBookings({ orgId: 1, userId: 42, teamId: 10, teamsIds: "10,20" });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/users/42/bookings", {
+      params: { teamId: 10, teamsIds: "10,20" },
+    });
+  });
+
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    const result = await getOrgUserBookings({ orgId: 1, userId: 42 });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success" });
+  });
+
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(403, "Forbidden", {}));
+    const result = await getOrgUserBookings({ orgId: 1, userId: 42 });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("403");
+  });
+});

--- a/apps/mcp-server/src/tools/organizations/bookings.ts
+++ b/apps/mcp-server/src/tools/organizations/bookings.ts
@@ -1,71 +1,13 @@
 import { z } from "zod";
+import {
+  type BookingFilterParams,
+  type BookingTeamFilterParams,
+  bookingFiltersSchema,
+  bookingTeamFiltersSchema,
+  buildBookingQueryParams,
+} from "../booking-filters.js";
 import { calApi } from "../../utils/api-client.js";
 import { handleError, ok } from "../../utils/tool-helpers.js";
-
-const bookingFiltersSchema = {
-  status: z.string().optional().describe("Comma-separated statuses: upcoming, recurring, past, cancelled, unconfirmed"),
-  attendeeEmail: z.string().email().optional().describe("Filter by attendee email"),
-  attendeeName: z.string().optional().describe("Filter by attendee name"),
-  eventTypeId: z.number().int().optional().describe("Filter by event type ID"),
-  eventTypeIds: z.string().optional().describe("Comma-separated event type IDs (e.g. '100,200')"),
-  afterStart: z.string().optional().describe("Filter bookings starting after this ISO 8601 date"),
-  beforeEnd: z.string().optional().describe("Filter bookings ending before this ISO 8601 date"),
-  afterCreatedAt: z.string().optional().describe("Filter bookings created after this ISO 8601 date"),
-  beforeCreatedAt: z.string().optional().describe("Filter bookings created before this ISO 8601 date"),
-  afterUpdatedAt: z.string().optional().describe("Filter bookings updated after this ISO 8601 date"),
-  beforeUpdatedAt: z.string().optional().describe("Filter bookings updated before this ISO 8601 date"),
-  bookingUid: z.string().optional().describe("Filter by booking UID"),
-  sortStart: z.enum(["asc", "desc"]).optional().describe("Sort by start time"),
-  sortEnd: z.enum(["asc", "desc"]).optional().describe("Sort by end time"),
-  sortCreated: z.enum(["asc", "desc"]).optional().describe("Sort by creation time"),
-  sortUpdatedAt: z.enum(["asc", "desc"]).optional().describe("Sort by updated time"),
-  take: z.number().int().optional().describe("Max results to return (default 100, max 250)"),
-  skip: z.number().int().optional().describe("Results to skip (offset)"),
-};
-
-interface BookingFilterParams {
-  status?: string;
-  attendeeEmail?: string;
-  attendeeName?: string;
-  eventTypeId?: number;
-  eventTypeIds?: string;
-  afterStart?: string;
-  beforeEnd?: string;
-  afterCreatedAt?: string;
-  beforeCreatedAt?: string;
-  afterUpdatedAt?: string;
-  beforeUpdatedAt?: string;
-  bookingUid?: string;
-  sortStart?: "asc" | "desc";
-  sortEnd?: "asc" | "desc";
-  sortCreated?: "asc" | "desc";
-  sortUpdatedAt?: "asc" | "desc";
-  take?: number;
-  skip?: number;
-}
-
-function buildBookingQueryParams(params: BookingFilterParams): Record<string, string | number | undefined> {
-  const qp: Record<string, string | number | undefined> = {};
-  if (params.status !== undefined) qp.status = params.status;
-  if (params.attendeeEmail !== undefined) qp.attendeeEmail = params.attendeeEmail;
-  if (params.attendeeName !== undefined) qp.attendeeName = params.attendeeName;
-  if (params.eventTypeId !== undefined) qp.eventTypeId = params.eventTypeId;
-  if (params.eventTypeIds !== undefined) qp.eventTypeIds = params.eventTypeIds;
-  if (params.afterStart !== undefined) qp.afterStart = params.afterStart;
-  if (params.beforeEnd !== undefined) qp.beforeEnd = params.beforeEnd;
-  if (params.afterCreatedAt !== undefined) qp.afterCreatedAt = params.afterCreatedAt;
-  if (params.beforeCreatedAt !== undefined) qp.beforeCreatedAt = params.beforeCreatedAt;
-  if (params.afterUpdatedAt !== undefined) qp.afterUpdatedAt = params.afterUpdatedAt;
-  if (params.beforeUpdatedAt !== undefined) qp.beforeUpdatedAt = params.beforeUpdatedAt;
-  if (params.bookingUid !== undefined) qp.bookingUid = params.bookingUid;
-  if (params.sortStart !== undefined) qp.sortStart = params.sortStart;
-  if (params.sortEnd !== undefined) qp.sortEnd = params.sortEnd;
-  if (params.sortCreated !== undefined) qp.sortCreated = params.sortCreated;
-  if (params.sortUpdatedAt !== undefined) qp.sortUpdatedAt = params.sortUpdatedAt;
-  if (params.take !== undefined) qp.take = params.take;
-  if (params.skip !== undefined) qp.skip = params.skip;
-  return qp;
-}
 
 // ── Org Team Bookings ──
 
@@ -90,16 +32,13 @@ export async function getOrgTeamBookings(params: { orgId: number; teamId: number
 export const getOrgUserBookingsSchema = {
   orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
   userId: z.number().int().describe("User ID of the organization member whose bookings to retrieve."),
-  teamId: z.number().int().optional().describe("Filter by team ID"),
-  teamsIds: z.string().optional().describe("Comma-separated team IDs (e.g. '50,60')"),
+  ...bookingTeamFiltersSchema,
   ...bookingFiltersSchema,
 };
 
-export async function getOrgUserBookings(params: { orgId: number; userId: number; teamId?: number; teamsIds?: string } & BookingFilterParams) {
+export async function getOrgUserBookings(params: { orgId: number; userId: number } & BookingFilterParams & BookingTeamFilterParams) {
   try {
-    const qp = buildBookingQueryParams(params);
-    if (params.teamId !== undefined) qp.teamId = params.teamId;
-    if (params.teamsIds !== undefined) qp.teamsIds = params.teamsIds;
+    const qp = buildBookingQueryParams(params, { includeTeamFilters: true });
     const data = await calApi(`organizations/${params.orgId}/users/${params.userId}/bookings`, { params: qp });
     return ok(data);
   } catch (err) {

--- a/apps/mcp-server/src/tools/organizations/bookings.ts
+++ b/apps/mcp-server/src/tools/organizations/bookings.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+import { calApi } from "../../utils/api-client.js";
+import { handleError, ok } from "../../utils/tool-helpers.js";
+
+const bookingFiltersSchema = {
+  status: z.string().optional().describe("Comma-separated statuses: upcoming, recurring, past, cancelled, unconfirmed"),
+  attendeeEmail: z.string().email().optional().describe("Filter by attendee email"),
+  attendeeName: z.string().optional().describe("Filter by attendee name"),
+  eventTypeId: z.number().int().optional().describe("Filter by event type ID"),
+  eventTypeIds: z.string().optional().describe("Comma-separated event type IDs (e.g. '100,200')"),
+  afterStart: z.string().optional().describe("Filter bookings starting after this ISO 8601 date"),
+  beforeEnd: z.string().optional().describe("Filter bookings ending before this ISO 8601 date"),
+  afterCreatedAt: z.string().optional().describe("Filter bookings created after this ISO 8601 date"),
+  beforeCreatedAt: z.string().optional().describe("Filter bookings created before this ISO 8601 date"),
+  afterUpdatedAt: z.string().optional().describe("Filter bookings updated after this ISO 8601 date"),
+  beforeUpdatedAt: z.string().optional().describe("Filter bookings updated before this ISO 8601 date"),
+  bookingUid: z.string().optional().describe("Filter by booking UID"),
+  sortStart: z.enum(["asc", "desc"]).optional().describe("Sort by start time"),
+  sortEnd: z.enum(["asc", "desc"]).optional().describe("Sort by end time"),
+  sortCreated: z.enum(["asc", "desc"]).optional().describe("Sort by creation time"),
+  sortUpdatedAt: z.enum(["asc", "desc"]).optional().describe("Sort by updated time"),
+  take: z.number().int().optional().describe("Max results to return (default 100, max 250)"),
+  skip: z.number().int().optional().describe("Results to skip (offset)"),
+};
+
+interface BookingFilterParams {
+  status?: string;
+  attendeeEmail?: string;
+  attendeeName?: string;
+  eventTypeId?: number;
+  eventTypeIds?: string;
+  afterStart?: string;
+  beforeEnd?: string;
+  afterCreatedAt?: string;
+  beforeCreatedAt?: string;
+  afterUpdatedAt?: string;
+  beforeUpdatedAt?: string;
+  bookingUid?: string;
+  sortStart?: "asc" | "desc";
+  sortEnd?: "asc" | "desc";
+  sortCreated?: "asc" | "desc";
+  sortUpdatedAt?: "asc" | "desc";
+  take?: number;
+  skip?: number;
+}
+
+function buildBookingQueryParams(params: BookingFilterParams): Record<string, string | number | undefined> {
+  const qp: Record<string, string | number | undefined> = {};
+  if (params.status !== undefined) qp.status = params.status;
+  if (params.attendeeEmail !== undefined) qp.attendeeEmail = params.attendeeEmail;
+  if (params.attendeeName !== undefined) qp.attendeeName = params.attendeeName;
+  if (params.eventTypeId !== undefined) qp.eventTypeId = params.eventTypeId;
+  if (params.eventTypeIds !== undefined) qp.eventTypeIds = params.eventTypeIds;
+  if (params.afterStart !== undefined) qp.afterStart = params.afterStart;
+  if (params.beforeEnd !== undefined) qp.beforeEnd = params.beforeEnd;
+  if (params.afterCreatedAt !== undefined) qp.afterCreatedAt = params.afterCreatedAt;
+  if (params.beforeCreatedAt !== undefined) qp.beforeCreatedAt = params.beforeCreatedAt;
+  if (params.afterUpdatedAt !== undefined) qp.afterUpdatedAt = params.afterUpdatedAt;
+  if (params.beforeUpdatedAt !== undefined) qp.beforeUpdatedAt = params.beforeUpdatedAt;
+  if (params.bookingUid !== undefined) qp.bookingUid = params.bookingUid;
+  if (params.sortStart !== undefined) qp.sortStart = params.sortStart;
+  if (params.sortEnd !== undefined) qp.sortEnd = params.sortEnd;
+  if (params.sortCreated !== undefined) qp.sortCreated = params.sortCreated;
+  if (params.sortUpdatedAt !== undefined) qp.sortUpdatedAt = params.sortUpdatedAt;
+  if (params.take !== undefined) qp.take = params.take;
+  if (params.skip !== undefined) qp.skip = params.skip;
+  return qp;
+}
+
+// ── Org Team Bookings ──
+
+export const getOrgTeamBookingsSchema = {
+  orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  teamId: z.number().int().describe("Team ID within the organization."),
+  ...bookingFiltersSchema,
+};
+
+export async function getOrgTeamBookings(params: { orgId: number; teamId: number } & BookingFilterParams) {
+  try {
+    const qp = buildBookingQueryParams(params);
+    const data = await calApi(`organizations/${params.orgId}/teams/${params.teamId}/bookings`, { params: qp });
+    return ok(data);
+  } catch (err) {
+    return handleError("get_org_team_bookings", err);
+  }
+}
+
+// ── Org User Bookings ──
+
+export const getOrgUserBookingsSchema = {
+  orgId: z.number().int().describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  userId: z.number().int().describe("User ID of the organization member whose bookings to retrieve."),
+  teamId: z.number().int().optional().describe("Filter by team ID"),
+  teamsIds: z.string().optional().describe("Comma-separated team IDs (e.g. '50,60')"),
+  ...bookingFiltersSchema,
+};
+
+export async function getOrgUserBookings(params: { orgId: number; userId: number; teamId?: number; teamsIds?: string } & BookingFilterParams) {
+  try {
+    const qp = buildBookingQueryParams(params);
+    if (params.teamId !== undefined) qp.teamId = params.teamId;
+    if (params.teamsIds !== undefined) qp.teamsIds = params.teamsIds;
+    const data = await calApi(`organizations/${params.orgId}/users/${params.userId}/bookings`, { params: qp });
+    return ok(data);
+  } catch (err) {
+    return handleError("get_org_user_bookings", err);
+  }
+}

--- a/apps/mcp-server/src/tools/organizations/index.ts
+++ b/apps/mcp-server/src/tools/organizations/index.ts
@@ -1,2 +1,3 @@
+export * from "./bookings.js";
 export * from "./memberships.js";
 export * from "./routing-forms.js";


### PR DESCRIPTION
Fixes: https://linear.app/calcom/issue/ENG-1698/add-mcp-tool-for-list-and-search-bookings

https://github.com/calcom/companion/pull/103 had some issues and review comments like ORG_BOOKING_READ and TEAM_BOOKING_READ wasn't in the default scope string and Readme and `apps/mcp-server/src/server-instructions.ts` wasn't updated