### PR TITLE
fix(mobile): restore booking request action follow-ups

### DIFF
--- a/apps/mobile/app/(tabs)/(bookings)/booking-detail.ios.tsx
+++ b/apps/mobile/app/(tabs)/(bookings)/booking-detail.ios.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import * as Clipboard from "expo-clipboard";
 import { isLiquidGlassAvailable } from "expo-glass-effect";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
@@ -10,6 +11,7 @@ import { useBookingByUid } from "@/hooks/useBookings";
 import { showErrorAlert, showInfoAlert, showSuccessAlert } from "@/utils/alerts";
 import { getMeetingUrl } from "@/utils/booking";
 import { type BookingActionsResult, getBookingActions } from "@/utils/booking-actions";
+import { getBookingForCacheUpdate, updateBookingCaches } from "@/utils/booking-cache";
 import { openInDefaultBrowser } from "@/utils/browser";
 
 // Empty actions result for when no booking is loaded
@@ -47,6 +49,7 @@ export default function BookingDetailIOS() {
   const { uid, source } = useLocalSearchParams<{ uid: string; source?: string }>();
   const { userInfo } = useAuth();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const colorScheme = useColorScheme();
   const openedFromNotification = source === "notification";
 
@@ -96,8 +99,15 @@ export default function BookingDetailIOS() {
   }, [meetingUrl]);
 
   const handleBackToBookings = useCallback(() => {
-    router.replace("/(tabs)/(bookings)");
-  }, [router]);
+    const bookingForCacheUpdate = getBookingForCacheUpdate(queryClient, uid, enrichedBooking);
+    if (bookingForCacheUpdate) {
+      updateBookingCaches(queryClient, bookingForCacheUpdate);
+    }
+    router.replace({
+      pathname: "/(tabs)/(bookings)",
+      params: { sync: Date.now().toString() },
+    });
+  }, [enrichedBooking, queryClient, router, uid]);
 
   // Handle copy meeting link
   const handleCopyMeetingLink = useCallback(async () => {

--- a/apps/mobile/app/(tabs)/(bookings)/index.ios.tsx
+++ b/apps/mobile/app/(tabs)/(bookings)/index.ios.tsx
@@ -21,7 +21,7 @@ function isValidBookingFilter(value: string | undefined): value is BookingFilter
 }
 
 export default function Bookings() {
-  const { filter } = useLocalSearchParams<{ filter?: string }>();
+  const { filter, sync } = useLocalSearchParams<{ filter?: string; sync?: string }>();
   const initialFilter = isValidBookingFilter(filter) ? filter : "upcoming";
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -211,6 +211,7 @@ export default function Bookings() {
         selectedEventTypeId={selectedEventTypeId}
         activeFilter={activeFilter}
         filterParams={filterParams}
+        syncKey={sync}
         iosStyle={true}
       />
     </>

--- a/apps/mobile/app/(tabs)/(bookings)/index.tsx
+++ b/apps/mobile/app/(tabs)/(bookings)/index.tsx
@@ -28,7 +28,7 @@ function isValidBookingFilter(value: string | undefined): value is BookingFilter
 }
 
 export default function Bookings() {
-  const { filter } = useLocalSearchParams<{ filter?: string }>();
+  const { filter, sync } = useLocalSearchParams<{ filter?: string; sync?: string }>();
   const initialFilter = isValidBookingFilter(filter) ? filter : "upcoming";
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -226,6 +226,7 @@ export default function Bookings() {
       onEventTypeChange={handleEventTypeSelect}
       activeFilter={activeFilter}
       filterParams={filterParams}
+      syncKey={sync}
     />
   );
 }

--- a/apps/mobile/components/PushNotificationProvider.tsx
+++ b/apps/mobile/components/PushNotificationProvider.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/hooks/use-push-notifications";
 import { type Booking, CalComAPIService } from "@/services/calcom";
 import { showInfoAlert, showSuccessAlert } from "@/utils/alerts";
-import { updateBookingCaches } from "@/utils/booking-cache";
+import { syncBookingCachesAfterMutation } from "@/utils/booking-cache";
 
 // How long the pre-logout callback waits for an in-flight registration to
 // settle before deregistering, so a token that registered moments before
@@ -226,7 +226,7 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
         } else {
           return;
         }
-        updateBookingCaches(queryClientRef.current, updatedBooking);
+        syncBookingCachesAfterMutation(queryClientRef.current, updatedBooking);
       } catch (error) {
         // Includes the non-idempotent "Booking already confirmed" case — show
         // it as feedback rather than retrying, then refresh so the UI reflects

--- a/apps/mobile/components/PushNotificationProvider.tsx
+++ b/apps/mobile/components/PushNotificationProvider.tsx
@@ -16,8 +16,9 @@ import {
   drainPendingDeregistrations,
   requestAndRegisterPushToken,
 } from "@/hooks/use-push-notifications";
-import { CalComAPIService } from "@/services/calcom";
+import { type Booking, CalComAPIService } from "@/services/calcom";
 import { showInfoAlert, showSuccessAlert } from "@/utils/alerts";
+import { updateBookingCaches } from "@/utils/booking-cache";
 
 // How long the pre-logout callback waits for an in-flight registration to
 // settle before deregistering, so a token that registered moments before
@@ -215,16 +216,17 @@ export function PushNotificationProvider({ children }: PushNotificationProviderP
         ]);
 
       try {
+        let updatedBooking: Booking;
         if (actionId === CONFIRM_BOOKING_REQUEST_ACTION_ID) {
-          await CalComAPIService.confirmBooking(bookingUid);
+          updatedBooking = await CalComAPIService.confirmBooking(bookingUid);
           showSuccessAlert("Success", "Booking confirmed successfully");
         } else if (actionId === DECLINE_BOOKING_REQUEST_ACTION_ID) {
-          await CalComAPIService.declineBooking(bookingUid);
+          updatedBooking = await CalComAPIService.declineBooking(bookingUid);
           showSuccessAlert("Success", "Booking declined successfully");
         } else {
           return;
         }
-        await refresh();
+        updateBookingCaches(queryClientRef.current, updatedBooking);
       } catch (error) {
         // Includes the non-idempotent "Booking already confirmed" case — show
         // it as feedback rather than retrying, then refresh so the UI reflects

--- a/apps/mobile/components/booking-list-screen/BookingListScreen.tsx
+++ b/apps/mobile/components/booking-list-screen/BookingListScreen.tsx
@@ -87,6 +87,9 @@ interface BookingListScreenProps {
   activeFilter: BookingFilter;
   filterParams: Record<string, unknown>;
 
+  // One-time background sync signal from routes that know list data may have moved
+  syncKey?: string;
+
   // iOS-style list (no wrapper)
   iosStyle?: boolean;
 }
@@ -103,6 +106,7 @@ export const BookingListScreen: React.FC<BookingListScreenProps> = ({
   onEventTypeChange,
   activeFilter,
   filterParams,
+  syncKey,
   iosStyle = false,
 }) => {
   const router = useRouter();
@@ -119,6 +123,14 @@ export const BookingListScreen: React.FC<BookingListScreenProps> = ({
     error: queryError,
     refetch,
   } = useBookings(filterParams);
+  const handledSyncKeyRef = React.useRef<string | undefined>(undefined);
+
+  React.useEffect(() => {
+    if (!syncKey || handledSyncKeyRef.current === syncKey) return;
+
+    handledSyncKeyRef.current = syncKey;
+    void refetch();
+  }, [refetch, syncKey]);
 
   // Cancel booking mutation
   const { mutate: cancelBookingMutation } = useCancelBooking();

--- a/apps/mobile/components/screens/BookingDetailRequestActions.state.ts
+++ b/apps/mobile/components/screens/BookingDetailRequestActions.state.ts
@@ -1,0 +1,67 @@
+import type { Booking } from "@/services/types/bookings.types";
+import { getBookingPaymentStatus } from "@/utils/booking-payment-status";
+
+type CanRespondToBookingRequestParams = {
+  booking: Booking;
+  currentUserId?: number;
+  currentUserEmail?: string;
+  now?: Date;
+};
+
+type BookingRequestActionState = {
+  canConfirm: boolean;
+  canReject: boolean;
+};
+
+const getBookingStatus = (booking: Booking): string => booking.status?.toLowerCase() || "";
+
+const getBookingEndTime = (booking: Booking): string => booking.endTime || booking.end || "";
+
+const isBookingPending = (booking: Booking): boolean => getBookingStatus(booking) === "pending";
+
+const isBookingInPast = (booking: Booking, now: Date): boolean => {
+  const endTime = new Date(getBookingEndTime(booking));
+  return !Number.isNaN(endTime.getTime()) && endTime < now;
+};
+
+const isUserOrganizer = (booking: Booking, userId?: number, userEmail?: string): boolean => {
+  if (!booking.user) return false;
+
+  if (userId && booking.user.id === userId) return true;
+  if (userEmail && booking.user.email?.toLowerCase() === userEmail.toLowerCase()) return true;
+
+  return false;
+};
+
+const isUserHost = (booking: Booking, userId?: number, userEmail?: string): boolean => {
+  if (!booking.hosts || booking.hosts.length === 0) return false;
+
+  return booking.hosts.some((host) => {
+    if (userId && host.id !== undefined && String(host.id) === String(userId)) return true;
+    if (userEmail && host.email?.toLowerCase() === userEmail.toLowerCase()) return true;
+    return false;
+  });
+};
+
+export function getBookingRequestActionState({
+  booking,
+  currentUserId,
+  currentUserEmail,
+  now = new Date(),
+}: CanRespondToBookingRequestParams): BookingRequestActionState {
+  const isPending = isBookingPending(booking);
+  const isPast = isBookingInPast(booking, now);
+  const { isPendingPayment } = getBookingPaymentStatus(booking);
+  const isOrganizer = isUserOrganizer(booking, currentUserId, currentUserEmail);
+  const isHost = isUserHost(booking, currentUserId, currentUserEmail);
+  const canReject = isPending && !isPast && (isOrganizer || isHost);
+
+  return {
+    canConfirm: canReject && !isPendingPayment,
+    canReject,
+  };
+}
+
+export function canRespondToBookingRequest(params: CanRespondToBookingRequestParams): boolean {
+  return getBookingRequestActionState(params).canReject;
+}

--- a/apps/mobile/components/screens/BookingDetailRequestActions.state.ts
+++ b/apps/mobile/components/screens/BookingDetailRequestActions.state.ts
@@ -17,7 +17,14 @@ const getBookingStatus = (booking: Booking): string => booking.status?.toLowerCa
 
 const getBookingEndTime = (booking: Booking): string => booking.endTime || booking.end || "";
 
-const isBookingPending = (booking: Booking): boolean => getBookingStatus(booking) === "pending";
+const isBookingPending = (booking: Booking): boolean => {
+  const status = getBookingStatus(booking);
+  return (
+    status === "pending" ||
+    status === "requires_confirmation" ||
+    booking.requiresConfirmation === true
+  );
+};
 
 const isBookingInPast = (booking: Booking, now: Date): boolean => {
   const endTime = new Date(getBookingEndTime(booking));

--- a/apps/mobile/components/screens/BookingDetailRequestActions.test.js
+++ b/apps/mobile/components/screens/BookingDetailRequestActions.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { getBookingRequestActionState } from "./BookingDetailRequestActions.state";
+
+const now = new Date("2026-06-11T00:00:00.000Z");
+
+function createBooking(overrides = {}) {
+  return {
+    id: 1,
+    uid: "booking-1",
+    title: "Demo booking",
+    status: "pending",
+    startTime: "2026-06-12T10:00:00.000Z",
+    endTime: "2026-06-12T10:30:00.000Z",
+    user: {
+      id: 42,
+      email: "organizer@example.com",
+      name: "Organizer",
+      timeZone: "UTC",
+    },
+    ...overrides,
+  };
+}
+
+describe("getBookingRequestActionState", () => {
+  test("allows confirming paid booking requests with a successful on-booking payment row", () => {
+    const booking = createBooking({
+      payment: [
+        {
+          id: 1,
+          success: true,
+          paymentOption: "ON_BOOKING",
+          refunded: false,
+        },
+      ],
+    });
+
+    expect(
+      getBookingRequestActionState({
+        booking,
+        currentUserId: 42,
+        currentUserEmail: "organizer@example.com",
+        now,
+      })
+    ).toEqual({
+      canConfirm: true,
+      canReject: true,
+    });
+  });
+
+  test("keeps confirm hidden while an on-booking payment is pending", () => {
+    const booking = createBooking({
+      payment: [
+        {
+          id: 1,
+          success: false,
+          paymentOption: "ON_BOOKING",
+          refunded: false,
+        },
+      ],
+    });
+
+    expect(
+      getBookingRequestActionState({
+        booking,
+        currentUserId: 42,
+        currentUserEmail: "organizer@example.com",
+        now,
+      })
+    ).toEqual({
+      canConfirm: false,
+      canReject: true,
+    });
+  });
+});

--- a/apps/mobile/components/screens/BookingDetailRequestActions.test.js
+++ b/apps/mobile/components/screens/BookingDetailRequestActions.test.js
@@ -71,4 +71,22 @@ describe("getBookingRequestActionState", () => {
       canReject: true,
     });
   });
+
+  test("treats requires_confirmation status as a pending booking request", () => {
+    const booking = createBooking({
+      status: "requires_confirmation",
+    });
+
+    expect(
+      getBookingRequestActionState({
+        booking,
+        currentUserId: 42,
+        currentUserEmail: "organizer@example.com",
+        now,
+      })
+    ).toEqual({
+      canConfirm: true,
+      canReject: true,
+    });
+  });
 });

--- a/apps/mobile/components/screens/BookingDetailRequestActions.tsx
+++ b/apps/mobile/components/screens/BookingDetailRequestActions.tsx
@@ -1,0 +1,126 @@
+import { Ionicons } from "@expo/vector-icons";
+import { ActivityIndicator, Text, useColorScheme, View } from "react-native";
+import { AppPressable } from "@/components/AppPressable";
+import { getBookingRequestActionState } from "@/components/screens/BookingDetailRequestActions.state";
+import type { Booking } from "@/services/calcom";
+
+export {
+  canRespondToBookingRequest,
+  getBookingRequestActionState,
+} from "@/components/screens/BookingDetailRequestActions.state";
+
+type RequestActionColors = {
+  cardBackground: string;
+  text: string;
+  textSecondary: string;
+  border: string;
+  destructive: string;
+};
+
+type BookingDetailRequestActionsProps = {
+  booking: Booking;
+  currentUserId?: number;
+  currentUserEmail?: string;
+  isConfirming: boolean;
+  isDeclining: boolean;
+  onConfirm: () => void;
+  onReject: () => void;
+  colors: RequestActionColors;
+};
+
+export function BookingDetailRequestActions({
+  booking,
+  currentUserId,
+  currentUserEmail,
+  isConfirming,
+  isDeclining,
+  onConfirm,
+  onReject,
+  colors,
+}: BookingDetailRequestActionsProps) {
+  const colorScheme = useColorScheme();
+  const isDark = colorScheme === "dark";
+  const { canConfirm, canReject } = getBookingRequestActionState({
+    booking,
+    currentUserId,
+    currentUserEmail,
+  });
+
+  if (!canReject) return null;
+
+  const isProcessing = isConfirming || isDeclining;
+  const primaryBackground = isDark ? "#FFFFFF" : "#111827";
+  const primaryText = isDark ? "#000000" : "#FFFFFF";
+  const iconBackground = isDark ? "#262626" : "#F2F2F7";
+  const helperText = canConfirm
+    ? "Confirm or reject this request."
+    : "Payment is still pending. You can reject this request.";
+
+  return (
+    <View
+      className="mb-4 overflow-hidden rounded-xl border"
+      style={{ backgroundColor: colors.cardBackground, borderColor: colors.border }}
+    >
+      <View className="gap-4 p-4">
+        <View className="flex-row gap-3">
+          <View
+            className="h-9 w-9 items-center justify-center rounded-full"
+            style={{ backgroundColor: iconBackground }}
+          >
+            <Ionicons name="time-outline" size={18} color={colors.text} />
+          </View>
+          <View className="flex-1">
+            <Text className="text-[17px] font-semibold" style={{ color: colors.text }}>
+              Booking request
+            </Text>
+            <Text className="mt-1 text-[14px] leading-5" style={{ color: colors.textSecondary }}>
+              {helperText}
+            </Text>
+          </View>
+        </View>
+
+        <View className="flex-row gap-2">
+          <AppPressable
+            className="h-11 flex-1 flex-row items-center justify-center rounded-lg border"
+            style={{
+              borderColor: colors.border,
+              opacity: isProcessing ? 0.6 : 1,
+            }}
+            disabled={isProcessing}
+            onPress={onReject}
+          >
+            {isDeclining ? (
+              <ActivityIndicator size="small" color={colors.destructive} />
+            ) : (
+              <Ionicons name="close" size={17} color={colors.destructive} />
+            )}
+            <Text className="ml-1.5 text-[15px] font-semibold" style={{ color: colors.text }}>
+              Reject
+            </Text>
+          </AppPressable>
+
+          {canConfirm ? (
+            <AppPressable
+              className="h-11 flex-1 flex-row items-center justify-center rounded-lg"
+              style={{
+                backgroundColor: primaryBackground,
+                opacity: isProcessing ? 0.6 : 1,
+              }}
+              disabled={isProcessing}
+              onPress={onConfirm}
+            >
+              {isConfirming ? (
+                <ActivityIndicator size="small" color={primaryText} />
+              ) : (
+                <Ionicons name="checkmark" size={17} color={primaryText} />
+              )}
+              <Text className="ml-1.5 text-[15px] font-semibold" style={{ color: primaryText }}>
+                Confirm
+              </Text>
+            </AppPressable>
+          ) : null}
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/components/screens/BookingDetailScreen.ios.tsx
+++ b/apps/mobile/components/screens/BookingDetailScreen.ios.tsx
@@ -13,7 +13,9 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AppPressable } from "@/components/AppPressable";
-import { useCancelBooking } from "@/hooks/useBookings";
+import { BookingDetailRequestActions } from "@/components/screens/BookingDetailRequestActions";
+import { useAuth } from "@/contexts/AuthContext";
+import { useCancelBooking, useConfirmBooking, useDeclineBooking } from "@/hooks/useBookings";
 import type { Booking } from "@/services/calcom";
 import { showErrorAlert, showSuccessAlert } from "@/utils/alerts";
 import { getBookingPaymentStatus } from "@/utils/booking-payment-status";
@@ -141,6 +143,7 @@ export function BookingDetailScreen({
   onActionsReady,
 }: BookingDetailScreenProps): React.JSX.Element {
   const router = useRouter();
+  const { userInfo } = useAuth();
   const insets = useSafeAreaInsets();
   const colorScheme = useColorScheme();
   const isDark = colorScheme === "dark";
@@ -160,7 +163,11 @@ export function BookingDetailScreen({
 
   // Cancel booking mutation
   const cancelBookingMutation = useCancelBooking();
+  const confirmBookingMutation = useConfirmBooking();
+  const declineBookingMutation = useDeclineBooking();
   const isCancelling = cancelBookingMutation.isPending;
+  const isConfirming = confirmBookingMutation.isPending;
+  const isDeclining = declineBookingMutation.isPending;
 
   const performCancelBooking = useCallback(
     (reason: string) => {
@@ -223,6 +230,73 @@ export function BookingDetailScreen({
       },
     ]);
   }, [booking, performCancelBooking]);
+
+  const handleConfirmBooking = useCallback(() => {
+    if (!booking || isConfirming || isDeclining) return;
+
+    confirmBookingMutation.mutate(
+      { uid: booking.uid },
+      {
+        onSuccess: () => {
+          showSuccessAlert("Success", "Booking confirmed successfully");
+        },
+        onError: (err) => {
+          console.error("Failed to confirm booking");
+          if (__DEV__) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.debug("[BookingDetailScreen.ios] confirmBooking failed", { message });
+          }
+          showErrorAlert("Error", "Failed to confirm booking. Please try again.");
+        },
+      }
+    );
+  }, [booking, confirmBookingMutation, isConfirming, isDeclining]);
+
+  const performRejectBooking = useCallback(
+    (reason?: string) => {
+      if (!booking || isDeclining) return;
+
+      declineBookingMutation.mutate(
+        { uid: booking.uid, reason },
+        {
+          onSuccess: () => {
+            showSuccessAlert("Success", "Booking rejected successfully");
+          },
+          onError: (err) => {
+            console.error("Failed to reject booking");
+            if (__DEV__) {
+              const message = err instanceof Error ? err.message : String(err);
+              console.debug("[BookingDetailScreen.ios] rejectBooking failed", { message });
+            }
+            showErrorAlert("Error", "Failed to reject booking. Please try again.");
+          },
+        }
+      );
+    },
+    [booking, declineBookingMutation, isDeclining]
+  );
+
+  const handleRejectBooking = useCallback(() => {
+    if (!booking || isConfirming || isDeclining) return;
+
+    Alert.prompt(
+      "Reject Booking",
+      "Add an optional reason for rejecting this booking request:",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Reject Booking",
+          style: "destructive",
+          onPress: (reason?: string) => {
+            performRejectBooking(reason?.trim() || undefined);
+          },
+        },
+      ],
+      "plain-text",
+      "",
+      "default"
+    );
+  }, [booking, isConfirming, isDeclining, performRejectBooking]);
 
   const openRescheduleModal = useCallback(() => {
     if (!booking) return;
@@ -460,7 +534,7 @@ export function BookingDetailScreen({
           )}
 
           {/* Payment and Confirmation Status Badges */}
-          {(isPendingPayment || isUnconfirmed) ? (
+          {isPendingPayment || isUnconfirmed ? (
             <View className="mt-3 flex-row flex-wrap items-center">
               {isPendingPayment ? (
                 <View className="mb-1 mr-2 rounded bg-cal-accent-warning px-2 py-0.5">
@@ -475,6 +549,23 @@ export function BookingDetailScreen({
             </View>
           ) : null}
         </View>
+
+        <BookingDetailRequestActions
+          booking={booking}
+          currentUserId={userInfo?.id}
+          currentUserEmail={userInfo?.email}
+          isConfirming={isConfirming}
+          isDeclining={isDeclining}
+          onConfirm={handleConfirmBooking}
+          onReject={handleRejectBooking}
+          colors={{
+            cardBackground: colors.cardBackground,
+            text: colors.text,
+            textSecondary: colors.textSecondary,
+            border: colors.border,
+            destructive: colors.destructive,
+          }}
+        />
 
         {/* Participants Card - iOS Calendar Style (Expandable) */}
         <View

--- a/apps/mobile/components/screens/BookingDetailScreen.tsx
+++ b/apps/mobile/components/screens/BookingDetailScreen.tsx
@@ -20,6 +20,7 @@ import { AppPressable } from "@/components/AppPressable";
 import { BookingActionsModal } from "@/components/BookingActionsModal";
 import { FullScreenModal } from "@/components/FullScreenModal";
 import { HeaderButtonWrapper } from "@/components/HeaderButtonWrapper";
+import { BookingDetailRequestActions } from "@/components/screens/BookingDetailRequestActions";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -40,7 +41,7 @@ import {
 import { Text as UIText } from "@/components/ui/text";
 import { getColors } from "@/constants/colors";
 import { useAuth } from "@/contexts/AuthContext";
-import { useCancelBooking } from "@/hooks/useBookings";
+import { useCancelBooking, useConfirmBooking, useDeclineBooking } from "@/hooks/useBookings";
 import type { Booking } from "@/services/calcom";
 import { showErrorAlert, showInfoAlert, showSuccessAlert } from "@/utils/alerts";
 import { getMeetingUrl } from "@/utils/booking";
@@ -196,12 +197,18 @@ export function BookingDetailScreen({
 
   const [showActionsModal, setShowActionsModal] = useState(false);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [showRejectDialog, setShowRejectDialog] = useState(false);
   const [cancellationReason, setCancellationReason] = useState("");
+  const [rejectReason, setRejectReason] = useState("");
   const [participantsExpanded, setParticipantsExpanded] = useState(true);
 
   // Cancel booking mutation
   const cancelBookingMutation = useCancelBooking();
+  const confirmBookingMutation = useConfirmBooking();
+  const declineBookingMutation = useDeclineBooking();
   const isCancelling = cancelBookingMutation.isPending;
+  const isConfirming = confirmBookingMutation.isPending;
+  const isDeclining = declineBookingMutation.isPending;
 
   const contentInsets = {
     top: insets.top,
@@ -299,6 +306,91 @@ export function BookingDetailScreen({
     setShowCancelDialog(false);
     setCancellationReason("");
   }, []);
+
+  const handleConfirmBooking = useCallback(() => {
+    if (!booking || isConfirming || isDeclining) return;
+
+    confirmBookingMutation.mutate(
+      { uid: booking.uid },
+      {
+        onSuccess: () => {
+          showSuccessAlert("Success", "Booking confirmed successfully");
+        },
+        onError: (err) => {
+          console.error("Failed to confirm booking");
+          if (__DEV__) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.debug("[BookingDetailScreen] confirmBooking failed", { message });
+          }
+          showErrorAlert("Error", "Failed to confirm booking. Please try again.");
+        },
+      }
+    );
+  }, [booking, confirmBookingMutation, isConfirming, isDeclining]);
+
+  const performRejectBooking = useCallback(
+    (reason?: string) => {
+      if (!booking || isDeclining) return;
+
+      declineBookingMutation.mutate(
+        { uid: booking.uid, reason },
+        {
+          onSuccess: () => {
+            setShowRejectDialog(false);
+            setRejectReason("");
+            showSuccessAlert("Success", "Booking rejected successfully");
+          },
+          onError: (err) => {
+            console.error("Failed to reject booking");
+            if (__DEV__) {
+              const message = err instanceof Error ? err.message : String(err);
+              console.debug("[BookingDetailScreen] rejectBooking failed", { message });
+            }
+            showErrorAlert("Error", "Failed to reject booking. Please try again.");
+          },
+        }
+      );
+    },
+    [booking, declineBookingMutation, isDeclining]
+  );
+
+  const handleRejectBooking = useCallback(() => {
+    if (!booking || isConfirming || isDeclining) return;
+
+    if (Platform.OS === "android" || Platform.OS === "web") {
+      setRejectReason("");
+      setShowRejectDialog(true);
+      return;
+    }
+
+    Alert.prompt(
+      "Reject Booking",
+      "Add an optional reason for rejecting this booking request:",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Reject Booking",
+          style: "destructive",
+          onPress: (reason?: string) => {
+            performRejectBooking(reason?.trim() || undefined);
+          },
+        },
+      ],
+      "plain-text",
+      "",
+      "default"
+    );
+  }, [booking, isConfirming, isDeclining, performRejectBooking]);
+
+  const handleConfirmReject = useCallback(() => {
+    performRejectBooking(rejectReason.trim() || undefined);
+  }, [performRejectBooking, rejectReason]);
+
+  const handleCloseRejectDialog = useCallback(() => {
+    if (isDeclining) return;
+    setShowRejectDialog(false);
+    setRejectReason("");
+  }, [isDeclining]);
 
   const handleReportBooking = useCallback(() => {
     showInfoAlert("Report Booking", "Report booking functionality is not yet available");
@@ -710,7 +802,7 @@ export function BookingDetailScreen({
             ) : null}
 
             {/* Payment and Confirmation Status Badges */}
-            {(isPendingPayment || isUnconfirmed) ? (
+            {isPendingPayment || isUnconfirmed ? (
               <View className="mt-3 flex-row flex-wrap items-center">
                 {isPendingPayment ? (
                   <View className="mb-1 mr-2 rounded bg-cal-accent-warning px-2 py-0.5">
@@ -725,6 +817,23 @@ export function BookingDetailScreen({
               </View>
             ) : null}
           </View>
+
+          <BookingDetailRequestActions
+            booking={booking}
+            currentUserId={userInfo?.id}
+            currentUserEmail={userInfo?.email}
+            isConfirming={isConfirming}
+            isDeclining={isDeclining}
+            onConfirm={handleConfirmBooking}
+            onReject={handleRejectBooking}
+            colors={{
+              cardBackground,
+              text: theme.text,
+              textSecondary: theme.textSecondary,
+              border: theme.border,
+              destructive: theme.destructive,
+            }}
+          />
 
           {/* Participants Card - iOS Calendar Style (Expandable) */}
           <View
@@ -1140,7 +1249,9 @@ export function BookingDetailScreen({
 
                   {/* Title and description */}
                   <View className="flex-1">
-                    <Text className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">Cancel Event</Text>
+                    <Text className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
+                      Cancel Event
+                    </Text>
                     <Text className="text-sm leading-5 text-gray-600 dark:text-[#A3A3A3]">
                       Are you sure you want to cancel "{booking?.title}"? Cancellation reason will
                       be shared with guests.
@@ -1174,14 +1285,92 @@ export function BookingDetailScreen({
                   style={{ backgroundColor: isDark ? "#FFFFFF" : "#111827" }}
                   onPress={handleConfirmCancel}
                 >
-                  <Text className="text-center text-base font-medium text-white dark:text-black">Cancel Event</Text>
+                  <Text className="text-center text-base font-medium text-white dark:text-black">
+                    Cancel Event
+                  </Text>
                 </TouchableOpacity>
 
                 <TouchableOpacity
                   className="rounded-lg border border-gray-300 bg-white px-4 py-2.5 dark:border-[#4D4D4D] dark:bg-[#262626]"
                   onPress={handleCloseCancelDialog}
                 >
-                  <Text className="text-center text-base font-medium text-gray-700 dark:text-white">Nevermind</Text>
+                  <Text className="text-center text-base font-medium text-gray-700 dark:text-white">
+                    Nevermind
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+        </FullScreenModal>
+      )}
+
+      {/* Web/Extension: Reject Booking Request Modal */}
+      {Platform.OS === "web" && (
+        <FullScreenModal
+          visible={showRejectDialog}
+          animationType="fade"
+          onRequestClose={handleCloseRejectDialog}
+        >
+          <View className="flex-1 items-center justify-center bg-black/50 p-4">
+            <View className="w-full max-w-md rounded-2xl bg-white shadow-2xl dark:bg-[#171717]">
+              <View className="p-6">
+                <View className="flex-row">
+                  <View className="mr-3 self-start rounded-full bg-red-50 p-2 dark:bg-red-900/30">
+                    <Ionicons name="close-circle" size={20} color={theme.destructive} />
+                  </View>
+
+                  <View className="flex-1">
+                    <Text className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
+                      Reject Booking Request
+                    </Text>
+                    <Text className="text-sm leading-5 text-gray-600 dark:text-[#A3A3A3]">
+                      The request will be declined. You can share a reason with the attendee.
+                    </Text>
+
+                    <View className="mt-4">
+                      <Text className="mb-2 text-sm font-medium text-gray-700 dark:text-[#A3A3A3]">
+                        Reason for rejection
+                      </Text>
+                      <TextInput
+                        className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-base text-gray-900 dark:border-[#4D4D4D] dark:bg-[#262626] dark:text-white"
+                        placeholder="Why are you rejecting?"
+                        placeholderTextColor={isDark ? "#636366" : "#9CA3AF"}
+                        value={rejectReason}
+                        onChangeText={setRejectReason}
+                        editable={!isDeclining}
+                        multiline
+                        numberOfLines={3}
+                        textAlignVertical="top"
+                        style={{ minHeight: 80 }}
+                      />
+                    </View>
+                  </View>
+                </View>
+              </View>
+
+              <View className="flex-row-reverse gap-2 px-6 pb-6 pt-2">
+                <TouchableOpacity
+                  className="rounded-lg px-4 py-2.5"
+                  style={{
+                    backgroundColor: theme.destructive,
+                    opacity: isDeclining ? 0.6 : 1,
+                  }}
+                  disabled={isDeclining}
+                  onPress={handleConfirmReject}
+                >
+                  <Text className="text-center text-base font-medium text-white">
+                    {isDeclining ? "Rejecting..." : "Reject Request"}
+                  </Text>
+                </TouchableOpacity>
+
+                <TouchableOpacity
+                  className="rounded-lg border border-gray-300 bg-white px-4 py-2.5 dark:border-[#4D4D4D] dark:bg-[#262626]"
+                  disabled={isDeclining}
+                  onPress={handleCloseRejectDialog}
+                >
+                  <Text className="text-center text-base font-medium text-gray-700 dark:text-white">
+                    Nevermind
+                  </Text>
                 </TouchableOpacity>
               </View>
             </View>
@@ -1226,6 +1415,65 @@ export function BookingDetailScreen({
               </AlertDialogCancel>
               <AlertDialogAction onPress={handleConfirmCancel}>
                 <UIText className="text-white">Cancel event</UIText>
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+
+      {/* Reject Booking Request AlertDialog (Android only) */}
+      {Platform.OS === "android" && (
+        <AlertDialog
+          open={showRejectDialog}
+          onOpenChange={(open) => {
+            if (open) {
+              setShowRejectDialog(true);
+              return;
+            }
+            handleCloseRejectDialog();
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader className="items-start">
+              <AlertDialogTitle>
+                <UIText className="text-left text-lg font-semibold">Reject booking request</UIText>
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                <UIText className="text-left text-sm text-muted-foreground">
+                  Rejection reason will be shared with the attendee
+                </UIText>
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+
+            <View>
+              <UIText className="mb-2 text-sm font-medium">Reason for rejection</UIText>
+              <TextInput
+                className="rounded-md border border-[#D1D5DB] bg-white px-3 py-2.5 text-base text-[#111827] dark:border-[#4D4D4D] dark:bg-[#262626] dark:text-white"
+                placeholder="Why are you rejecting?"
+                placeholderTextColor={isDark ? "#636366" : "#9CA3AF"}
+                value={rejectReason}
+                onChangeText={setRejectReason}
+                editable={!isDeclining}
+                autoFocus
+                multiline
+                numberOfLines={3}
+                textAlignVertical="top"
+                style={{ minHeight: 80 }}
+              />
+            </View>
+
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeclining} onPress={handleCloseRejectDialog}>
+                <UIText>Nevermind</UIText>
+              </AlertDialogCancel>
+              <AlertDialogAction
+                disabled={isDeclining}
+                onPress={handleConfirmReject}
+                className="bg-destructive"
+              >
+                <UIText className="text-white">
+                  {isDeclining ? "Rejecting..." : "Reject request"}
+                </UIText>
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/apps/mobile/hooks/useBookings.ts
+++ b/apps/mobile/hooks/useBookings.ts
@@ -13,6 +13,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CACHE_CONFIG, queryKeys } from "@/config/cache.config";
 import { RatingTrigger, requestRating } from "@/hooks/useAppStoreRating";
 import { type Booking, CalComAPIService } from "@/services/calcom";
+import { syncBookingCachesAfterMutation } from "@/utils/booking-cache";
 
 /**
  * Filter options for fetching bookings
@@ -219,14 +220,8 @@ export function useConfirmBooking() {
   return useMutation({
     mutationFn: ({ uid }: { uid: string }) => CalComAPIService.confirmBooking(uid),
     retry: false,
-    onSuccess: (_, variables) => {
-      // Invalidate all booking queries to refetch fresh data
-      queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
-
-      // Also invalidate the specific booking detail
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.bookings.detail(variables.uid),
-      });
+    onSuccess: (updatedBooking) => {
+      syncBookingCachesAfterMutation(queryClient, updatedBooking);
 
       // Request app store rating on first booking confirmation
       requestRating(RatingTrigger.BOOKING_CONFIRMED);
@@ -256,14 +251,8 @@ export function useDeclineBooking() {
     mutationFn: ({ uid, reason }: { uid: string; reason?: string }) =>
       CalComAPIService.declineBooking(uid, reason),
     retry: false,
-    onSuccess: (_, variables) => {
-      // Invalidate all booking queries to refetch fresh data
-      queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
-
-      // Also invalidate the specific booking detail
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.bookings.detail(variables.uid),
-      });
+    onSuccess: (updatedBooking) => {
+      syncBookingCachesAfterMutation(queryClient, updatedBooking);
 
       // Request app store rating on first booking rejection
       requestRating(RatingTrigger.BOOKING_REJECTED);

--- a/apps/mobile/utils/booking-cache.test.js
+++ b/apps/mobile/utils/booking-cache.test.js
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/config/cache.config";
+import * as bookingCache from "@/utils/booking-cache";
+import {
+  bookingMatchesListFilters,
+  getBookingForCacheUpdate,
+  updateBookingCaches,
+  updateBookingListForFilters,
+} from "@/utils/booking-cache";
+
+const futureDate = "2026-12-01T10:00:00.000Z";
+const futureEndDate = "2026-12-01T10:30:00.000Z";
+const pastDate = "2026-01-01T10:00:00.000Z";
+const pastEndDate = "2026-01-01T10:30:00.000Z";
+const now = new Date("2026-06-11T00:00:00.000Z");
+
+function booking(overrides = {}) {
+  return {
+    id: 1,
+    uid: "booking-1",
+    title: "Demo booking",
+    startTime: futureDate,
+    endTime: futureEndDate,
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("booking cache list helpers", () => {
+  test("moves a confirmed future booking out of unconfirmed and into upcoming", () => {
+    const pendingBooking = booking({ status: "pending" });
+    const confirmedBooking = booking({ status: "accepted", eventTypeId: 11 });
+
+    expect(
+      updateBookingListForFilters(
+        [pendingBooking],
+        confirmedBooking,
+        {
+          status: ["unconfirmed"],
+          limit: 50,
+        },
+        now
+      )
+    ).toEqual([]);
+
+    expect(
+      updateBookingListForFilters(
+        [],
+        confirmedBooking,
+        {
+          status: ["upcoming"],
+          limit: 50,
+        },
+        now
+      )
+    ).toEqual([confirmedBooking]);
+  });
+
+  test("treats accepted requires-confirmation bookings as upcoming, not unconfirmed", () => {
+    const confirmedBooking = booking({ status: "accepted", requiresConfirmation: true });
+
+    expect(
+      bookingMatchesListFilters(
+        confirmedBooking,
+        {
+          status: ["unconfirmed"],
+        },
+        now
+      )
+    ).toBe(false);
+
+    expect(
+      bookingMatchesListFilters(
+        confirmedBooking,
+        {
+          status: ["upcoming"],
+        },
+        now
+      )
+    ).toBe(true);
+  });
+
+  test("moves a rejected booking out of unconfirmed and into cancelled-style lists", () => {
+    const pendingBooking = booking({ status: "pending" });
+    const rejectedBooking = booking({ status: "rejected", rejectionReason: "Unavailable" });
+
+    expect(
+      updateBookingListForFilters(
+        [pendingBooking],
+        rejectedBooking,
+        {
+          status: ["unconfirmed"],
+        },
+        now
+      )
+    ).toEqual([]);
+
+    expect(
+      updateBookingListForFilters(
+        [],
+        rejectedBooking,
+        {
+          status: ["cancelled"],
+        },
+        now
+      )
+    ).toEqual([rejectedBooking]);
+  });
+
+  test("keeps existing list-only fields when replacing a cached booking", () => {
+    const cachedBooking = booking({
+      status: "pending",
+      eventType: { id: 11, slug: "intro", title: "Intro call" },
+    });
+    const confirmedBooking = booking({ status: "accepted", eventTypeId: 11 });
+
+    expect(
+      updateBookingListForFilters(
+        [cachedBooking],
+        confirmedBooking,
+        {
+          status: ["upcoming"],
+        },
+        now
+      )
+    ).toEqual([
+      {
+        ...cachedBooking,
+        ...confirmedBooking,
+        eventType: cachedBooking.eventType,
+      },
+    ]);
+  });
+
+  test("matches date and event type filters before inserting", () => {
+    const filteredBooking = booking({ status: "accepted", eventTypeId: 22 });
+
+    expect(
+      bookingMatchesListFilters(
+        filteredBooking,
+        {
+          status: ["upcoming"],
+          eventTypeId: 11,
+        },
+        now
+      )
+    ).toBe(false);
+
+    expect(
+      bookingMatchesListFilters(
+        booking({ status: "accepted", startTime: pastDate, endTime: pastEndDate }),
+        {
+          status: ["past"],
+          eventTypeId: undefined,
+        },
+        now
+      )
+    ).toBe(true);
+  });
+
+  test("prefers cached detail over stale fallback when navigating back", () => {
+    const queryClient = new QueryClient();
+    const pendingBooking = booking({ status: "pending", requiresConfirmation: true });
+    const confirmedBooking = booking({ status: "accepted", requiresConfirmation: true });
+
+    queryClient.setQueryData(queryKeys.bookings.detail(pendingBooking.uid), pendingBooking);
+    updateBookingCaches(queryClient, confirmedBooking);
+
+    expect(getBookingForCacheUpdate(queryClient, pendingBooking.uid, pendingBooking)).toEqual(
+      confirmedBooking
+    );
+  });
+
+  test("syncs mutation results immediately and invalidates bookings for server reconciliation", () => {
+    const queryClient = new QueryClient();
+    const pendingBooking = booking({ status: "pending" });
+    const confirmedBooking = booking({ status: "accepted" });
+    const invalidations = [];
+
+    queryClient.invalidateQueries = (filters) => {
+      invalidations.push(filters);
+      return Promise.resolve();
+    };
+
+    queryClient.setQueryData(queryKeys.bookings.detail(pendingBooking.uid), pendingBooking);
+
+    expect(typeof bookingCache.syncBookingCachesAfterMutation).toBe("function");
+    bookingCache.syncBookingCachesAfterMutation(queryClient, confirmedBooking);
+
+    expect(queryClient.getQueryData(queryKeys.bookings.detail(pendingBooking.uid))).toEqual(
+      confirmedBooking
+    );
+    expect(invalidations).toContainEqual({ queryKey: queryKeys.bookings.all });
+  });
+});

--- a/apps/mobile/utils/booking-cache.ts
+++ b/apps/mobile/utils/booking-cache.ts
@@ -1,0 +1,189 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import { queryKeys } from "@/config/cache.config";
+import type { Booking } from "@/services/calcom";
+
+export interface BookingListCacheFilters {
+  status?: unknown;
+  fromDate?: unknown;
+  toDate?: unknown;
+  eventTypeId?: unknown;
+  [key: string]: unknown;
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getStatusFilters = (status: unknown): string[] => {
+  if (Array.isArray(status)) {
+    return status.filter((value): value is string => typeof value === "string");
+  }
+
+  return typeof status === "string" ? [status] : [];
+};
+
+const getBookingStartTime = (booking: Booking): string => booking.start || booking.startTime || "";
+
+const getBookingEndTime = (booking: Booking): string => booking.end || booking.endTime || "";
+
+const getBookingEventTypeId = (booking: Booking): number | undefined =>
+  booking.eventTypeId ?? booking.eventType?.id;
+
+const getBookingStatus = (booking: Booking): string => booking.status?.toLowerCase() || "";
+
+const isPendingBooking = (booking: Booking): boolean => {
+  const status = getBookingStatus(booking);
+  return status === "pending" || status === "requires_confirmation";
+};
+
+const isCancelledOrRejectedBooking = (booking: Booking): boolean => {
+  const status = getBookingStatus(booking);
+  return status === "cancelled" || status === "rejected";
+};
+
+const isRecurringBooking = (booking: Booking): boolean =>
+  Boolean(booking.recurringBookingUid || booking.recurringEventId);
+
+const getTime = (dateString: unknown): number | null => {
+  if (typeof dateString !== "string" || dateString.length === 0) return null;
+
+  const time = new Date(dateString).getTime();
+  return Number.isNaN(time) ? null : time;
+};
+
+const matchesDateRange = (booking: Booking, filters: BookingListCacheFilters): boolean => {
+  const startTime = getTime(getBookingStartTime(booking));
+  if (startTime === null) return false;
+
+  const fromTime = getTime(filters.fromDate);
+  if (fromTime !== null && startTime < fromTime) return false;
+
+  const toTime = getTime(filters.toDate);
+  if (toTime !== null && startTime > toTime) return false;
+
+  return true;
+};
+
+const bookingMatchesStatusFilter = (booking: Booking, statusFilter: string, now: Date): boolean => {
+  const normalizedStatusFilter = statusFilter.toLowerCase();
+  const status = getBookingStatus(booking);
+  const endTime = getTime(getBookingEndTime(booking));
+  const isPast = endTime !== null && endTime < now.getTime();
+
+  switch (normalizedStatusFilter) {
+    case "upcoming":
+      return !isPast && !isPendingBooking(booking) && !isCancelledOrRejectedBooking(booking);
+    case "unconfirmed":
+      return isPendingBooking(booking);
+    case "past":
+      return isPast && !isCancelledOrRejectedBooking(booking);
+    case "cancelled":
+      return isCancelledOrRejectedBooking(booking);
+    case "recurring":
+      return isRecurringBooking(booking);
+    default:
+      return status === normalizedStatusFilter;
+  }
+};
+
+export const bookingMatchesListFilters = (
+  booking: Booking,
+  filters: BookingListCacheFilters,
+  now = new Date()
+): boolean => {
+  const eventTypeId = filters.eventTypeId;
+  if (typeof eventTypeId === "number" && getBookingEventTypeId(booking) !== eventTypeId) {
+    return false;
+  }
+
+  if (!matchesDateRange(booking, filters)) {
+    return false;
+  }
+
+  const statusFilters = getStatusFilters(filters.status);
+  if (statusFilters.length === 0) {
+    return true;
+  }
+
+  return statusFilters.some((status) => bookingMatchesStatusFilter(booking, status, now));
+};
+
+const mergeBookingForCache = (
+  currentBooking: Booking | undefined,
+  updatedBooking: Booking
+): Booking => {
+  if (!currentBooking) return updatedBooking;
+
+  const mergedEventType =
+    currentBooking.eventType && updatedBooking.eventType
+      ? {
+          ...currentBooking.eventType,
+          ...updatedBooking.eventType,
+        }
+      : (updatedBooking.eventType ?? currentBooking.eventType);
+
+  return {
+    ...currentBooking,
+    ...updatedBooking,
+    eventType: mergedEventType,
+  };
+};
+
+export const updateBookingListForFilters = (
+  currentBookings: Booking[] | undefined,
+  updatedBooking: Booking,
+  filters: BookingListCacheFilters,
+  now = new Date()
+): Booking[] | undefined => {
+  if (!currentBookings) return currentBookings;
+
+  const currentBooking = currentBookings.find((booking) => booking.uid === updatedBooking.uid);
+  const bookingForCache = mergeBookingForCache(currentBooking, updatedBooking);
+  const bookingsWithoutUpdated = currentBookings.filter(
+    (booking) => booking.uid !== updatedBooking.uid
+  );
+
+  if (!bookingMatchesListFilters(bookingForCache, filters, now)) {
+    return bookingsWithoutUpdated;
+  }
+
+  return [...bookingsWithoutUpdated, bookingForCache];
+};
+
+const getBookingListFiltersFromQueryKey = (queryKey: QueryKey): BookingListCacheFilters | null => {
+  const [resource, scope, filters] = queryKey;
+  if (resource !== "bookings" || scope !== "list") {
+    return null;
+  }
+
+  return isObject(filters) ? filters : {};
+};
+
+export const updateBookingCaches = (queryClient: QueryClient, updatedBooking: Booking): void => {
+  queryClient.setQueryData(queryKeys.bookings.detail(updatedBooking.uid), updatedBooking);
+
+  const listQueries = queryClient.getQueryCache().findAll({ queryKey: queryKeys.bookings.lists() });
+
+  for (const query of listQueries) {
+    const filters = getBookingListFiltersFromQueryKey(query.queryKey);
+    if (!filters) continue;
+
+    queryClient.setQueryData<Booking[]>(query.queryKey, (currentBookings) =>
+      updateBookingListForFilters(currentBookings, updatedBooking, filters)
+    );
+  }
+};
+
+export const syncBookingCachesAfterMutation = (
+  queryClient: QueryClient,
+  updatedBooking: Booking
+): void => {
+  updateBookingCaches(queryClient, updatedBooking);
+  void queryClient.invalidateQueries({ queryKey: queryKeys.bookings.all });
+};
+
+export const getBookingForCacheUpdate = (
+  queryClient: QueryClient,
+  bookingUid: string,
+  fallbackBooking: Booking | null | undefined
+): Booking | null | undefined =>
+  queryClient.getQueryData<Booking>(queryKeys.bookings.detail(bookingUid)) ?? fallbackBooking;


### PR DESCRIPTION
## What changed

Restores the mobile booking-request detail actions and booking-list cache sync follow-ups onto `main`.

This reapplies the mobile code from the tested top stacked branch after PRs 114 and 115 were merged into their stacked base branches instead of `main`.

## Why

`main` only received PR 113 (`fix(mobile): open booking notifications on detail`). The follow-up request-action UI and cache-sync changes were marked merged by GitHub, but their bases were `codex/booking-request-detail-actions` and `codex/booking-detail-request-actions`, so they did not land on `main`.

## Validation

- `bun test 'apps/mobile/components/screens/BookingDetailRequestActions.test.js' 'apps/mobile/utils/booking-cache.test.js'`
- `bunx biome check --write` on the touched mobile files
- `bun --filter mobile typecheck`
- `git diff --check`
- Verified `apps/mobile` matches `upstream/codex/booking-list-sync-after-action` exactly
