### PR TITLE
feat: add get_scheduling_config MCP tool

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -202,7 +202,7 @@ Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specifi
 |---|---|---|---|
 | `get_event_types` | List Event Types | Read | List all event types |
 | `get_event_type` | Get Event Type | Read | Get a specific event type by ID |
-| `get_round_robin_config` | Get Round-Robin Config | Read | Get round-robin scheduling config for a team event type |
+| `get_scheduling_config` | Get Scheduling Config | Read | Get scheduling configuration for a team event type |
 | `create_event_type` | Create Event Type | Create | Create a new event type |
 | `update_event_type` | Update Event Type | Update | Update an event type |
 | `delete_event_type` | Delete Event Type | Destructive | Delete an event type |

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -4,7 +4,7 @@ A **Model Context Protocol (MCP)** server that wraps the [Cal.com Platform API v
 
 ## Features
 
-- **51 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Booking Routing Trace, Routing Forms, Organizations, Teams, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- **52 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Booking Routing Trace, Routing Forms, Organizations, Teams, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
 - **Dual transport** — stdio for local dev tooling, StreamableHTTP for remote/production
 - **Dual auth** — API key for stdio (local dev), OAuth 2.1 Authorization Code + PKCE for HTTP (production)
 - **Per-user token storage** — encrypted at rest with AES-256-GCM in SQLite
@@ -178,7 +178,7 @@ The server acts as an intermediary: it issues its own access tokens to MCP clien
 - Expired tokens are cleaned up automatically every 5 minutes
 - In-process rate limiting on all OAuth endpoints (token bucket per IP, configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX`)
 
-## Tools (51)
+## Tools (52)
 
 Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specification/draft/server/tools#tool-annotations) — a human-readable `title` plus behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so MCP clients can render them appropriately and apply safety policies.
 
@@ -197,11 +197,12 @@ Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specifi
 | `get_me` | Get My Profile | Read | Get authenticated user profile |
 | `update_me` | Update My Profile | Update | Update user profile |
 
-### Event Types (5)
+### Event Types (6)
 | Tool | Title | Hint | Description |
 |---|---|---|---|
 | `get_event_types` | List Event Types | Read | List all event types |
 | `get_event_type` | Get Event Type | Read | Get a specific event type by ID |
+| `get_round_robin_config` | Get Round-Robin Config | Read | Get round-robin scheduling config for a team event type |
 | `create_event_type` | Create Event Type | Create | Create a new event type |
 | `update_event_type` | Update Event Type | Update | Update an event type |
 | `delete_event_type` | Delete Event Type | Destructive | Delete an event type |

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -1,153 +1,141 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
-
-// ── Users ──
-import { getMeSchema, getMe, updateMeSchema, updateMe } from "./tools/users.js";
-
-// ── Event Types ──
+// ── Availability / Slots ──
+import { getAvailability, getAvailabilitySchema } from "./tools/availability.js";
+// ── Booking Routing Trace ──
 import {
-  getEventTypesSchema,
-  getEventTypes,
-  getEventTypeSchema,
-  getEventType,
-  createEventTypeSchema,
-  createEventType,
-  updateEventTypeSchema,
-  updateEventType,
-  deleteEventTypeSchema,
-  deleteEventType,
-  getRoundRobinConfigSchema,
-  getRoundRobinConfig,
-} from "./tools/event-types.js";
+  getBookingRoutingTrace,
+  getBookingRoutingTraceSchema,
+} from "./tools/booking-routing-trace.js";
 
 // ── Bookings ──
 import {
-  getBookingsSchema,
-  getBookings,
-  getBookingSchema,
-  getBooking,
-  createBookingSchema,
-  createBooking,
-  rescheduleBookingSchema,
-  rescheduleBooking,
-  cancelBookingSchema,
-  cancelBooking,
-  confirmBookingSchema,
-  confirmBooking,
-  markBookingAbsentSchema,
-  markBookingAbsent,
-  getBookingAttendeesSchema,
-  getBookingAttendees,
-  addBookingAttendeeSchema,
   addBookingAttendee,
-  getBookingAttendeeSchema,
+  addBookingAttendeeSchema,
+  cancelBooking,
+  cancelBookingSchema,
+  confirmBooking,
+  confirmBookingSchema,
+  createBooking,
+  createBookingSchema,
+  getBooking,
   getBookingAttendee,
+  getBookingAttendeeSchema,
+  getBookingAttendees,
+  getBookingAttendeesSchema,
+  getBookingSchema,
+  getBookings,
+  getBookingsSchema,
+  markBookingAbsent,
+  markBookingAbsentSchema,
+  rescheduleBooking,
+  rescheduleBookingSchema,
 } from "./tools/bookings.js";
-
-// ── Schedules ──
-import {
-  getSchedulesSchema,
-  getSchedules,
-  getScheduleSchema,
-  getSchedule,
-  createScheduleSchema,
-  createSchedule,
-  updateScheduleSchema,
-  updateSchedule,
-  deleteScheduleSchema,
-  deleteSchedule,
-  getDefaultScheduleSchema,
-  getDefaultSchedule,
-} from "./tools/schedules.js";
-
-// ── Availability / Slots ──
-import { getAvailabilitySchema, getAvailability } from "./tools/availability.js";
-
 // ── Calendars ──
 import {
-  getConnectedCalendarsSchema,
-  getConnectedCalendars,
-  getBusyTimesSchema,
   getBusyTimes,
+  getBusyTimesSchema,
+  getConnectedCalendars,
+  getConnectedCalendarsSchema,
 } from "./tools/calendars.js";
-
 // ── Conferencing ──
-import { getConferencingAppsSchema, getConferencingApps } from "./tools/conferencing.js";
-
-// ── Routing Forms ──
+import { getConferencingApps, getConferencingAppsSchema } from "./tools/conferencing.js";
+// ── Event Types ──
 import {
-  calculateRoutingFormSlotsSchema,
-  calculateRoutingFormSlots,
-} from "./tools/routing-forms.js";
-
-// ── Booking Routing Trace ──
-import {
-  getBookingRoutingTraceSchema,
-  getBookingRoutingTrace,
-} from "./tools/booking-routing-trace.js";
+  createEventType,
+  createEventTypeSchema,
+  deleteEventType,
+  deleteEventTypeSchema,
+  getEventType,
+  getEventTypeSchema,
+  getEventTypes,
+  getEventTypesSchema,
+  getSchedulingConfig,
+  getSchedulingConfigSchema,
+  updateEventType,
+  updateEventTypeSchema,
+} from "./tools/event-types.js";
 // ── Organizations: Attributes ──
 import {
-  getOrgAttributesSchema,
-  getOrgAttributes,
-  getOrgAttributeSchema,
-  getOrgAttribute,
-  getAttributeOptionsSchema,
-  getAttributeOptions,
-  getUserAttributesSchema,
-  getUserAttributes,
-  assignAttributeToUserSchema,
   assignAttributeToUser,
-  updateUserAttributeSchema,
-  updateUserAttribute,
-  unassignAttributeFromUserSchema,
+  assignAttributeToUserSchema,
+  getAttributeOptions,
+  getAttributeOptionsSchema,
+  getOrgAttribute,
+  getOrgAttributeSchema,
+  getOrgAttributes,
+  getOrgAttributesSchema,
+  getUserAttributes,
+  getUserAttributesSchema,
   unassignAttributeFromUser,
+  unassignAttributeFromUserSchema,
+  updateUserAttribute,
+  updateUserAttributeSchema,
 } from "./tools/organizations/attributes.js";
-
 // ── Organizations: Memberships ──
 import {
-  getOrgMembershipsSchema,
-  getOrgMemberships,
-  createOrgMembershipSchema,
   createOrgMembership,
-  getOrgMembershipSchema,
-  getOrgMembership,
-  deleteOrgMembershipSchema,
+  createOrgMembershipSchema,
   deleteOrgMembership,
-  updateOrgMembershipSchema,
+  deleteOrgMembershipSchema,
+  getOrgMembership,
+  getOrgMembershipSchema,
+  getOrgMemberships,
+  getOrgMembershipsSchema,
   updateOrgMembership,
+  updateOrgMembershipSchema,
 } from "./tools/organizations/memberships.js";
-
-// ── Organizations: Teams ──
-import {
-  getOrgTeamsSchema,
-  getOrgTeams,
-  getMyTeamsSchema,
-  getMyTeams,
-} from "./tools/organizations/teams.js";
-
 // ── Organizations: Routing Forms ──
 import {
-  getOrgRoutingFormsSchema,
-  getOrgRoutingForms,
-  getOrgRoutingFormResponsesSchema,
   getOrgRoutingFormResponses,
+  getOrgRoutingFormResponsesSchema,
+  getOrgRoutingForms,
+  getOrgRoutingFormsSchema,
 } from "./tools/organizations/routing-forms.js";
-
+// ── Organizations: Teams ──
+import {
+  getMyTeams,
+  getMyTeamsSchema,
+  getOrgTeams,
+  getOrgTeamsSchema,
+} from "./tools/organizations/teams.js";
+// ── Routing Forms ──
+import {
+  calculateRoutingFormSlots,
+  calculateRoutingFormSlotsSchema,
+} from "./tools/routing-forms.js";
+// ── Schedules ──
+import {
+  createSchedule,
+  createScheduleSchema,
+  deleteSchedule,
+  deleteScheduleSchema,
+  getDefaultSchedule,
+  getDefaultScheduleSchema,
+  getSchedule,
+  getScheduleSchema,
+  getSchedules,
+  getSchedulesSchema,
+  updateSchedule,
+  updateScheduleSchema,
+} from "./tools/schedules.js";
 // ── Teams: Memberships ──
 import {
-  getTeamMembershipsSchema,
-  getTeamMemberships,
-  getTeamMembershipSchema,
-  getTeamMembership,
-  createTeamMembershipSchema,
-  createTeamMembership,
-  updateTeamMembershipSchema,
-  updateTeamMembership,
-  deleteTeamMembershipSchema,
-  deleteTeamMembership,
-  createTeamInviteSchema,
   createTeamInvite,
+  createTeamInviteSchema,
+  createTeamMembership,
+  createTeamMembershipSchema,
+  deleteTeamMembership,
+  deleteTeamMembershipSchema,
+  getTeamMembership,
+  getTeamMembershipSchema,
+  getTeamMemberships,
+  getTeamMembershipsSchema,
+  updateTeamMembership,
+  updateTeamMembershipSchema,
 } from "./tools/teams/memberships.js";
+// ── Users ──
+import { getMe, getMeSchema, updateMe, updateMeSchema } from "./tools/users.js";
 
 /**
  * Tool annotation presets matching MCP behaviour hints.
@@ -273,15 +261,15 @@ export function registerTools(server: McpServer): void {
     deleteEventType
   );
   server.registerTool(
-    "get_round_robin_config",
+    "get_scheduling_config",
     {
-      title: "Get Round-Robin Config",
+      title: "Get Scheduling Config",
       description:
-        "Get the round-robin scheduling configuration for a team event type. Returns hosts (with priority, weight, mandatory status, group assignment), host groups, distribution settings (maxLeadThreshold), and advanced settings (weights enabled, no-show calculation, CRM fallback). The event type must be a team event type with round-robin scheduling — returns 422 otherwise.",
-      inputSchema: getRoundRobinConfigSchema,
+        "Get the scheduling configuration for a team event type. For roundRobin types: returns hosts (with priority, weight, mandatory status, group assignment), host groups, distribution settings (maxLeadThreshold), and advanced settings (weights enabled, no-show calculation, CRM fallback). For collective/managed types: returns hosts with basic info and assignAllTeamMembers. The event type must be a team event type — returns 422 otherwise.",
+      inputSchema: getSchedulingConfigSchema,
       annotations: READ_ONLY,
     },
-    getRoundRobinConfig
+    getSchedulingConfig
   );
 
   // ── Bookings (10) ──
@@ -521,7 +509,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingRoutingTraceSchema,
       annotations: READ_ONLY,
     },
-    getBookingRoutingTrace,
+    getBookingRoutingTrace
   );
 
   // ── Routing Forms (1) ──

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -16,6 +16,8 @@ import {
   updateEventType,
   deleteEventTypeSchema,
   deleteEventType,
+  getRoundRobinConfigSchema,
+  getRoundRobinConfig,
 } from "./tools/event-types.js";
 
 // ── Bookings ──
@@ -214,7 +216,7 @@ export function registerTools(server: McpServer): void {
     updateMe
   );
 
-  // ── Event Types (5) ──
+  // ── Event Types (6) ──
   server.registerTool(
     "get_event_types",
     {
@@ -269,6 +271,17 @@ export function registerTools(server: McpServer): void {
       annotations: DESTRUCTIVE,
     },
     deleteEventType
+  );
+  server.registerTool(
+    "get_round_robin_config",
+    {
+      title: "Get Round-Robin Config",
+      description:
+        "Get the round-robin scheduling configuration for a team event type. Returns hosts (with priority, weight, mandatory status, group assignment), host groups, distribution settings (maxLeadThreshold), and advanced settings (weights enabled, no-show calculation, CRM fallback). The event type must be a team event type with round-robin scheduling — returns 422 otherwise.",
+      inputSchema: getRoundRobinConfigSchema,
+      annotations: READ_ONLY,
+    },
+    getRoundRobinConfig
   );
 
   // ── Bookings (10) ──

--- a/apps/mcp-server/src/server-instructions.ts
+++ b/apps/mcp-server/src/server-instructions.ts
@@ -7,6 +7,7 @@ export const SERVER_INSTRUCTIONS = `You are connected to the Cal.com MCP server.
 CAPABILITIES — what you CAN do with the available tools:
 - Manage the user's profile (get_me, update_me)
 - List, create, update, and delete event types
+- Get round-robin scheduling configuration for team event types (hosts, priorities, weights, groups, distribution settings)
 - List, get, create, reschedule, cancel, and confirm bookings
 - Manage booking attendees (list, get, add)
 - Mark bookings as absent (no-show)

--- a/apps/mcp-server/src/server-instructions.ts
+++ b/apps/mcp-server/src/server-instructions.ts
@@ -7,7 +7,7 @@ export const SERVER_INSTRUCTIONS = `You are connected to the Cal.com MCP server.
 CAPABILITIES — what you CAN do with the available tools:
 - Manage the user's profile (get_me, update_me)
 - List, create, update, and delete event types
-- Get round-robin scheduling configuration for team event types (hosts, priorities, weights, groups, distribution settings)
+- Get scheduling configuration for team event types (hosts, priorities, weights, groups, distribution settings for roundRobin; basic host info for collective/managed)
 - List, get, create, reschedule, cancel, and confirm bookings
 - Manage booking attendees (list, get, add)
 - Mark bookings as absent (no-show)

--- a/apps/mcp-server/src/tools/event-types.test.ts
+++ b/apps/mcp-server/src/tools/event-types.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CalApiError } from "../utils/errors.js";
 
 vi.mock("../utils/api-client.js", () => ({
@@ -7,18 +7,18 @@ vi.mock("../utils/api-client.js", () => ({
 
 import { calApi } from "../utils/api-client.js";
 import {
-  getEventTypes,
-  getEventType,
   createEventType,
-  updateEventType,
-  deleteEventType,
-  getRoundRobinConfig,
-  getEventTypesSchema,
-  getEventTypeSchema,
   createEventTypeSchema,
-  updateEventTypeSchema,
+  deleteEventType,
   deleteEventTypeSchema,
-  getRoundRobinConfigSchema,
+  getEventType,
+  getEventTypeSchema,
+  getEventTypes,
+  getEventTypesSchema,
+  getSchedulingConfig,
+  getSchedulingConfigSchema,
+  updateEventType,
+  updateEventTypeSchema,
 } from "./event-types.js";
 
 const mockCalApi = vi.mocked(calApi);
@@ -177,21 +177,21 @@ describe("deleteEventType", () => {
   });
 });
 
-describe("getRoundRobinConfig schema", () => {
-  it("exports getRoundRobinConfigSchema with eventTypeId", () => {
-    expect(getRoundRobinConfigSchema.eventTypeId).toBeDefined();
+describe("getSchedulingConfig schema", () => {
+  it("exports getSchedulingConfigSchema with eventTypeId", () => {
+    expect(getSchedulingConfigSchema.eventTypeId).toBeDefined();
   });
 
   it("requires eventTypeId to be a positive integer", () => {
-    expect(getRoundRobinConfigSchema.eventTypeId.safeParse(1).success).toBe(true);
-    expect(getRoundRobinConfigSchema.eventTypeId.safeParse(0).success).toBe(false);
-    expect(getRoundRobinConfigSchema.eventTypeId.safeParse(-1).success).toBe(false);
-    expect(getRoundRobinConfigSchema.eventTypeId.safeParse(1.5).success).toBe(false);
-    expect(getRoundRobinConfigSchema.eventTypeId.safeParse("abc").success).toBe(false);
+    expect(getSchedulingConfigSchema.eventTypeId.safeParse(1).success).toBe(true);
+    expect(getSchedulingConfigSchema.eventTypeId.safeParse(0).success).toBe(false);
+    expect(getSchedulingConfigSchema.eventTypeId.safeParse(-1).success).toBe(false);
+    expect(getSchedulingConfigSchema.eventTypeId.safeParse(1.5).success).toBe(false);
+    expect(getSchedulingConfigSchema.eventTypeId.safeParse("abc").success).toBe(false);
   });
 });
 
-describe("getRoundRobinConfig", () => {
+describe("getSchedulingConfig", () => {
   it("calls the correct API path", async () => {
     mockCalApi.mockResolvedValueOnce({
       eventTypeId: 10,
@@ -200,9 +200,9 @@ describe("getRoundRobinConfig", () => {
       hostGroups: [],
     });
 
-    const result = await getRoundRobinConfig({ eventTypeId: 10 });
+    const result = await getSchedulingConfig({ eventTypeId: 10 });
 
-    expect(mockCalApi).toHaveBeenCalledWith("event-types/10/round-robin");
+    expect(mockCalApi).toHaveBeenCalledWith("event-types/10/scheduling-config");
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.schedulingType).toBe("roundRobin");
   });
@@ -233,7 +233,7 @@ describe("getRoundRobinConfig", () => {
     };
     mockCalApi.mockResolvedValueOnce(mockResponse);
 
-    const result = await getRoundRobinConfig({ eventTypeId: 10 });
+    const result = await getSchedulingConfig({ eventTypeId: 10 });
 
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.hosts).toHaveLength(1);
@@ -244,9 +244,9 @@ describe("getRoundRobinConfig", () => {
   });
 
   it("handles errors", async () => {
-    mockCalApi.mockRejectedValueOnce(new CalApiError(422, "Not a round-robin event type", {}));
+    mockCalApi.mockRejectedValueOnce(new CalApiError(422, "Not a team event type", {}));
 
-    const result = await getRoundRobinConfig({ eventTypeId: 99 });
+    const result = await getSchedulingConfig({ eventTypeId: 99 });
 
     expect(result).toHaveProperty("isError", true);
   });

--- a/apps/mcp-server/src/tools/event-types.test.ts
+++ b/apps/mcp-server/src/tools/event-types.test.ts
@@ -12,11 +12,13 @@ import {
   createEventType,
   updateEventType,
   deleteEventType,
+  getRoundRobinConfig,
   getEventTypesSchema,
   getEventTypeSchema,
   createEventTypeSchema,
   updateEventTypeSchema,
   deleteEventTypeSchema,
+  getRoundRobinConfigSchema,
 } from "./event-types.js";
 
 const mockCalApi = vi.mocked(calApi);
@@ -172,5 +174,79 @@ describe("deleteEventType", () => {
     await deleteEventType({ eventTypeId: 42 });
 
     expect(mockCalApi).toHaveBeenCalledWith("event-types/42", { method: "DELETE" });
+  });
+});
+
+describe("getRoundRobinConfig schema", () => {
+  it("exports getRoundRobinConfigSchema with eventTypeId", () => {
+    expect(getRoundRobinConfigSchema.eventTypeId).toBeDefined();
+  });
+
+  it("requires eventTypeId to be a positive integer", () => {
+    expect(getRoundRobinConfigSchema.eventTypeId.safeParse(1).success).toBe(true);
+    expect(getRoundRobinConfigSchema.eventTypeId.safeParse(0).success).toBe(true);
+    expect(getRoundRobinConfigSchema.eventTypeId.safeParse(1.5).success).toBe(false);
+    expect(getRoundRobinConfigSchema.eventTypeId.safeParse("abc").success).toBe(false);
+  });
+});
+
+describe("getRoundRobinConfig", () => {
+  it("calls the correct API path", async () => {
+    mockCalApi.mockResolvedValueOnce({
+      eventTypeId: 10,
+      schedulingType: "roundRobin",
+      hosts: [],
+      hostGroups: [],
+    });
+
+    const result = await getRoundRobinConfig({ eventTypeId: 10 });
+
+    expect(mockCalApi).toHaveBeenCalledWith("event-types/10/round-robin");
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.schedulingType).toBe("roundRobin");
+  });
+
+  it("returns full round-robin config data", async () => {
+    const mockResponse = {
+      eventTypeId: 10,
+      schedulingType: "roundRobin",
+      hosts: [
+        {
+          userId: 1,
+          name: "Alice",
+          username: "alice",
+          mandatory: false,
+          priority: "high",
+          weight: 150,
+          avatarUrl: null,
+          groupId: "group-1",
+        },
+      ],
+      hostGroups: [{ id: "group-1", name: "Sales Team" }],
+      assignAllTeamMembers: false,
+      rescheduleWithSameRoundRobinHost: true,
+      isRRWeightsEnabled: true,
+      maxLeadThreshold: 3,
+      includeNoShowInRRCalculation: false,
+      crmRecordOwnerFallbackWindowHours: 24,
+    };
+    mockCalApi.mockResolvedValueOnce(mockResponse);
+
+    const result = await getRoundRobinConfig({ eventTypeId: 10 });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.hosts).toHaveLength(1);
+    expect(parsed.hosts[0].weight).toBe(150);
+    expect(parsed.hostGroups[0].name).toBe("Sales Team");
+    expect(parsed.isRRWeightsEnabled).toBe(true);
+    expect(parsed.maxLeadThreshold).toBe(3);
+  });
+
+  it("handles errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(422, "Not a round-robin event type", {}));
+
+    const result = await getRoundRobinConfig({ eventTypeId: 99 });
+
+    expect(result).toHaveProperty("isError", true);
   });
 });

--- a/apps/mcp-server/src/tools/event-types.test.ts
+++ b/apps/mcp-server/src/tools/event-types.test.ts
@@ -184,7 +184,8 @@ describe("getRoundRobinConfig schema", () => {
 
   it("requires eventTypeId to be a positive integer", () => {
     expect(getRoundRobinConfigSchema.eventTypeId.safeParse(1).success).toBe(true);
-    expect(getRoundRobinConfigSchema.eventTypeId.safeParse(0).success).toBe(true);
+    expect(getRoundRobinConfigSchema.eventTypeId.safeParse(0).success).toBe(false);
+    expect(getRoundRobinConfigSchema.eventTypeId.safeParse(-1).success).toBe(false);
     expect(getRoundRobinConfigSchema.eventTypeId.safeParse(1.5).success).toBe(false);
     expect(getRoundRobinConfigSchema.eventTypeId.safeParse("abc").success).toBe(false);
   });

--- a/apps/mcp-server/src/tools/event-types.ts
+++ b/apps/mcp-server/src/tools/event-types.ts
@@ -311,6 +311,7 @@ export const getRoundRobinConfigSchema = {
   eventTypeId: z
     .number()
     .int()
+    .positive()
     .describe(
       "Event type ID. Must be a team event type with round-robin scheduling. Use get_event_types to find this."
     ),

--- a/apps/mcp-server/src/tools/event-types.ts
+++ b/apps/mcp-server/src/tools/event-types.ts
@@ -6,7 +6,9 @@ export const getEventTypesSchema = {
   username: z
     .string()
     .optional()
-    .describe("Username of the person whose event types you want to list. Omit to list the authenticated user's event types."),
+    .describe(
+      "Username of the person whose event types you want to list. Omit to list the authenticated user's event types."
+    ),
   eventSlug: z
     .string()
     .optional()
@@ -14,7 +16,9 @@ export const getEventTypesSchema = {
   usernames: z
     .string()
     .optional()
-    .describe("Comma-separated usernames for fetching a dynamic group event type (e.g. 'alice,bob')."),
+    .describe(
+      "Comma-separated usernames for fetching a dynamic group event type (e.g. 'alice,bob')."
+    ),
   orgSlug: z.string().optional().describe("Organization slug to filter by."),
   orgId: z.number().optional().describe("Organization ID to filter by (alternative to orgSlug)."),
   sortCreatedAt: z.enum(["asc", "desc"]).optional().describe("Sort event types by creation date."),
@@ -60,57 +64,140 @@ export const createEventTypeSchema = {
   title: z.string().describe("Event type title"),
   slug: z.string().describe("URL-friendly slug (e.g. '30min')"),
   lengthInMinutes: z.number().int().positive().describe("Duration in minutes"),
-  lengthInMinutesOptions: z.array(z.number().int().positive()).optional().describe("Multiple duration options the attendee can choose from (e.g. [15, 30, 60]). If provided, the booker picks their preferred duration."),
+  lengthInMinutesOptions: z
+    .array(z.number().int().positive())
+    .optional()
+    .describe(
+      "Multiple duration options the attendee can choose from (e.g. [15, 30, 60]). If provided, the booker picks their preferred duration."
+    ),
   description: z.string().optional().describe("Description shown on the booking page"),
   locations: z
     .array(z.record(z.unknown()))
     .optional()
-    .describe("Locations where the event takes place. If not provided, Cal Video is used. Each element is a location object (e.g. {type: 'inPerson', address: '...'}). Note: setting a conferencing app as location requires the app to already be installed."),
+    .describe(
+      "Locations where the event takes place. If not provided, Cal Video is used. Each element is a location object (e.g. {type: 'inPerson', address: '...'}). Note: setting a conferencing app as location requires the app to already be installed."
+    ),
   bookingFields: z
     .array(z.record(z.unknown()))
     .optional()
-    .describe("Custom fields added to the booking form. Each object defines a field with properties like name, type, label, required, etc."),
+    .describe(
+      "Custom fields added to the booking form. Each object defines a field with properties like name, type, label, required, etc."
+    ),
   disableGuests: z.boolean().optional().describe("If true, bookers cannot add guest emails."),
-  slotInterval: z.number().int().optional().describe("Length of each slot in minutes. Defaults to the event duration."),
-  minimumBookingNotice: z.number().int().optional().describe("Minimum minutes before the event that a booking can be made."),
-  beforeEventBuffer: z.number().int().optional().describe("Minutes blocked on calendar before the meeting starts."),
-  afterEventBuffer: z.number().int().optional().describe("Minutes blocked on calendar after the meeting ends."),
-  scheduleId: z.number().int().optional().describe("Use a specific schedule instead of the user's default. Use get_schedules to find schedule IDs."),
+  slotInterval: z
+    .number()
+    .int()
+    .optional()
+    .describe("Length of each slot in minutes. Defaults to the event duration."),
+  minimumBookingNotice: z
+    .number()
+    .int()
+    .optional()
+    .describe("Minimum minutes before the event that a booking can be made."),
+  beforeEventBuffer: z
+    .number()
+    .int()
+    .optional()
+    .describe("Minutes blocked on calendar before the meeting starts."),
+  afterEventBuffer: z
+    .number()
+    .int()
+    .optional()
+    .describe("Minutes blocked on calendar after the meeting ends."),
+  scheduleId: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      "Use a specific schedule instead of the user's default. Use get_schedules to find schedule IDs."
+    ),
   recurrence: z
     .record(z.unknown())
     .optional()
-    .describe("Recurrence settings to create a recurring event type (e.g. {frequency: 'weekly', interval: 1, occurrences: 12})."),
+    .describe(
+      "Recurrence settings to create a recurring event type (e.g. {frequency: 'weekly', interval: 1, occurrences: 12})."
+    ),
   confirmationPolicy: z
     .record(z.unknown())
     .optional()
     .describe("Manual confirmation policy. Controls whether bookings require host confirmation."),
-  requiresBookerEmailVerification: z.boolean().optional().describe("Whether booker must verify their email before the booking is confirmed."),
+  requiresBookerEmailVerification: z
+    .boolean()
+    .optional()
+    .describe("Whether booker must verify their email before the booking is confirmed."),
   hideCalendarNotes: z.boolean().optional().describe("Hide calendar notes from the booking."),
-  lockTimeZoneToggleOnBookingPage: z.boolean().optional().describe("Lock the timezone on the booking page."),
+  lockTimeZoneToggleOnBookingPage: z
+    .boolean()
+    .optional()
+    .describe("Lock the timezone on the booking page."),
   seats: z
     .record(z.unknown())
     .optional()
     .describe("Enable seated events. Object with seatsPerTimeSlot and other seat settings."),
-  customName: z.string().optional().describe("Custom event name template with variables: {Event type title}, {Organiser}, {Scheduler}, {Location}."),
-  successRedirectUrl: z.string().optional().describe("URL to redirect the booker to after a successful booking."),
-  hidden: z.boolean().optional().describe("Whether the event type is hidden from the public profile."),
-  offsetStart: z.number().int().optional().describe("Offset timeslots shown to bookers by a specified number of minutes."),
-  onlyShowFirstAvailableSlot: z.boolean().optional().describe("Limit availability to one slot per day (the earliest available)."),
-  bookingLimitsCount: z.object({
-    day: z.number().int().min(1).optional().describe("Max bookings per day"),
-    week: z.number().int().min(1).optional().describe("Max bookings per week"),
-    month: z.number().int().min(1).optional().describe("Max bookings per month"),
-    year: z.number().int().min(1).optional().describe("Max bookings per year"),
-  }).optional().describe("Limit how many times this event can be booked per period (e.g. {day: 2, week: 5})."),
-  bookingWindow: z.object({
-    type: z.enum(["businessDays", "calendarDays", "range"]).describe("Window type"),
-    value: z.union([z.number(), z.array(z.string())]).describe("Number of days (for businessDays/calendarDays) or date range array ['2030-09-05', '2030-09-09'] (for range)"),
-    rolling: z.boolean().optional().describe("If true the window rolls forward keeping 'value' days available. Only for businessDays/calendarDays."),
-  }).optional().describe("Limit how far in the future this event can be booked."),
-  destinationCalendar: z.object({
-    integration: z.string().describe("Integration type (e.g. 'google_calendar'). Use get_connected_calendars to find this."),
-    externalId: z.string().describe("External calendar ID (e.g. email for Google Calendar). Use get_connected_calendars to find this."),
-  }).optional().describe("Which external calendar new bookings are added to."),
+  customName: z
+    .string()
+    .optional()
+    .describe(
+      "Custom event name template with variables: {Event type title}, {Organiser}, {Scheduler}, {Location}."
+    ),
+  successRedirectUrl: z
+    .string()
+    .optional()
+    .describe("URL to redirect the booker to after a successful booking."),
+  hidden: z
+    .boolean()
+    .optional()
+    .describe("Whether the event type is hidden from the public profile."),
+  offsetStart: z
+    .number()
+    .int()
+    .optional()
+    .describe("Offset timeslots shown to bookers by a specified number of minutes."),
+  onlyShowFirstAvailableSlot: z
+    .boolean()
+    .optional()
+    .describe("Limit availability to one slot per day (the earliest available)."),
+  bookingLimitsCount: z
+    .object({
+      day: z.number().int().min(1).optional().describe("Max bookings per day"),
+      week: z.number().int().min(1).optional().describe("Max bookings per week"),
+      month: z.number().int().min(1).optional().describe("Max bookings per month"),
+      year: z.number().int().min(1).optional().describe("Max bookings per year"),
+    })
+    .optional()
+    .describe("Limit how many times this event can be booked per period (e.g. {day: 2, week: 5})."),
+  bookingWindow: z
+    .object({
+      type: z.enum(["businessDays", "calendarDays", "range"]).describe("Window type"),
+      value: z
+        .union([z.number(), z.array(z.string())])
+        .describe(
+          "Number of days (for businessDays/calendarDays) or date range array ['2030-09-05', '2030-09-09'] (for range)"
+        ),
+      rolling: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true the window rolls forward keeping 'value' days available. Only for businessDays/calendarDays."
+        ),
+    })
+    .optional()
+    .describe("Limit how far in the future this event can be booked."),
+  destinationCalendar: z
+    .object({
+      integration: z
+        .string()
+        .describe(
+          "Integration type (e.g. 'google_calendar'). Use get_connected_calendars to find this."
+        ),
+      externalId: z
+        .string()
+        .describe(
+          "External calendar ID (e.g. email for Google Calendar). Use get_connected_calendars to find this."
+        ),
+    })
+    .optional()
+    .describe("Which external calendar new bookings are added to."),
 };
 
 export async function createEventType(params: {
@@ -148,30 +235,39 @@ export async function createEventType(params: {
       slug: params.slug,
       lengthInMinutes: params.lengthInMinutes,
     };
-    if (params.lengthInMinutesOptions !== undefined) body.lengthInMinutesOptions = params.lengthInMinutesOptions;
+    if (params.lengthInMinutesOptions !== undefined)
+      body.lengthInMinutesOptions = params.lengthInMinutesOptions;
     if (params.description !== undefined) body.description = params.description;
     if (params.locations !== undefined) body.locations = params.locations;
     if (params.bookingFields !== undefined) body.bookingFields = params.bookingFields;
     if (params.disableGuests !== undefined) body.disableGuests = params.disableGuests;
     if (params.slotInterval !== undefined) body.slotInterval = params.slotInterval;
-    if (params.minimumBookingNotice !== undefined) body.minimumBookingNotice = params.minimumBookingNotice;
+    if (params.minimumBookingNotice !== undefined)
+      body.minimumBookingNotice = params.minimumBookingNotice;
     if (params.beforeEventBuffer !== undefined) body.beforeEventBuffer = params.beforeEventBuffer;
     if (params.afterEventBuffer !== undefined) body.afterEventBuffer = params.afterEventBuffer;
     if (params.scheduleId !== undefined) body.scheduleId = params.scheduleId;
     if (params.recurrence !== undefined) body.recurrence = params.recurrence;
-    if (params.confirmationPolicy !== undefined) body.confirmationPolicy = params.confirmationPolicy;
-    if (params.requiresBookerEmailVerification !== undefined) body.requiresBookerEmailVerification = params.requiresBookerEmailVerification;
+    if (params.confirmationPolicy !== undefined)
+      body.confirmationPolicy = params.confirmationPolicy;
+    if (params.requiresBookerEmailVerification !== undefined)
+      body.requiresBookerEmailVerification = params.requiresBookerEmailVerification;
     if (params.hideCalendarNotes !== undefined) body.hideCalendarNotes = params.hideCalendarNotes;
-    if (params.lockTimeZoneToggleOnBookingPage !== undefined) body.lockTimeZoneToggleOnBookingPage = params.lockTimeZoneToggleOnBookingPage;
+    if (params.lockTimeZoneToggleOnBookingPage !== undefined)
+      body.lockTimeZoneToggleOnBookingPage = params.lockTimeZoneToggleOnBookingPage;
     if (params.seats !== undefined) body.seats = params.seats;
     if (params.customName !== undefined) body.customName = params.customName;
-    if (params.successRedirectUrl !== undefined) body.successRedirectUrl = params.successRedirectUrl;
+    if (params.successRedirectUrl !== undefined)
+      body.successRedirectUrl = params.successRedirectUrl;
     if (params.hidden !== undefined) body.hidden = params.hidden;
     if (params.offsetStart !== undefined) body.offsetStart = params.offsetStart;
-    if (params.onlyShowFirstAvailableSlot !== undefined) body.onlyShowFirstAvailableSlot = params.onlyShowFirstAvailableSlot;
-    if (params.bookingLimitsCount !== undefined) body.bookingLimitsCount = params.bookingLimitsCount;
+    if (params.onlyShowFirstAvailableSlot !== undefined)
+      body.onlyShowFirstAvailableSlot = params.onlyShowFirstAvailableSlot;
+    if (params.bookingLimitsCount !== undefined)
+      body.bookingLimitsCount = params.bookingLimitsCount;
     if (params.bookingWindow !== undefined) body.bookingWindow = params.bookingWindow;
-    if (params.destinationCalendar !== undefined) body.destinationCalendar = params.destinationCalendar;
+    if (params.destinationCalendar !== undefined)
+      body.destinationCalendar = params.destinationCalendar;
     const data = await calApi("event-types", { method: "POST", body });
     return ok(data);
   } catch (err) {
@@ -180,11 +276,19 @@ export async function createEventType(params: {
 }
 
 export const updateEventTypeSchema = {
-  eventTypeId: z.number().int().describe("Event type ID to update. Use get_event_types to find this."),
+  eventTypeId: z
+    .number()
+    .int()
+    .describe("Event type ID to update. Use get_event_types to find this."),
   title: z.string().optional().describe("New title"),
   slug: z.string().optional().describe("New URL-friendly slug"),
   lengthInMinutes: z.number().int().positive().optional().describe("New duration in minutes"),
-  lengthInMinutesOptions: z.array(z.number().int().positive()).optional().describe("Multiple duration options the attendee can choose from (e.g. [15, 30, 60]). If provided, the booker picks their preferred duration."),
+  lengthInMinutesOptions: z
+    .array(z.number().int().positive())
+    .optional()
+    .describe(
+      "Multiple duration options the attendee can choose from (e.g. [15, 30, 60]). If provided, the booker picks their preferred duration."
+    ),
   description: z.string().optional().describe("New description"),
   locations: z
     .array(z.record(z.unknown()))
@@ -193,39 +297,98 @@ export const updateEventTypeSchema = {
   bookingFields: z
     .array(z.record(z.unknown()))
     .optional()
-    .describe("Updated booking fields array. Replaces ALL existing booking fields. To modify fields, first fetch the current event type with get_event_type, then include all desired fields here."),
+    .describe(
+      "Updated booking fields array. Replaces ALL existing booking fields. To modify fields, first fetch the current event type with get_event_type, then include all desired fields here."
+    ),
   disableGuests: z.boolean().optional().describe("If true, bookers cannot add guest emails."),
   slotInterval: z.number().int().optional().describe("Length of each slot in minutes."),
-  minimumBookingNotice: z.number().int().optional().describe("Minimum minutes before event that a booking can be made."),
-  beforeEventBuffer: z.number().int().optional().describe("Minutes blocked on calendar before the meeting."),
-  afterEventBuffer: z.number().int().optional().describe("Minutes blocked on calendar after the meeting."),
-  scheduleId: z.number().int().optional().describe("Schedule ID to use instead of default. Use get_schedules to find schedule IDs."),
-  recurrence: z.record(z.unknown()).optional().describe("Recurrence settings (e.g. {frequency: 'weekly', interval: 1, occurrences: 12})."),
-  confirmationPolicy: z.record(z.unknown()).optional().describe("Manual confirmation policy settings."),
-  requiresBookerEmailVerification: z.boolean().optional().describe("Whether booker must verify their email."),
+  minimumBookingNotice: z
+    .number()
+    .int()
+    .optional()
+    .describe("Minimum minutes before event that a booking can be made."),
+  beforeEventBuffer: z
+    .number()
+    .int()
+    .optional()
+    .describe("Minutes blocked on calendar before the meeting."),
+  afterEventBuffer: z
+    .number()
+    .int()
+    .optional()
+    .describe("Minutes blocked on calendar after the meeting."),
+  scheduleId: z
+    .number()
+    .int()
+    .optional()
+    .describe("Schedule ID to use instead of default. Use get_schedules to find schedule IDs."),
+  recurrence: z
+    .record(z.unknown())
+    .optional()
+    .describe("Recurrence settings (e.g. {frequency: 'weekly', interval: 1, occurrences: 12})."),
+  confirmationPolicy: z
+    .record(z.unknown())
+    .optional()
+    .describe("Manual confirmation policy settings."),
+  requiresBookerEmailVerification: z
+    .boolean()
+    .optional()
+    .describe("Whether booker must verify their email."),
   hideCalendarNotes: z.boolean().optional().describe("Hide calendar notes."),
-  lockTimeZoneToggleOnBookingPage: z.boolean().optional().describe("Lock timezone on booking page."),
+  lockTimeZoneToggleOnBookingPage: z
+    .boolean()
+    .optional()
+    .describe("Lock timezone on booking page."),
   seats: z.record(z.unknown()).optional().describe("Seated event settings."),
   customName: z.string().optional().describe("Custom event name template."),
   successRedirectUrl: z.string().optional().describe("Redirect URL after successful booking."),
   hidden: z.boolean().optional().describe("Whether the event type is hidden."),
   offsetStart: z.number().int().optional().describe("Offset timeslots by specified minutes."),
-  onlyShowFirstAvailableSlot: z.boolean().optional().describe("Show only the earliest available slot per day."),
-  bookingLimitsCount: z.object({
-    day: z.number().int().min(1).optional().describe("Max bookings per day"),
-    week: z.number().int().min(1).optional().describe("Max bookings per week"),
-    month: z.number().int().min(1).optional().describe("Max bookings per month"),
-    year: z.number().int().min(1).optional().describe("Max bookings per year"),
-  }).optional().describe("Limit how many times this event can be booked per period (e.g. {day: 2, week: 5})."),
-  bookingWindow: z.object({
-    type: z.enum(["businessDays", "calendarDays", "range"]).describe("Window type"),
-    value: z.union([z.number(), z.array(z.string())]).describe("Number of days (for businessDays/calendarDays) or date range array ['2030-09-05', '2030-09-09'] (for range)"),
-    rolling: z.boolean().optional().describe("If true the window rolls forward keeping 'value' days available. Only for businessDays/calendarDays."),
-  }).optional().describe("Limit how far in the future this event can be booked."),
-  destinationCalendar: z.object({
-    integration: z.string().describe("Integration type (e.g. 'google_calendar'). Use get_connected_calendars to find this."),
-    externalId: z.string().describe("External calendar ID (e.g. email for Google Calendar). Use get_connected_calendars to find this."),
-  }).optional().describe("Which external calendar new bookings are added to."),
+  onlyShowFirstAvailableSlot: z
+    .boolean()
+    .optional()
+    .describe("Show only the earliest available slot per day."),
+  bookingLimitsCount: z
+    .object({
+      day: z.number().int().min(1).optional().describe("Max bookings per day"),
+      week: z.number().int().min(1).optional().describe("Max bookings per week"),
+      month: z.number().int().min(1).optional().describe("Max bookings per month"),
+      year: z.number().int().min(1).optional().describe("Max bookings per year"),
+    })
+    .optional()
+    .describe("Limit how many times this event can be booked per period (e.g. {day: 2, week: 5})."),
+  bookingWindow: z
+    .object({
+      type: z.enum(["businessDays", "calendarDays", "range"]).describe("Window type"),
+      value: z
+        .union([z.number(), z.array(z.string())])
+        .describe(
+          "Number of days (for businessDays/calendarDays) or date range array ['2030-09-05', '2030-09-09'] (for range)"
+        ),
+      rolling: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true the window rolls forward keeping 'value' days available. Only for businessDays/calendarDays."
+        ),
+    })
+    .optional()
+    .describe("Limit how far in the future this event can be booked."),
+  destinationCalendar: z
+    .object({
+      integration: z
+        .string()
+        .describe(
+          "Integration type (e.g. 'google_calendar'). Use get_connected_calendars to find this."
+        ),
+      externalId: z
+        .string()
+        .describe(
+          "External calendar ID (e.g. email for Google Calendar). Use get_connected_calendars to find this."
+        ),
+    })
+    .optional()
+    .describe("Which external calendar new bookings are added to."),
 };
 
 export async function updateEventType(params: {
@@ -263,30 +426,39 @@ export async function updateEventType(params: {
     if (params.title !== undefined) body.title = params.title;
     if (params.slug !== undefined) body.slug = params.slug;
     if (params.lengthInMinutes !== undefined) body.lengthInMinutes = params.lengthInMinutes;
-    if (params.lengthInMinutesOptions !== undefined) body.lengthInMinutesOptions = params.lengthInMinutesOptions;
+    if (params.lengthInMinutesOptions !== undefined)
+      body.lengthInMinutesOptions = params.lengthInMinutesOptions;
     if (params.description !== undefined) body.description = params.description;
     if (params.locations !== undefined) body.locations = params.locations;
     if (params.bookingFields !== undefined) body.bookingFields = params.bookingFields;
     if (params.disableGuests !== undefined) body.disableGuests = params.disableGuests;
     if (params.slotInterval !== undefined) body.slotInterval = params.slotInterval;
-    if (params.minimumBookingNotice !== undefined) body.minimumBookingNotice = params.minimumBookingNotice;
+    if (params.minimumBookingNotice !== undefined)
+      body.minimumBookingNotice = params.minimumBookingNotice;
     if (params.beforeEventBuffer !== undefined) body.beforeEventBuffer = params.beforeEventBuffer;
     if (params.afterEventBuffer !== undefined) body.afterEventBuffer = params.afterEventBuffer;
     if (params.scheduleId !== undefined) body.scheduleId = params.scheduleId;
     if (params.recurrence !== undefined) body.recurrence = params.recurrence;
-    if (params.confirmationPolicy !== undefined) body.confirmationPolicy = params.confirmationPolicy;
-    if (params.requiresBookerEmailVerification !== undefined) body.requiresBookerEmailVerification = params.requiresBookerEmailVerification;
+    if (params.confirmationPolicy !== undefined)
+      body.confirmationPolicy = params.confirmationPolicy;
+    if (params.requiresBookerEmailVerification !== undefined)
+      body.requiresBookerEmailVerification = params.requiresBookerEmailVerification;
     if (params.hideCalendarNotes !== undefined) body.hideCalendarNotes = params.hideCalendarNotes;
-    if (params.lockTimeZoneToggleOnBookingPage !== undefined) body.lockTimeZoneToggleOnBookingPage = params.lockTimeZoneToggleOnBookingPage;
+    if (params.lockTimeZoneToggleOnBookingPage !== undefined)
+      body.lockTimeZoneToggleOnBookingPage = params.lockTimeZoneToggleOnBookingPage;
     if (params.seats !== undefined) body.seats = params.seats;
     if (params.customName !== undefined) body.customName = params.customName;
-    if (params.successRedirectUrl !== undefined) body.successRedirectUrl = params.successRedirectUrl;
+    if (params.successRedirectUrl !== undefined)
+      body.successRedirectUrl = params.successRedirectUrl;
     if (params.hidden !== undefined) body.hidden = params.hidden;
     if (params.offsetStart !== undefined) body.offsetStart = params.offsetStart;
-    if (params.onlyShowFirstAvailableSlot !== undefined) body.onlyShowFirstAvailableSlot = params.onlyShowFirstAvailableSlot;
-    if (params.bookingLimitsCount !== undefined) body.bookingLimitsCount = params.bookingLimitsCount;
+    if (params.onlyShowFirstAvailableSlot !== undefined)
+      body.onlyShowFirstAvailableSlot = params.onlyShowFirstAvailableSlot;
+    if (params.bookingLimitsCount !== undefined)
+      body.bookingLimitsCount = params.bookingLimitsCount;
     if (params.bookingWindow !== undefined) body.bookingWindow = params.bookingWindow;
-    if (params.destinationCalendar !== undefined) body.destinationCalendar = params.destinationCalendar;
+    if (params.destinationCalendar !== undefined)
+      body.destinationCalendar = params.destinationCalendar;
     const data = await calApi(`event-types/${params.eventTypeId}`, { method: "PATCH", body });
     return ok(data);
   } catch (err) {
@@ -295,7 +467,10 @@ export async function updateEventType(params: {
 }
 
 export const deleteEventTypeSchema = {
-  eventTypeId: z.number().int().describe("Event type ID to delete. Use get_event_types to find this."),
+  eventTypeId: z
+    .number()
+    .int()
+    .describe("Event type ID to delete. Use get_event_types to find this."),
 };
 
 export async function deleteEventType(params: { eventTypeId: number }) {
@@ -307,21 +482,19 @@ export async function deleteEventType(params: { eventTypeId: number }) {
   }
 }
 
-export const getRoundRobinConfigSchema = {
+export const getSchedulingConfigSchema = {
   eventTypeId: z
     .number()
     .int()
     .positive()
-    .describe(
-      "Event type ID. Must be a team event type with round-robin scheduling. Use get_event_types to find this."
-    ),
+    .describe("Event type ID. Must be a team event type. Use get_event_types to find this."),
 };
 
-export async function getRoundRobinConfig(params: { eventTypeId: number }) {
+export async function getSchedulingConfig(params: { eventTypeId: number }) {
   try {
-    const data = await calApi(`event-types/${params.eventTypeId}/round-robin`);
+    const data = await calApi(`event-types/${params.eventTypeId}/scheduling-config`);
     return ok(data);
   } catch (err) {
-    return handleError("get_round_robin_config", err);
+    return handleError("get_scheduling_config", err);
   }
 }

--- a/apps/mcp-server/src/tools/event-types.ts
+++ b/apps/mcp-server/src/tools/event-types.ts
@@ -306,3 +306,21 @@ export async function deleteEventType(params: { eventTypeId: number }) {
     return handleError("delete_event_type", err);
   }
 }
+
+export const getRoundRobinConfigSchema = {
+  eventTypeId: z
+    .number()
+    .int()
+    .describe(
+      "Event type ID. Must be a team event type with round-robin scheduling. Use get_event_types to find this."
+    ),
+};
+
+export async function getRoundRobinConfig(params: { eventTypeId: number }) {
+  try {
+    const data = await calApi(`event-types/${params.eventTypeId}/round-robin`);
+    return ok(data);
+  } catch (err) {
+    return handleError("get_round_robin_config", err);
+  }
+}


### PR DESCRIPTION
## Summary

Renames `get_round_robin_config` → `get_scheduling_config` to match the renamed API endpoint (`/scheduling-config`). The tool now covers all three scheduling types:

- **roundRobin**: full config (hosts with priority/weight/groupId, hostGroups, advanced settings)
- **collective/managed**: minimal shape (hosts with basic info, assignAllTeamMembers)

Depends on calcom/cal#3311 (API endpoint) being merged first.

Changes:
- `getSchedulingConfigSchema` / `getSchedulingConfig` in `tools/event-types.ts`
- Updated registration in `register-tools.ts` (tool name + description)
- Updated `server-instructions.ts` capability line
- Updated README tool table
- Updated tests to use new function name and API path (`/scheduling-config`)

Link to Devin session: https://app.devin.ai/sessions/c747f1c3c1354caa82756ac583b5de75
Requested by: @anikdhabal