### PR TITLE
fix(mobile): sync bookings list after request action

### DIFF
--- a/apps/mobile/app/(tabs)/(bookings)/booking-detail.ios.tsx
+++ b/apps/mobile/app/(tabs)/(bookings)/booking-detail.ios.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import * as Clipboard from "expo-clipboard";
 import { isLiquidGlassAvailable } from "expo-glass-effect";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
@@ -10,6 +11,7 @@ import { useBookingByUid } from "@/hooks/useBookings";
 import { showErrorAlert, showInfoAlert, showSuccessAlert } from "@/utils/alerts";
 import { getMeetingUrl } from "@/utils/booking";
 import { type BookingActionsResult, getBookingActions } from "@/utils/booking-actions";
+import { getBookingForCacheUpdate, updateBookingCaches } from "@/utils/booking-cache";
 import { openInDefaultBrowser } from "@/utils/browser";
 
 // Empty actions result for when no booking is loaded
@@ -47,6 +49,7 @@ export default function BookingDetailIOS() {
   const { uid, source } = useLocalSearchParams<{ uid: string; source?: string }>();
   const { userInfo } = useAuth();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const colorScheme = useColorScheme();
   const openedFromNotification = source === "notification";
 
@@ -96,8 +99,15 @@ export default function BookingDetailIOS() {
   }, [meetingUrl]);
 
   const handleBackToBookings = useCallback(() => {
-    router.replace("/(tabs)/(bookings)");
-  }, [router]);
+    const bookingForCacheUpdate = getBookingForCacheUpdate(queryClient, uid, enrichedBooking);
+    if (bookingForCacheUpdate) {
+      updateBookingCaches(queryClient, bookingForCacheUpdate);
+    }
+    router.replace({
+      pathname: "/(tabs)/(bookings)",
+      params: { sync: Date.now().toString() },
+    });
+  }, [enrichedBooking, queryClient, router, uid]);
 
   // Handle copy meeting link
   const handleCopyMeetingLink = useCallback(async () => {

--- a/apps/mobile/app/(tabs)/(bookings)/index.ios.tsx
+++ b/apps/mobile/app/(tabs)/(bookings)/index.ios.tsx
@@ -21,7 +21,7 @@ function isValidBookingFilter(value: string | undefined): value is BookingFilter
 }
 
 export default function Bookings() {
-  const { filter } = useLocalSearchParams<{ filter?: string }>();
+  const { filter, sync } = useLocalSearchParams<{ filter?: string; sync?: string }>();
   const initialFilter = isValidBookingFilter(filter) ? filter : "upcoming";
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -211,6 +211,7 @@ export default function Bookings() {
         selectedEventTypeId={selectedEventTypeId}
         activeFilter={activeFilter}
         filterParams={filterParams}
+        syncKey={sync}
         iosStyle={true}
       />
     </>

--- a/apps/mobile/app/(tabs)/(bookings)/index.tsx
+++ b/apps/mobile/app/(tabs)/(bookings)/index.tsx
@@ -28,7 +28,7 @@ function isValidBookingFilter(value: string | undefined): value is BookingFilter
 }
 
 export default function Bookings() {
-  const { filter } = useLocalSearchParams<{ filter?: string }>();
+  const { filter, sync } = useLocalSearchParams<{ filter?: string; sync?: string }>();
   const initialFilter = isValidBookingFilter(filter) ? filter : "upcoming";
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -226,6 +226,7 @@ export default function Bookings() {
       onEventTypeChange={handleEventTypeSelect}
       activeFilter={activeFilter}
       filterParams={filterParams}
+      syncKey={sync}
     />
   );
 }

--- a/apps/mobile/components/PushNotificationProvider.tsx
+++ b/apps/mobile/components/PushNotificationProvider.tsx
@@ -16,8 +16,9 @@ import {
   drainPendingDeregistrations,
   requestAndRegisterPushToken,
 } from "@/hooks/use-push-notifications";
-import { CalComAPIService } from "@/services/calcom";
+import { type Booking, CalComAPIService } from "@/services/calcom";
 import { showInfoAlert, showSuccessAlert } from "@/utils/alerts";
+import { updateBookingCaches } from "@/utils/booking-cache";
 
 // How long the pre-logout callback waits for an in-flight registration to
 // settle before deregistering, so a token that registered moments before
@@ -215,16 +216,17 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
         ]);
 
       try {
+        let updatedBooking: Booking;
         if (actionId === CONFIRM_BOOKING_REQUEST_ACTION_ID) {
-          await CalComAPIService.confirmBooking(bookingUid);
+          updatedBooking = await CalComAPIService.confirmBooking(bookingUid);
           showSuccessAlert("Success", "Booking confirmed successfully");
         } else if (actionId === DECLINE_BOOKING_REQUEST_ACTION_ID) {
-          await CalComAPIService.declineBooking(bookingUid);
+          updatedBooking = await CalComAPIService.declineBooking(bookingUid);
           showSuccessAlert("Success", "Booking declined successfully");
         } else {
           return;
         }
-        await refresh();
+        updateBookingCaches(queryClientRef.current, updatedBooking);
       } catch (error) {
         // Includes the non-idempotent "Booking already confirmed" case — show
         // it as feedback rather than retrying, then refresh so the UI reflects

--- a/apps/mobile/components/booking-list-screen/BookingListScreen.tsx
+++ b/apps/mobile/components/booking-list-screen/BookingListScreen.tsx
@@ -87,6 +87,9 @@ interface BookingListScreenProps {
   activeFilter: BookingFilter;
   filterParams: Record<string, unknown>;
 
+  // One-time background sync signal from routes that know list data may have moved
+  syncKey?: string;
+
   // iOS-style list (no wrapper)
   iosStyle?: boolean;
 }
@@ -103,6 +106,7 @@ export const BookingListScreen: React.FC<BookingListScreenProps> = ({
   onEventTypeChange,
   activeFilter,
   filterParams,
+  syncKey,
   iosStyle = false,
 }) => {
   const router = useRouter();
@@ -119,6 +123,14 @@ export const BookingListScreen: React.FC<BookingListScreenProps> = ({
     error: queryError,
     refetch,
   } = useBookings(filterParams);
+  const handledSyncKeyRef = React.useRef<string | undefined>(undefined);
+
+  React.useEffect(() => {
+    if (!syncKey || handledSyncKeyRef.current === syncKey) return;
+
+    handledSyncKeyRef.current = syncKey;
+    void refetch();
+  }, [refetch, syncKey]);
 
   // Cancel booking mutation
   const { mutate: cancelBookingMutation } = useCancelBooking();

--- a/apps/mobile/hooks/useBookings.ts
+++ b/apps/mobile/hooks/useBookings.ts
@@ -13,6 +13,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CACHE_CONFIG, queryKeys } from "@/config/cache.config";
 import { RatingTrigger, requestRating } from "@/hooks/useAppStoreRating";
 import { type Booking, CalComAPIService } from "@/services/calcom";
+import { updateBookingCaches } from "@/utils/booking-cache";
 
 /**
  * Filter options for fetching bookings
@@ -219,14 +220,8 @@ export function useConfirmBooking() {
   return useMutation({
     mutationFn: ({ uid }: { uid: string }) => CalComAPIService.confirmBooking(uid),
     retry: false,
-    onSuccess: (_, variables) => {
-      // Invalidate all booking queries to refetch fresh data
-      queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
-
-      // Also invalidate the specific booking detail
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.bookings.detail(variables.uid),
-      });
+    onSuccess: (updatedBooking) => {
+      updateBookingCaches(queryClient, updatedBooking);
 
       // Request app store rating on first booking confirmation
       requestRating(RatingTrigger.BOOKING_CONFIRMED);
@@ -256,14 +251,8 @@ export function useDeclineBooking() {
     mutationFn: ({ uid, reason }: { uid: string; reason?: string }) =>
       CalComAPIService.declineBooking(uid, reason),
     retry: false,
-    onSuccess: (_, variables) => {
-      // Invalidate all booking queries to refetch fresh data
-      queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
-
-      // Also invalidate the specific booking detail
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.bookings.detail(variables.uid),
-      });
+    onSuccess: (updatedBooking) => {
+      updateBookingCaches(queryClient, updatedBooking);
 
       // Request app store rating on first booking rejection
       requestRating(RatingTrigger.BOOKING_REJECTED);

--- a/apps/mobile/hooks/useBookings.ts
+++ b/apps/mobile/hooks/useBookings.ts
@@ -13,7 +13,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CACHE_CONFIG, queryKeys } from "@/config/cache.config";
 import { RatingTrigger, requestRating } from "@/hooks/useAppStoreRating";
 import { type Booking, CalComAPIService } from "@/services/calcom";
-import { updateBookingCaches } from "@/utils/booking-cache";
+import { syncBookingCachesAfterMutation } from "@/utils/booking-cache";
 
 /**
  * Filter options for fetching bookings
@@ -221,7 +221,7 @@ export function useConfirmBooking() {
     mutationFn: ({ uid }: { uid: string }) => CalComAPIService.confirmBooking(uid),
     retry: false,
     onSuccess: (updatedBooking) => {
-      updateBookingCaches(queryClient, updatedBooking);
+      syncBookingCachesAfterMutation(queryClient, updatedBooking);
 
       // Request app store rating on first booking confirmation
       requestRating(RatingTrigger.BOOKING_CONFIRMED);
@@ -252,7 +252,7 @@ export function useDeclineBooking() {
       CalComAPIService.declineBooking(uid, reason),
     retry: false,
     onSuccess: (updatedBooking) => {
-      updateBookingCaches(queryClient, updatedBooking);
+      syncBookingCachesAfterMutation(queryClient, updatedBooking);
 
       // Request app store rating on first booking rejection
       requestRating(RatingTrigger.BOOKING_REJECTED);

--- a/apps/mobile/utils/booking-cache.test.js
+++ b/apps/mobile/utils/booking-cache.test.js
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/config/cache.config";
+import {
+  bookingMatchesListFilters,
+  getBookingForCacheUpdate,
+  updateBookingCaches,
+  updateBookingListForFilters,
+} from "@/utils/booking-cache";
+
+const futureDate = "2026-12-01T10:00:00.000Z";
+const futureEndDate = "2026-12-01T10:30:00.000Z";
+const pastDate = "2026-01-01T10:00:00.000Z";
+const pastEndDate = "2026-01-01T10:30:00.000Z";
+const now = new Date("2026-06-11T00:00:00.000Z");
+
+function booking(overrides = {}) {
+  return {
+    id: 1,
+    uid: "booking-1",
+    title: "Demo booking",
+    startTime: futureDate,
+    endTime: futureEndDate,
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("booking cache list helpers", () => {
+  test("moves a confirmed future booking out of unconfirmed and into upcoming", () => {
+    const pendingBooking = booking({ status: "pending" });
+    const confirmedBooking = booking({ status: "accepted", eventTypeId: 11 });
+
+    expect(
+      updateBookingListForFilters(
+        [pendingBooking],
+        confirmedBooking,
+        {
+          status: ["unconfirmed"],
+          limit: 50,
+        },
+        now
+      )
+    ).toEqual([]);
+
+    expect(
+      updateBookingListForFilters(
+        [],
+        confirmedBooking,
+        {
+          status: ["upcoming"],
+          limit: 50,
+        },
+        now
+      )
+    ).toEqual([confirmedBooking]);
+  });
+
+  test("treats accepted requires-confirmation bookings as upcoming, not unconfirmed", () => {
+    const confirmedBooking = booking({ status: "accepted", requiresConfirmation: true });
+
+    expect(
+      bookingMatchesListFilters(
+        confirmedBooking,
+        {
+          status: ["unconfirmed"],
+        },
+        now
+      )
+    ).toBe(false);
+
+    expect(
+      bookingMatchesListFilters(
+        confirmedBooking,
+        {
+          status: ["upcoming"],
+        },
+        now
+      )
+    ).toBe(true);
+  });
+
+  test("moves a rejected booking out of unconfirmed and into cancelled-style lists", () => {
+    const pendingBooking = booking({ status: "pending" });
+    const rejectedBooking = booking({ status: "rejected", rejectionReason: "Unavailable" });
+
+    expect(
+      updateBookingListForFilters(
+        [pendingBooking],
+        rejectedBooking,
+        {
+          status: ["unconfirmed"],
+        },
+        now
+      )
+    ).toEqual([]);
+
+    expect(
+      updateBookingListForFilters(
+        [],
+        rejectedBooking,
+        {
+          status: ["cancelled"],
+        },
+        now
+      )
+    ).toEqual([rejectedBooking]);
+  });
+
+  test("keeps existing list-only fields when replacing a cached booking", () => {
+    const cachedBooking = booking({
+      status: "pending",
+      eventType: { id: 11, slug: "intro", title: "Intro call" },
+    });
+    const confirmedBooking = booking({ status: "accepted", eventTypeId: 11 });
+
+    expect(
+      updateBookingListForFilters(
+        [cachedBooking],
+        confirmedBooking,
+        {
+          status: ["upcoming"],
+        },
+        now
+      )
+    ).toEqual([
+      {
+        ...cachedBooking,
+        ...confirmedBooking,
+        eventType: cachedBooking.eventType,
+      },
+    ]);
+  });
+
+  test("matches date and event type filters before inserting", () => {
+    const filteredBooking = booking({ status: "accepted", eventTypeId: 22 });
+
+    expect(
+      bookingMatchesListFilters(
+        filteredBooking,
+        {
+          status: ["upcoming"],
+          eventTypeId: 11,
+        },
+        now
+      )
+    ).toBe(false);
+
+    expect(
+      bookingMatchesListFilters(
+        booking({ status: "accepted", startTime: pastDate, endTime: pastEndDate }),
+        {
+          status: ["past"],
+          eventTypeId: undefined,
+        },
+        now
+      )
+    ).toBe(true);
+  });
+
+  test("prefers cached detail over stale fallback when navigating back", () => {
+    const queryClient = new QueryClient();
+    const pendingBooking = booking({ status: "pending", requiresConfirmation: true });
+    const confirmedBooking = booking({ status: "accepted", requiresConfirmation: true });
+
+    queryClient.setQueryData(queryKeys.bookings.detail(pendingBooking.uid), pendingBooking);
+    updateBookingCaches(queryClient, confirmedBooking);
+
+    expect(getBookingForCacheUpdate(queryClient, pendingBooking.uid, pendingBooking)).toEqual(
+      confirmedBooking
+    );
+  });
+});

--- a/apps/mobile/utils/booking-cache.test.js
+++ b/apps/mobile/utils/booking-cache.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { QueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/config/cache.config";
+import * as bookingCache from "@/utils/booking-cache";
 import {
   bookingMatchesListFilters,
   getBookingForCacheUpdate,
@@ -169,5 +170,27 @@ describe("booking cache list helpers", () => {
     expect(getBookingForCacheUpdate(queryClient, pendingBooking.uid, pendingBooking)).toEqual(
       confirmedBooking
     );
+  });
+
+  test("syncs mutation results immediately and invalidates bookings for server reconciliation", () => {
+    const queryClient = new QueryClient();
+    const pendingBooking = booking({ status: "pending" });
+    const confirmedBooking = booking({ status: "accepted" });
+    const invalidations = [];
+
+    queryClient.invalidateQueries = (filters) => {
+      invalidations.push(filters);
+      return Promise.resolve();
+    };
+
+    queryClient.setQueryData(queryKeys.bookings.detail(pendingBooking.uid), pendingBooking);
+
+    expect(typeof bookingCache.syncBookingCachesAfterMutation).toBe("function");
+    bookingCache.syncBookingCachesAfterMutation(queryClient, confirmedBooking);
+
+    expect(queryClient.getQueryData(queryKeys.bookings.detail(pendingBooking.uid))).toEqual(
+      confirmedBooking
+    );
+    expect(invalidations).toContainEqual({ queryKey: queryKeys.bookings.all });
   });
 });

--- a/apps/mobile/utils/booking-cache.ts
+++ b/apps/mobile/utils/booking-cache.ts
@@ -173,6 +173,14 @@ export const updateBookingCaches = (queryClient: QueryClient, updatedBooking: Bo
   }
 };
 
+export const syncBookingCachesAfterMutation = (
+  queryClient: QueryClient,
+  updatedBooking: Booking
+): void => {
+  updateBookingCaches(queryClient, updatedBooking);
+  void queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
+};
+
 export const getBookingForCacheUpdate = (
   queryClient: QueryClient,
   bookingUid: string,

--- a/apps/mobile/utils/booking-cache.ts
+++ b/apps/mobile/utils/booking-cache.ts
@@ -1,0 +1,181 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import { queryKeys } from "@/config/cache.config";
+import type { Booking } from "@/services/calcom";
+
+export interface BookingListCacheFilters {
+  status?: unknown;
+  fromDate?: unknown;
+  toDate?: unknown;
+  eventTypeId?: unknown;
+  [key: string]: unknown;
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getStatusFilters = (status: unknown): string[] => {
+  if (Array.isArray(status)) {
+    return status.filter((value): value is string => typeof value === "string");
+  }
+
+  return typeof status === "string" ? [status] : [];
+};
+
+const getBookingStartTime = (booking: Booking): string => booking.start || booking.startTime || "";
+
+const getBookingEndTime = (booking: Booking): string => booking.end || booking.endTime || "";
+
+const getBookingEventTypeId = (booking: Booking): number | undefined =>
+  booking.eventTypeId ?? booking.eventType?.id;
+
+const getBookingStatus = (booking: Booking): string => booking.status?.toLowerCase() || "";
+
+const isPendingBooking = (booking: Booking): boolean => {
+  const status = getBookingStatus(booking);
+  return status === "pending" || status === "requires_confirmation";
+};
+
+const isCancelledOrRejectedBooking = (booking: Booking): boolean => {
+  const status = getBookingStatus(booking);
+  return status === "cancelled" || status === "rejected";
+};
+
+const isRecurringBooking = (booking: Booking): boolean =>
+  Boolean(booking.recurringBookingUid || booking.recurringEventId);
+
+const getTime = (dateString: unknown): number | null => {
+  if (typeof dateString !== "string" || dateString.length === 0) return null;
+
+  const time = new Date(dateString).getTime();
+  return Number.isNaN(time) ? null : time;
+};
+
+const matchesDateRange = (booking: Booking, filters: BookingListCacheFilters): boolean => {
+  const startTime = getTime(getBookingStartTime(booking));
+  if (startTime === null) return false;
+
+  const fromTime = getTime(filters.fromDate);
+  if (fromTime !== null && startTime < fromTime) return false;
+
+  const toTime = getTime(filters.toDate);
+  if (toTime !== null && startTime > toTime) return false;
+
+  return true;
+};
+
+const bookingMatchesStatusFilter = (booking: Booking, statusFilter: string, now: Date): boolean => {
+  const normalizedStatusFilter = statusFilter.toLowerCase();
+  const status = getBookingStatus(booking);
+  const endTime = getTime(getBookingEndTime(booking));
+  const isPast = endTime !== null && endTime < now.getTime();
+
+  switch (normalizedStatusFilter) {
+    case "upcoming":
+      return !isPast && !isPendingBooking(booking) && !isCancelledOrRejectedBooking(booking);
+    case "unconfirmed":
+      return isPendingBooking(booking);
+    case "past":
+      return isPast && !isCancelledOrRejectedBooking(booking);
+    case "cancelled":
+      return isCancelledOrRejectedBooking(booking);
+    case "recurring":
+      return isRecurringBooking(booking);
+    default:
+      return status === normalizedStatusFilter;
+  }
+};
+
+export const bookingMatchesListFilters = (
+  booking: Booking,
+  filters: BookingListCacheFilters,
+  now = new Date()
+): boolean => {
+  const eventTypeId = filters.eventTypeId;
+  if (typeof eventTypeId === "number" && getBookingEventTypeId(booking) !== eventTypeId) {
+    return false;
+  }
+
+  if (!matchesDateRange(booking, filters)) {
+    return false;
+  }
+
+  const statusFilters = getStatusFilters(filters.status);
+  if (statusFilters.length === 0) {
+    return true;
+  }
+
+  return statusFilters.some((status) => bookingMatchesStatusFilter(booking, status, now));
+};
+
+const mergeBookingForCache = (
+  currentBooking: Booking | undefined,
+  updatedBooking: Booking
+): Booking => {
+  if (!currentBooking) return updatedBooking;
+
+  const mergedEventType =
+    currentBooking.eventType && updatedBooking.eventType
+      ? {
+          ...currentBooking.eventType,
+          ...updatedBooking.eventType,
+        }
+      : (updatedBooking.eventType ?? currentBooking.eventType);
+
+  return {
+    ...currentBooking,
+    ...updatedBooking,
+    eventType: mergedEventType,
+  };
+};
+
+export const updateBookingListForFilters = (
+  currentBookings: Booking[] | undefined,
+  updatedBooking: Booking,
+  filters: BookingListCacheFilters,
+  now = new Date()
+): Booking[] | undefined => {
+  if (!currentBookings) return currentBookings;
+
+  const currentBooking = currentBookings.find((booking) => booking.uid === updatedBooking.uid);
+  const bookingForCache = mergeBookingForCache(currentBooking, updatedBooking);
+  const bookingsWithoutUpdated = currentBookings.filter(
+    (booking) => booking.uid !== updatedBooking.uid
+  );
+
+  if (!bookingMatchesListFilters(bookingForCache, filters, now)) {
+    return bookingsWithoutUpdated;
+  }
+
+  return [...bookingsWithoutUpdated, bookingForCache];
+};
+
+const getBookingListFiltersFromQueryKey = (queryKey: QueryKey): BookingListCacheFilters | null => {
+  const [resource, scope, filters] = queryKey;
+  if (resource !== "bookings" || scope !== "list") {
+    return null;
+  }
+
+  return isObject(filters) ? filters : {};
+};
+
+export const updateBookingCaches = (queryClient: QueryClient, updatedBooking: Booking): void => {
+  queryClient.setQueryData(queryKeys.bookings.detail(updatedBooking.uid), updatedBooking);
+
+  const listQueries = queryClient.getQueryCache().findAll({ queryKey: queryKeys.bookings.lists() });
+
+  for (const query of listQueries) {
+    const filters = getBookingListFiltersFromQueryKey(query.queryKey);
+    if (!filters) continue;
+
+    queryClient.setQueryData<Booking[]>(query.queryKey, (currentBookings) =>
+      updateBookingListForFilters(currentBookings, updatedBooking, filters)
+    );
+  }
+};
+
+export const getBookingForCacheUpdate = (
+  queryClient: QueryClient,
+  bookingUid: string,
+  fallbackBooking: Booking | null | undefined
+): Booking | null | undefined =>
+  queryClient.getQueryData<Booking>(queryKeys.bookings.detail(bookingUid)) ?? fallbackBooking;


### PR DESCRIPTION
## Stack
1. #113 opens booking request notifications on booking detail.
2. #114 adds detail-screen confirm/reject actions.
3. This PR syncs the bookings list after a detail action.

## Summary
- Patch booking list/detail caches from confirm/reject mutation responses.
- Treat accepted confirmation-required bookings as upcoming instead of unconfirmed.
- Prefer the latest cached detail booking when returning from notification-opened detail routes.
- Add a one-time silent sync of the currently visible bookings list after returning from detail.
- Add focused Bun tests for cache list membership and stale detail fallback behavior.

## Testing
- `bun test apps/mobile/utils/booking-cache.test.js`
- `bun --filter mobile typecheck`
- `bun run lint:react-compiler`
- `git diff --check`
