### PR TITLE
fix(mobile): open booking notifications on detail

### DIFF
--- a/apps/mobile/app/(tabs)/(bookings)/booking-detail.ios.tsx
+++ b/apps/mobile/app/(tabs)/(bookings)/booking-detail.ios.tsx
@@ -1,6 +1,6 @@
 import * as Clipboard from "expo-clipboard";
 import { isLiquidGlassAvailable } from "expo-glass-effect";
-import { Stack, useLocalSearchParams } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useMemo, useRef } from "react";
 import { useColorScheme } from "react-native";
 import { BookingDetailScreen } from "@/components/screens/BookingDetailScreen";
@@ -44,9 +44,11 @@ const getMonthName = (dateString: string | undefined): string => {
 };
 
 export default function BookingDetailIOS() {
-  const { uid } = useLocalSearchParams<{ uid: string }>();
+  const { uid, source } = useLocalSearchParams<{ uid: string; source?: string }>();
   const { userInfo } = useAuth();
+  const router = useRouter();
   const colorScheme = useColorScheme();
+  const openedFromNotification = source === "notification";
 
   // Use React Query hook for booking data - single source of truth
   const { data: booking, isLoading, error, refetch, isRefetching } = useBookingByUid(uid);
@@ -81,6 +83,7 @@ export default function BookingDetailIOS() {
     const startTime = enrichedBooking?.start || enrichedBooking?.startTime;
     return getMonthName(startTime);
   }, [enrichedBooking?.start, enrichedBooking?.startTime]);
+  const backTitle = openedFromNotification ? "Bookings" : monthName;
 
   // Get meeting URL for Join button
   const meetingUrl = useMemo(() => getMeetingUrl(enrichedBooking ?? null), [enrichedBooking]);
@@ -91,6 +94,10 @@ export default function BookingDetailIOS() {
       openInDefaultBrowser(meetingUrl, "meeting link");
     }
   }, [meetingUrl]);
+
+  const handleBackToBookings = useCallback(() => {
+    router.replace("/(tabs)/(bookings)");
+  }, [router]);
 
   // Handle copy meeting link
   const handleCopyMeetingLink = useCallback(async () => {
@@ -224,7 +231,7 @@ export default function BookingDetailIOS() {
       <Stack.Screen
         options={{
           title: "Booking", // This appears in long-press navigation history
-          headerBackTitle: monthName, // This shows on the back button
+          headerBackTitle: backTitle, // This shows on the back button
           headerBackButtonDisplayMode: "default",
           headerTitle: "", // Hide the title in the header bar itself
           headerShadowVisible: false,
@@ -236,6 +243,20 @@ export default function BookingDetailIOS() {
         style={{ backgroundColor: "transparent", shadowColor: "transparent" }}
         blurEffect={isLiquidGlassAvailable() ? undefined : "light"}
       >
+        {openedFromNotification ? (
+          <Stack.Header.Left>
+            <Stack.Header.Button
+              accessibilityLabel="Back to bookings"
+              onPress={handleBackToBookings}
+              tintColor={colorScheme === "dark" ? "#FFF" : "#000"}
+            >
+              <Stack.Header.Icon sf="chevron.backward" />
+            </Stack.Header.Button>
+          </Stack.Header.Left>
+        ) : (
+          <Stack.Header.BackButton displayMode="default">{backTitle}</Stack.Header.BackButton>
+        )}
+
         <Stack.Header.Right>
           {/* Actions Menu */}
           <Stack.Header.Menu>

--- a/apps/mobile/components/PushNotificationProvider.tsx
+++ b/apps/mobile/components/PushNotificationProvider.tsx
@@ -111,7 +111,12 @@ function handleNotificationUrl(url: string, router: ReturnType<typeof useRouter>
     const parsed = Linking.parse(url);
     const uid = typeof parsed.queryParams?.uid === "string" ? parsed.queryParams.uid : null;
     if (uid) {
-      router.push(`/(tabs)/(bookings)/booking-detail?uid=${encodeURIComponent(uid)}`);
+      router.push(
+        `/(tabs)/(bookings)/booking-detail?uid=${encodeURIComponent(uid)}&source=notification`,
+        {
+          withAnchor: true,
+        }
+      );
     }
   } catch {
     // Malformed deep link — ignore.


### PR DESCRIPTION
## Stack
1. This PR: open booking request notifications on booking detail and provide a reliable back path.
2. Follow-up PR: add confirm/reject actions to the booking detail screen.
3. Follow-up PR: sync the bookings list after a detail action.

## Summary
- Route booking request notification taps to the normal booking detail page.
- Mark notification-opened detail routes with `source=notification`.
- Show an iOS header chevron that returns to the Bookings tab when the route has no native stack history.

## Testing
- `bun --filter mobile typecheck`
- `git diff --check`
