### PR TITLE
feat(mobile): add booking detail request actions

### DIFF
--- a/apps/mobile/components/screens/BookingDetailRequestActions.state.ts
+++ b/apps/mobile/components/screens/BookingDetailRequestActions.state.ts
@@ -1,0 +1,67 @@
+import type { Booking } from "@/services/types/bookings.types";
+import { getBookingPaymentStatus } from "@/utils/booking-payment-status";
+
+type CanRespondToBookingRequestParams = {
+  booking: Booking;
+  currentUserId?: number;
+  currentUserEmail?: string;
+  now?: Date;
+};
+
+type BookingRequestActionState = {
+  canConfirm: boolean;
+  canReject: boolean;
+};
+
+const getBookingStatus = (booking: Booking): string => booking.status?.toLowerCase() || "";
+
+const getBookingEndTime = (booking: Booking): string => booking.endTime || booking.end || "";
+
+const isBookingPending = (booking: Booking): boolean => getBookingStatus(booking) === "pending";
+
+const isBookingInPast = (booking: Booking, now: Date): boolean => {
+  const endTime = new Date(getBookingEndTime(booking));
+  return !Number.isNaN(endTime.getTime()) && endTime < now;
+};
+
+const isUserOrganizer = (booking: Booking, userId?: number, userEmail?: string): boolean => {
+  if (!booking.user) return false;
+
+  if (userId && booking.user.id === userId) return true;
+  if (userEmail && booking.user.email?.toLowerCase() === userEmail.toLowerCase()) return true;
+
+  return false;
+};
+
+const isUserHost = (booking: Booking, userId?: number, userEmail?: string): boolean => {
+  if (!booking.hosts || booking.hosts.length === 0) return false;
+
+  return booking.hosts.some((host) => {
+    if (userId && host.id !== undefined && String(host.id) === String(userId)) return true;
+    if (userEmail && host.email?.toLowerCase() === userEmail.toLowerCase()) return true;
+    return false;
+  });
+};
+
+export function getBookingRequestActionState({
+  booking,
+  currentUserId,
+  currentUserEmail,
+  now = new Date(),
+}: CanRespondToBookingRequestParams): BookingRequestActionState {
+  const isPending = isBookingPending(booking);
+  const isPast = isBookingInPast(booking, now);
+  const { isPendingPayment } = getBookingPaymentStatus(booking);
+  const isOrganizer = isUserOrganizer(booking, currentUserId, currentUserEmail);
+  const isHost = isUserHost(booking, currentUserId, currentUserEmail);
+  const canReject = isPending && !isPast && (isOrganizer || isHost);
+
+  return {
+    canConfirm: canReject && !isPendingPayment,
+    canReject,
+  };
+}
+
+export function canRespondToBookingRequest(params: CanRespondToBookingRequestParams): boolean {
+  return getBookingRequestActionState(params).canReject;
+}

--- a/apps/mobile/components/screens/BookingDetailRequestActions.test.js
+++ b/apps/mobile/components/screens/BookingDetailRequestActions.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { getBookingRequestActionState } from "./BookingDetailRequestActions.state";
+
+const now = new Date("2026-06-11T00:00:00.000Z");
+
+function createBooking(overrides = {}) {
+  return {
+    id: 1,
+    uid: "booking-1",
+    title: "Demo booking",
+    status: "pending",
+    startTime: "2026-06-12T10:00:00.000Z",
+    endTime: "2026-06-12T10:30:00.000Z",
+    user: {
+      id: 42,
+      email: "organizer@example.com",
+      name: "Organizer",
+      timeZone: "UTC",
+    },
+    ...overrides,
+  };
+}
+
+describe("getBookingRequestActionState", () => {
+  test("allows confirming paid booking requests with a successful on-booking payment row", () => {
+    const booking = createBooking({
+      payment: [
+        {
+          id: 1,
+          success: true,
+          paymentOption: "ON_BOOKING",
+          refunded: false,
+        },
+      ],
+    });
+
+    expect(
+      getBookingRequestActionState({
+        booking,
+        currentUserId: 42,
+        currentUserEmail: "organizer@example.com",
+        now,
+      })
+    ).toEqual({
+      canConfirm: true,
+      canReject: true,
+    });
+  });
+
+  test("keeps confirm hidden while an on-booking payment is pending", () => {
+    const booking = createBooking({
+      payment: [
+        {
+          id: 1,
+          success: false,
+          paymentOption: "ON_BOOKING",
+          refunded: false,
+        },
+      ],
+    });
+
+    expect(
+      getBookingRequestActionState({
+        booking,
+        currentUserId: 42,
+        currentUserEmail: "organizer@example.com",
+        now,
+      })
+    ).toEqual({
+      canConfirm: false,
+      canReject: true,
+    });
+  });
+});

--- a/apps/mobile/components/screens/BookingDetailRequestActions.tsx
+++ b/apps/mobile/components/screens/BookingDetailRequestActions.tsx
@@ -1,0 +1,166 @@
+import { Ionicons } from "@expo/vector-icons";
+import { ActivityIndicator, Text, useColorScheme, View } from "react-native";
+import { AppPressable } from "@/components/AppPressable";
+import type { Booking } from "@/services/calcom";
+import {
+  isBookingInPast,
+  isBookingPending,
+  isUserHost,
+  isUserOrganizer,
+  normalizeBooking,
+} from "@/utils/booking-actions";
+import { getBookingPaymentStatus } from "@/utils/booking-payment-status";
+
+type RequestActionColors = {
+  cardBackground: string;
+  text: string;
+  textSecondary: string;
+  border: string;
+  destructive: string;
+};
+
+type CanRespondToBookingRequestParams = {
+  booking: Booking;
+  currentUserId?: number;
+  currentUserEmail?: string;
+  now?: Date;
+};
+
+type BookingRequestActionState = {
+  canConfirm: boolean;
+  canReject: boolean;
+};
+
+export function getBookingRequestActionState({
+  booking,
+  currentUserId,
+  currentUserEmail,
+  now = new Date(),
+}: CanRespondToBookingRequestParams): BookingRequestActionState {
+  const normalizedBooking = normalizeBooking(booking);
+  const isPending = isBookingPending(normalizedBooking);
+  const isPast = isBookingInPast(normalizedBooking, now);
+  const { isPendingPayment } = getBookingPaymentStatus(booking);
+  const isOrganizer = isUserOrganizer(normalizedBooking, currentUserId, currentUserEmail);
+  const isHost = isUserHost(normalizedBooking, currentUserId, currentUserEmail);
+  const hasUnpaidPayment =
+    booking.paid !== true && ((booking.payment?.length ?? 0) > 0 || isPendingPayment);
+  const canReject = isPending && !isPast && (isOrganizer || isHost);
+
+  return {
+    canConfirm: canReject && !hasUnpaidPayment,
+    canReject,
+  };
+}
+
+export function canRespondToBookingRequest(params: CanRespondToBookingRequestParams): boolean {
+  return getBookingRequestActionState(params).canReject;
+}
+
+type BookingDetailRequestActionsProps = {
+  booking: Booking;
+  currentUserId?: number;
+  currentUserEmail?: string;
+  isConfirming: boolean;
+  isDeclining: boolean;
+  onConfirm: () => void;
+  onReject: () => void;
+  colors: RequestActionColors;
+};
+
+export function BookingDetailRequestActions({
+  booking,
+  currentUserId,
+  currentUserEmail,
+  isConfirming,
+  isDeclining,
+  onConfirm,
+  onReject,
+  colors,
+}: BookingDetailRequestActionsProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+  const { canConfirm, canReject } = getBookingRequestActionState({
+    booking,
+    currentUserId,
+    currentUserEmail,
+  });
+
+  if (!canReject) return null;
+
+  const isProcessing = isConfirming || isDeclining;
+  const primaryBackground = isDark ? "#FFFFFF" : "#111827";
+  const primaryText = isDark ? "#000000" : "#FFFFFF";
+  const iconBackground = isDark ? "#262626" : "#F2F2F7";
+  const helperText = canConfirm
+    ? "Confirm or reject this request."
+    : "Payment is still pending. You can reject this request.";
+
+  return (
+    <View
+      className="mb-4 overflow-hidden rounded-xl border"
+      style={{ backgroundColor: colors.cardBackground, borderColor: colors.border }}
+    >
+      <View className="gap-4 p-4">
+        <View className="flex-row gap-3">
+          <View
+            className="h-9 w-9 items-center justify-center rounded-full"
+            style={{ backgroundColor: iconBackground }}
+          >
+            <Ionicons name="time-outline" size={18} color={colors.text} />
+          </View>
+          <View className="flex-1">
+            <Text className="text-[17px] font-semibold" style={{ color: colors.text }}>
+              Booking request
+            </Text>
+            <Text className="mt-1 text-[14px] leading-5" style={{ color: colors.textSecondary }}>
+              {helperText}
+            </Text>
+          </View>
+        </View>
+
+        <View className="flex-row gap-2">
+          <AppPressable
+            className="h-11 flex-1 flex-row items-center justify-center rounded-lg border"
+            style={{
+              borderColor: colors.border,
+              opacity: isProcessing ? 0.6 : 1,
+            }}
+            disabled={isProcessing}
+            onPress={onReject}
+          >
+            {isDeclining ? (
+              <ActivityIndicator size="small" color={colors.destructive} />
+            ) : (
+              <Ionicons name="close" size={17} color={colors.destructive} />
+            )}
+            <Text className="ml-1.5 text-[15px] font-semibold" style={{ color: colors.text }}>
+              Reject
+            </Text>
+          </AppPressable>
+
+          {canConfirm ? (
+            <AppPressable
+              className="h-11 flex-1 flex-row items-center justify-center rounded-lg"
+              style={{
+                backgroundColor: primaryBackground,
+                opacity: isProcessing ? 0.6 : 1,
+              }}
+              disabled={isProcessing}
+              onPress={onConfirm}
+            >
+              {isConfirming ? (
+                <ActivityIndicator size="small" color={primaryText} />
+              ) : (
+                <Ionicons name="checkmark" size={17} color={primaryText} />
+              )}
+              <Text className="ml-1.5 text-[15px] font-semibold" style={{ color: primaryText }}>
+                Confirm
+              </Text>
+            </AppPressable>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/components/screens/BookingDetailRequestActions.tsx
+++ b/apps/mobile/components/screens/BookingDetailRequestActions.tsx
@@ -1,15 +1,13 @@
 import { Ionicons } from "@expo/vector-icons";
 import { ActivityIndicator, Text, useColorScheme, View } from "react-native";
 import { AppPressable } from "@/components/AppPressable";
+import { getBookingRequestActionState } from "@/components/screens/BookingDetailRequestActions.state";
 import type { Booking } from "@/services/calcom";
-import {
-  isBookingInPast,
-  isBookingPending,
-  isUserHost,
-  isUserOrganizer,
-  normalizeBooking,
-} from "@/utils/booking-actions";
-import { getBookingPaymentStatus } from "@/utils/booking-payment-status";
+
+export {
+  canRespondToBookingRequest,
+  getBookingRequestActionState,
+} from "@/components/screens/BookingDetailRequestActions.state";
 
 type RequestActionColors = {
   cardBackground: string;
@@ -18,44 +16,6 @@ type RequestActionColors = {
   border: string;
   destructive: string;
 };
-
-type CanRespondToBookingRequestParams = {
-  booking: Booking;
-  currentUserId?: number;
-  currentUserEmail?: string;
-  now?: Date;
-};
-
-type BookingRequestActionState = {
-  canConfirm: boolean;
-  canReject: boolean;
-};
-
-export function getBookingRequestActionState({
-  booking,
-  currentUserId,
-  currentUserEmail,
-  now = new Date(),
-}: CanRespondToBookingRequestParams): BookingRequestActionState {
-  const normalizedBooking = normalizeBooking(booking);
-  const isPending = isBookingPending(normalizedBooking);
-  const isPast = isBookingInPast(normalizedBooking, now);
-  const { isPendingPayment } = getBookingPaymentStatus(booking);
-  const isOrganizer = isUserOrganizer(normalizedBooking, currentUserId, currentUserEmail);
-  const isHost = isUserHost(normalizedBooking, currentUserId, currentUserEmail);
-  const hasUnpaidPayment =
-    booking.paid !== true && ((booking.payment?.length ?? 0) > 0 || isPendingPayment);
-  const canReject = isPending && !isPast && (isOrganizer || isHost);
-
-  return {
-    canConfirm: canReject && !hasUnpaidPayment,
-    canReject,
-  };
-}
-
-export function canRespondToBookingRequest(params: CanRespondToBookingRequestParams): boolean {
-  return getBookingRequestActionState(params).canReject;
-}
 
 type BookingDetailRequestActionsProps = {
   booking: Booking;

--- a/apps/mobile/components/screens/BookingDetailScreen.ios.tsx
+++ b/apps/mobile/components/screens/BookingDetailScreen.ios.tsx
@@ -13,7 +13,9 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AppPressable } from "@/components/AppPressable";
-import { useCancelBooking } from "@/hooks/useBookings";
+import { BookingDetailRequestActions } from "@/components/screens/BookingDetailRequestActions";
+import { useAuth } from "@/contexts/AuthContext";
+import { useCancelBooking, useConfirmBooking, useDeclineBooking } from "@/hooks/useBookings";
 import type { Booking } from "@/services/calcom";
 import { showErrorAlert, showSuccessAlert } from "@/utils/alerts";
 import { getBookingPaymentStatus } from "@/utils/booking-payment-status";
@@ -141,6 +143,7 @@ export function BookingDetailScreen({
   onActionsReady,
 }: BookingDetailScreenProps): React.JSX.Element {
   const router = useRouter();
+  const { userInfo } = useAuth();
   const insets = useSafeAreaInsets();
   const colorScheme = useColorScheme();
   const isDark = colorScheme === "dark";
@@ -160,7 +163,11 @@ export function BookingDetailScreen({
 
   // Cancel booking mutation
   const cancelBookingMutation = useCancelBooking();
+  const confirmBookingMutation = useConfirmBooking();
+  const declineBookingMutation = useDeclineBooking();
   const isCancelling = cancelBookingMutation.isPending;
+  const isConfirming = confirmBookingMutation.isPending;
+  const isDeclining = declineBookingMutation.isPending;
 
   const performCancelBooking = useCallback(
     (reason: string) => {
@@ -223,6 +230,73 @@ export function BookingDetailScreen({
       },
     ]);
   }, [booking, performCancelBooking]);
+
+  const handleConfirmBooking = useCallback(() => {
+    if (!booking || isConfirming || isDeclining) return;
+
+    confirmBookingMutation.mutate(
+      { uid: booking.uid },
+      {
+        onSuccess: () => {
+          showSuccessAlert("Success", "Booking confirmed successfully");
+        },
+        onError: (err) => {
+          console.error("Failed to confirm booking");
+          if (__DEV__) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.debug("[BookingDetailScreen.ios] confirmBooking failed", { message });
+          }
+          showErrorAlert("Error", "Failed to confirm booking. Please try again.");
+        },
+      }
+    );
+  }, [booking, confirmBookingMutation, isConfirming, isDeclining]);
+
+  const performRejectBooking = useCallback(
+    (reason?: string) => {
+      if (!booking || isDeclining) return;
+
+      declineBookingMutation.mutate(
+        { uid: booking.uid, reason },
+        {
+          onSuccess: () => {
+            showSuccessAlert("Success", "Booking rejected successfully");
+          },
+          onError: (err) => {
+            console.error("Failed to reject booking");
+            if (__DEV__) {
+              const message = err instanceof Error ? err.message : String(err);
+              console.debug("[BookingDetailScreen.ios] rejectBooking failed", { message });
+            }
+            showErrorAlert("Error", "Failed to reject booking. Please try again.");
+          },
+        }
+      );
+    },
+    [booking, declineBookingMutation, isDeclining]
+  );
+
+  const handleRejectBooking = useCallback(() => {
+    if (!booking || isConfirming || isDeclining) return;
+
+    Alert.prompt(
+      "Reject Booking",
+      "Add an optional reason for rejecting this booking request:",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Reject Booking",
+          style: "destructive",
+          onPress: (reason?: string) => {
+            performRejectBooking(reason?.trim() || undefined);
+          },
+        },
+      ],
+      "plain-text",
+      "",
+      "default"
+    );
+  }, [booking, isConfirming, isDeclining, performRejectBooking]);
 
   const openRescheduleModal = useCallback(() => {
     if (!booking) return;
@@ -460,7 +534,7 @@ export function BookingDetailScreen({
           )}
 
           {/* Payment and Confirmation Status Badges */}
-          {(isPendingPayment || isUnconfirmed) ? (
+          {isPendingPayment || isUnconfirmed ? (
             <View className="mt-3 flex-row flex-wrap items-center">
               {isPendingPayment ? (
                 <View className="mb-1 mr-2 rounded bg-cal-accent-warning px-2 py-0.5">
@@ -475,6 +549,23 @@ export function BookingDetailScreen({
             </View>
           ) : null}
         </View>
+
+        <BookingDetailRequestActions
+          booking={booking}
+          currentUserId={userInfo?.id}
+          currentUserEmail={userInfo?.email}
+          isConfirming={isConfirming}
+          isDeclining={isDeclining}
+          onConfirm={handleConfirmBooking}
+          onReject={handleRejectBooking}
+          colors={{
+            cardBackground: colors.cardBackground,
+            text: colors.text,
+            textSecondary: colors.textSecondary,
+            border: colors.border,
+            destructive: colors.destructive,
+          }}
+        />
 
         {/* Participants Card - iOS Calendar Style (Expandable) */}
         <View

--- a/apps/mobile/components/screens/BookingDetailScreen.tsx
+++ b/apps/mobile/components/screens/BookingDetailScreen.tsx
@@ -20,6 +20,7 @@ import { AppPressable } from "@/components/AppPressable";
 import { BookingActionsModal } from "@/components/BookingActionsModal";
 import { FullScreenModal } from "@/components/FullScreenModal";
 import { HeaderButtonWrapper } from "@/components/HeaderButtonWrapper";
+import { BookingDetailRequestActions } from "@/components/screens/BookingDetailRequestActions";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -40,7 +41,7 @@ import {
 import { Text as UIText } from "@/components/ui/text";
 import { getColors } from "@/constants/colors";
 import { useAuth } from "@/contexts/AuthContext";
-import { useCancelBooking } from "@/hooks/useBookings";
+import { useCancelBooking, useConfirmBooking, useDeclineBooking } from "@/hooks/useBookings";
 import type { Booking } from "@/services/calcom";
 import { showErrorAlert, showInfoAlert, showSuccessAlert } from "@/utils/alerts";
 import { getMeetingUrl } from "@/utils/booking";
@@ -196,12 +197,18 @@ export function BookingDetailScreen({
 
   const [showActionsModal, setShowActionsModal] = useState(false);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [showRejectDialog, setShowRejectDialog] = useState(false);
   const [cancellationReason, setCancellationReason] = useState("");
+  const [rejectReason, setRejectReason] = useState("");
   const [participantsExpanded, setParticipantsExpanded] = useState(true);
 
   // Cancel booking mutation
   const cancelBookingMutation = useCancelBooking();
+  const confirmBookingMutation = useConfirmBooking();
+  const declineBookingMutation = useDeclineBooking();
   const isCancelling = cancelBookingMutation.isPending;
+  const isConfirming = confirmBookingMutation.isPending;
+  const isDeclining = declineBookingMutation.isPending;
 
   const contentInsets = {
     top: insets.top,
@@ -299,6 +306,91 @@ export function BookingDetailScreen({
     setShowCancelDialog(false);
     setCancellationReason("");
   }, []);
+
+  const handleConfirmBooking = useCallback(() => {
+    if (!booking || isConfirming || isDeclining) return;
+
+    confirmBookingMutation.mutate(
+      { uid: booking.uid },
+      {
+        onSuccess: () => {
+          showSuccessAlert("Success", "Booking confirmed successfully");
+        },
+        onError: (err) => {
+          console.error("Failed to confirm booking");
+          if (__DEV__) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.debug("[BookingDetailScreen] confirmBooking failed", { message });
+          }
+          showErrorAlert("Error", "Failed to confirm booking. Please try again.");
+        },
+      }
+    );
+  }, [booking, confirmBookingMutation, isConfirming, isDeclining]);
+
+  const performRejectBooking = useCallback(
+    (reason?: string) => {
+      if (!booking || isDeclining) return;
+
+      declineBookingMutation.mutate(
+        { uid: booking.uid, reason },
+        {
+          onSuccess: () => {
+            setShowRejectDialog(false);
+            setRejectReason("");
+            showSuccessAlert("Success", "Booking rejected successfully");
+          },
+          onError: (err) => {
+            console.error("Failed to reject booking");
+            if (__DEV__) {
+              const message = err instanceof Error ? err.message : String(err);
+              console.debug("[BookingDetailScreen] rejectBooking failed", { message });
+            }
+            showErrorAlert("Error", "Failed to reject booking. Please try again.");
+          },
+        }
+      );
+    },
+    [booking, declineBookingMutation, isDeclining]
+  );
+
+  const handleRejectBooking = useCallback(() => {
+    if (!booking || isConfirming || isDeclining) return;
+
+    if (Platform.OS === "android" || Platform.OS === "web") {
+      setRejectReason("");
+      setShowRejectDialog(true);
+      return;
+    }
+
+    Alert.prompt(
+      "Reject Booking",
+      "Add an optional reason for rejecting this booking request:",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Reject Booking",
+          style: "destructive",
+          onPress: (reason?: string) => {
+            performRejectBooking(reason?.trim() || undefined);
+          },
+        },
+      ],
+      "plain-text",
+      "",
+      "default"
+    );
+  }, [booking, isConfirming, isDeclining, performRejectBooking]);
+
+  const handleConfirmReject = useCallback(() => {
+    performRejectBooking(rejectReason.trim() || undefined);
+  }, [performRejectBooking, rejectReason]);
+
+  const handleCloseRejectDialog = useCallback(() => {
+    if (isDeclining) return;
+    setShowRejectDialog(false);
+    setRejectReason("");
+  }, [isDeclining]);
 
   const handleReportBooking = useCallback(() => {
     showInfoAlert("Report Booking", "Report booking functionality is not yet available");
@@ -710,7 +802,7 @@ export function BookingDetailScreen({
             ) : null}
 
             {/* Payment and Confirmation Status Badges */}
-            {(isPendingPayment || isUnconfirmed) ? (
+            {isPendingPayment || isUnconfirmed ? (
               <View className="mt-3 flex-row flex-wrap items-center">
                 {isPendingPayment ? (
                   <View className="mb-1 mr-2 rounded bg-cal-accent-warning px-2 py-0.5">
@@ -725,6 +817,23 @@ export function BookingDetailScreen({
               </View>
             ) : null}
           </View>
+
+          <BookingDetailRequestActions
+            booking={booking}
+            currentUserId={userInfo?.id}
+            currentUserEmail={userInfo?.email}
+            isConfirming={isConfirming}
+            isDeclining={isDeclining}
+            onConfirm={handleConfirmBooking}
+            onReject={handleRejectBooking}
+            colors={{
+              cardBackground,
+              text: theme.text,
+              textSecondary: theme.textSecondary,
+              border: theme.border,
+              destructive: theme.destructive,
+            }}
+          />
 
           {/* Participants Card - iOS Calendar Style (Expandable) */}
           <View
@@ -1140,7 +1249,9 @@ export function BookingDetailScreen({
 
                   {/* Title and description */}
                   <View className="flex-1">
-                    <Text className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">Cancel Event</Text>
+                    <Text className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
+                      Cancel Event
+                    </Text>
                     <Text className="text-sm leading-5 text-gray-600 dark:text-[#A3A3A3]">
                       Are you sure you want to cancel "{booking?.title}"? Cancellation reason will
                       be shared with guests.
@@ -1174,14 +1285,92 @@ export function BookingDetailScreen({
                   style={{ backgroundColor: isDark ? "#FFFFFF" : "#111827" }}
                   onPress={handleConfirmCancel}
                 >
-                  <Text className="text-center text-base font-medium text-white dark:text-black">Cancel Event</Text>
+                  <Text className="text-center text-base font-medium text-white dark:text-black">
+                    Cancel Event
+                  </Text>
                 </TouchableOpacity>
 
                 <TouchableOpacity
                   className="rounded-lg border border-gray-300 bg-white px-4 py-2.5 dark:border-[#4D4D4D] dark:bg-[#262626]"
                   onPress={handleCloseCancelDialog}
                 >
-                  <Text className="text-center text-base font-medium text-gray-700 dark:text-white">Nevermind</Text>
+                  <Text className="text-center text-base font-medium text-gray-700 dark:text-white">
+                    Nevermind
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+        </FullScreenModal>
+      )}
+
+      {/* Web/Extension: Reject Booking Request Modal */}
+      {Platform.OS === "web" && (
+        <FullScreenModal
+          visible={showRejectDialog}
+          animationType="fade"
+          onRequestClose={handleCloseRejectDialog}
+        >
+          <View className="flex-1 items-center justify-center bg-black/50 p-4">
+            <View className="w-full max-w-md rounded-2xl bg-white shadow-2xl dark:bg-[#171717]">
+              <View className="p-6">
+                <View className="flex-row">
+                  <View className="mr-3 self-start rounded-full bg-red-50 p-2 dark:bg-red-900/30">
+                    <Ionicons name="close-circle" size={20} color={theme.destructive} />
+                  </View>
+
+                  <View className="flex-1">
+                    <Text className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
+                      Reject Booking Request
+                    </Text>
+                    <Text className="text-sm leading-5 text-gray-600 dark:text-[#A3A3A3]">
+                      The request will be declined. You can share a reason with the attendee.
+                    </Text>
+
+                    <View className="mt-4">
+                      <Text className="mb-2 text-sm font-medium text-gray-700 dark:text-[#A3A3A3]">
+                        Reason for rejection
+                      </Text>
+                      <TextInput
+                        className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-base text-gray-900 dark:border-[#4D4D4D] dark:bg-[#262626] dark:text-white"
+                        placeholder="Why are you rejecting?"
+                        placeholderTextColor={isDark ? "#636366" : "#9CA3AF"}
+                        value={rejectReason}
+                        onChangeText={setRejectReason}
+                        editable={!isDeclining}
+                        multiline
+                        numberOfLines={3}
+                        textAlignVertical="top"
+                        style={{ minHeight: 80 }}
+                      />
+                    </View>
+                  </View>
+                </View>
+              </View>
+
+              <View className="flex-row-reverse gap-2 px-6 pb-6 pt-2">
+                <TouchableOpacity
+                  className="rounded-lg px-4 py-2.5"
+                  style={{
+                    backgroundColor: theme.destructive,
+                    opacity: isDeclining ? 0.6 : 1,
+                  }}
+                  disabled={isDeclining}
+                  onPress={handleConfirmReject}
+                >
+                  <Text className="text-center text-base font-medium text-white">
+                    {isDeclining ? "Rejecting..." : "Reject Request"}
+                  </Text>
+                </TouchableOpacity>
+
+                <TouchableOpacity
+                  className="rounded-lg border border-gray-300 bg-white px-4 py-2.5 dark:border-[#4D4D4D] dark:bg-[#262626]"
+                  disabled={isDeclining}
+                  onPress={handleCloseRejectDialog}
+                >
+                  <Text className="text-center text-base font-medium text-gray-700 dark:text-white">
+                    Nevermind
+                  </Text>
                 </TouchableOpacity>
               </View>
             </View>
@@ -1226,6 +1415,65 @@ export function BookingDetailScreen({
               </AlertDialogCancel>
               <AlertDialogAction onPress={handleConfirmCancel}>
                 <UIText className="text-white">Cancel event</UIText>
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+
+      {/* Reject Booking Request AlertDialog (Android only) */}
+      {Platform.OS === "android" && (
+        <AlertDialog
+          open={showRejectDialog}
+          onOpenChange={(open) => {
+            if (open) {
+              setShowRejectDialog(true);
+              return;
+            }
+            handleCloseRejectDialog();
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader className="items-start">
+              <AlertDialogTitle>
+                <UIText className="text-left text-lg font-semibold">Reject booking request</UIText>
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                <UIText className="text-left text-sm text-muted-foreground">
+                  Rejection reason will be shared with the attendee
+                </UIText>
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+
+            <View>
+              <UIText className="mb-2 text-sm font-medium">Reason for rejection</UIText>
+              <TextInput
+                className="rounded-md border border-[#D1D5DB] bg-white px-3 py-2.5 text-base text-[#111827] dark:border-[#4D4D4D] dark:bg-[#262626] dark:text-white"
+                placeholder="Why are you rejecting?"
+                placeholderTextColor={isDark ? "#636366" : "#9CA3AF"}
+                value={rejectReason}
+                onChangeText={setRejectReason}
+                editable={!isDeclining}
+                autoFocus
+                multiline
+                numberOfLines={3}
+                textAlignVertical="top"
+                style={{ minHeight: 80 }}
+              />
+            </View>
+
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeclining} onPress={handleCloseRejectDialog}>
+                <UIText>Nevermind</UIText>
+              </AlertDialogCancel>
+              <AlertDialogAction
+                disabled={isDeclining}
+                onPress={handleConfirmReject}
+                className="bg-destructive"
+              >
+                <UIText className="text-white">
+                  {isDeclining ? "Rejecting..." : "Reject request"}
+                </UIText>
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>


### PR DESCRIPTION
## Stack
1. #113 opens booking request notifications on the booking detail screen.
2. This PR adds detail-screen confirm/reject actions.
3. Follow-up PR syncs the bookings list after a detail action.

## Summary
- Add a booking request action card to booking detail screens.
- Show Reject and Confirm controls for pending booking requests when the current user is the organizer or host.
- Keep Confirm hidden for unpaid pending-payment bookings while still allowing Reject.
- Add iOS prompt and Android/web dialog flows for optional rejection reasons.

## Testing
- `bun --filter mobile typecheck`
- `bun run lint:react-compiler`
- `git diff --check`
