### PR TITLE
feat(mcp-server): constrain redirect URIs at dynamic client registration

### DIFF
--- a/apps/mcp-server/.env.example
+++ b/apps/mcp-server/.env.example
@@ -34,3 +34,10 @@ CAL_API_KEY=cal_live_xxxx
 # Rate limiting for OAuth endpoints (token bucket per IP)
 # RATE_LIMIT_WINDOW_MS=60000
 # RATE_LIMIT_MAX=30
+
+# Comma-separated allowlist of hostnames permitted as non-loopback https redirect
+# URIs at dynamic client registration. Loopback (localhost / 127.0.0.0/8 / ::1) is
+# always allowed; cleartext http to non-loopback hosts is always rejected. When
+# unset, any https host is accepted (open DCR) but logged. Set this in production
+# to the hosts of trusted MCP clients, e.g. claude.ai,chatgpt.com
+# ALLOWED_REDIRECT_HOSTS=claude.ai,chatgpt.com

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -60,6 +60,7 @@ cp apps/mcp-server/.env.example apps/mcp-server/.env
 | `DATABASE_PATH` | No | `mcp-server.db` | SQLite database file path |
 | `RATE_LIMIT_WINDOW_MS` | No | `60000` | Rate limit window in ms (per IP) |
 | `RATE_LIMIT_MAX` | No | `30` | Max OAuth requests per window per IP |
+| `ALLOWED_REDIRECT_HOSTS` | No | — | Comma-separated allowlist of hostnames for non-loopback `https` redirect URIs at client registration. Loopback is always allowed; non-loopback cleartext `http` is always rejected. When unset, any `https` host is accepted (open DCR) but logged. |
 | `OPENAI_APPS_CHALLENGE_TOKEN` | No | — | Token served at `/.well-known/openai-apps-challenge` for OpenAI Apps domain verification. When unset, the endpoint returns 404. |
 
 ## Transport Modes
@@ -177,6 +178,7 @@ The server acts as an intermediary: it issues its own access tokens to MCP clien
 - Auth codes are single-use
 - Expired tokens are cleaned up automatically every 5 minutes
 - In-process rate limiting on all OAuth endpoints (token bucket per IP, configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX`)
+- Redirect URIs registered via dynamic client registration are constrained: loopback (`localhost` / `127.0.0.0/8` / `::1`) is always allowed, cleartext `http` to non-loopback hosts is always rejected, and non-loopback `https` hosts can be restricted to a vetted allowlist via `ALLOWED_REDIRECT_HOSTS` (recommended in production to limit the open-DCR phishing surface)
 
 ## Tools (52)
 

--- a/apps/mcp-server/src/auth/oauth-handlers.test.ts
+++ b/apps/mcp-server/src/auth/oauth-handlers.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+
+// oauth-handlers transitively imports the token store, which creates a Postgres
+// pool at import time. Mock it so these pure-function tests need no database.
+vi.mock("@vercel/postgres", () => {
+  const sql = vi.fn(async () => ({ rows: [], rowCount: 0 }));
+  const pool = { sql, connect: vi.fn(), end: vi.fn() };
+  return { createPool: () => pool, sql, db: pool };
+});
+
+const { isLoopbackHost, validateRedirectUri } = await import("./oauth-handlers.js");
+type RedirectUriPolicy = import("./oauth-handlers.js").RedirectUriPolicy;
+
+const OPEN: RedirectUriPolicy = { allowedHosts: [] };
+const ALLOWLIST: RedirectUriPolicy = { allowedHosts: ["claude.ai", "chatgpt.com"] };
+
+describe("isLoopbackHost", () => {
+  it("recognizes localhost and the 127.0.0.0/8 block", () => {
+    expect(isLoopbackHost("localhost")).toBe(true);
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackHost("127.0.0.2")).toBe(true);
+    expect(isLoopbackHost("127.255.255.255")).toBe(true);
+  });
+
+  it("recognizes IPv6 loopback with or without brackets", () => {
+    expect(isLoopbackHost("::1")).toBe(true);
+    expect(isLoopbackHost("[::1]")).toBe(true);
+  });
+
+  it("rejects external and look-alike hosts", () => {
+    expect(isLoopbackHost("evil.com")).toBe(false);
+    expect(isLoopbackHost("127.0.0.1.evil.com")).toBe(false);
+    expect(isLoopbackHost("128.0.0.1")).toBe(false);
+  });
+});
+
+describe("validateRedirectUri", () => {
+  it("allows loopback over http (desktop clients)", () => {
+    expect(validateRedirectUri("http://localhost:8765/callback", OPEN).ok).toBe(true);
+    expect(validateRedirectUri("http://127.0.0.5:9000/cb", OPEN).ok).toBe(true);
+    expect(validateRedirectUri("http://[::1]:9000/cb", OPEN).ok).toBe(true);
+  });
+
+  it("rejects cleartext http to non-loopback hosts", () => {
+    const res = validateRedirectUri("http://evil.com/callback", OPEN);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("https");
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    expect(validateRedirectUri("ftp://example.com/cb", OPEN).ok).toBe(false);
+    expect(validateRedirectUri("javascript:alert(1)", OPEN).ok).toBe(false);
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(validateRedirectUri("not a url", OPEN).ok).toBe(false);
+  });
+
+  it("with no allowlist, accepts any https host (open DCR default)", () => {
+    expect(validateRedirectUri("https://evil.com/callback", OPEN).ok).toBe(true);
+  });
+
+  it("with an allowlist, rejects https hosts not on it", () => {
+    const res = validateRedirectUri("https://evil.com/callback", ALLOWLIST);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("not in the allowed list");
+  });
+
+  it("with an allowlist, accepts https hosts on it (case-insensitive)", () => {
+    expect(validateRedirectUri("https://claude.ai/callback", ALLOWLIST).ok).toBe(true);
+    expect(validateRedirectUri("https://Claude.AI/callback", ALLOWLIST).ok).toBe(true);
+  });
+
+  it("with an allowlist, still allows loopback regardless", () => {
+    expect(validateRedirectUri("http://localhost:8765/callback", ALLOWLIST).ok).toBe(true);
+  });
+});

--- a/apps/mcp-server/src/auth/oauth-handlers.ts
+++ b/apps/mcp-server/src/auth/oauth-handlers.ts
@@ -35,6 +35,62 @@ export interface OAuthConfig {
 
 const MAX_BODY_SIZE = 1024 * 1024; // 1 MB
 
+/** Policy controlling which redirect URIs may be registered via Dynamic Client Registration. */
+export interface RedirectUriPolicy {
+  /**
+   * Lowercased exact hostnames permitted for non-loopback `https` redirect URIs.
+   * When empty, any `https` host is accepted (loopback is always accepted, and
+   * cleartext `http` to non-loopback hosts is always rejected).
+   */
+  allowedHosts: string[];
+}
+
+/**
+ * Whether a hostname refers to the loopback interface (the victim's own machine).
+ * Codes registered against these never leave the user's device, so they are safe
+ * for public/native clients regardless of the allowlist. Covers `localhost`, the
+ * entire IPv4 `127.0.0.0/8` block, and IPv6 `::1`.
+ */
+export function isLoopbackHost(hostname: string): boolean {
+  const h = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (h === "localhost" || h === "::1") return true;
+  return /^127(?:\.\d{1,3}){3}$/.test(h);
+}
+
+/**
+ * Validate a single redirect URI against the registration policy.
+ *
+ * Rules (defense against the open-DCR confused-deputy exfiltration path):
+ *   - Must be a valid `http`/`https` URL.
+ *   - Loopback hosts are always allowed (any scheme) — the code stays on-device.
+ *   - Non-loopback hosts must use `https` (no cleartext exfiltration).
+ *   - When `policy.allowedHosts` is non-empty, non-loopback hosts must match it exactly.
+ */
+export function validateRedirectUri(
+  uri: string,
+  policy: RedirectUriPolicy,
+): { ok: true } | { ok: false; reason: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return { ok: false, reason: "not a valid URL" };
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return { ok: false, reason: `invalid scheme: ${parsed.protocol} — only http and https are allowed` };
+  }
+  if (isLoopbackHost(parsed.hostname)) {
+    return { ok: true };
+  }
+  if (parsed.protocol !== "https:") {
+    return { ok: false, reason: "non-loopback redirect_uri must use https" };
+  }
+  if (policy.allowedHosts.length > 0 && !policy.allowedHosts.includes(parsed.hostname.toLowerCase())) {
+    return { ok: false, reason: `redirect_uri host '${parsed.hostname.toLowerCase()}' is not in the allowed list` };
+  }
+  return { ok: true };
+}
+
 /** Read the full request body as a string (capped at 1 MB). */
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -65,6 +121,7 @@ function jsonResponse(res: ServerResponse, status: number, body: unknown): void 
 export async function handleRegister(
   req: IncomingMessage,
   res: ServerResponse,
+  policy: RedirectUriPolicy,
 ): Promise<void> {
   if (req.method !== "POST") {
     jsonResponse(res, 405, { error: "method_not_allowed" });
@@ -94,18 +151,25 @@ export async function handleRegister(
       jsonResponse(res, 400, { error: "invalid_request", error_description: "Each redirect_uri must be a string" });
       return;
     }
-    try {
-      const parsed = new URL(uri);
-      if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
-        jsonResponse(res, 400, { error: "invalid_request", error_description: `Invalid redirect_uri scheme: ${parsed.protocol} — only http and https are allowed` });
-        return;
-      }
-      redirectUris.push(uri);
-    } catch {
-      jsonResponse(res, 400, { error: "invalid_request", error_description: `Invalid redirect_uri: not a valid URL` });
+    const check = validateRedirectUri(uri, policy);
+    if (!check.ok) {
+      jsonResponse(res, 400, { error: "invalid_request", error_description: `Invalid redirect_uri: ${check.reason}` });
       return;
     }
+    redirectUris.push(uri);
   }
+
+  // Surface external (non-loopback) registrations: with no allowlist configured these
+  // are still accepted, but they are the surface a confused-deputy phishing attack uses.
+  if (policy.allowedHosts.length === 0) {
+    for (const uri of redirectUris) {
+      const host = new URL(uri).hostname;
+      if (!isLoopbackHost(host)) {
+        logger.warn("Registered client with non-loopback redirect_uri and no allowlist configured", { host });
+      }
+    }
+  }
+
   const clientName = typeof body.client_name === "string" ? body.client_name : undefined;
 
   const client = await createRegisteredClient(redirectUris, clientName);

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -60,6 +60,23 @@ const httpSchema = baseSchema.extend({
   maxSessions: z.coerce.number().int().positive().default(10_000),
   sessionIdleTimeoutMs: z.coerce.number().int().positive().default(30 * 60 * 1000),
   maxRegisteredClients: z.coerce.number().int().positive().default(10_000),
+  /**
+   * Comma-separated allowlist of hostnames permitted for non-loopback `https`
+   * redirect URIs at Dynamic Client Registration. Loopback redirect URIs are
+   * always allowed; cleartext `http` to non-loopback hosts is always rejected.
+   * When empty, any `https` host is accepted (open DCR) but logged.
+   */
+  allowedRedirectHosts: z
+    .string()
+    .optional()
+    .transform((val) =>
+      val
+        ? val
+            .split(",")
+            .map((h) => h.trim().toLowerCase())
+            .filter(Boolean)
+        : [],
+    ),
   trustProxy: z
     .enum(["true", "false", "1", "0"])
     .transform((val) => val === "true" || val === "1")
@@ -101,6 +118,7 @@ function readEnv(): Record<string, unknown> {
     maxSessions: process.env.MAX_SESSIONS || undefined,
     sessionIdleTimeoutMs: process.env.SESSION_IDLE_TIMEOUT_MS || undefined,
     maxRegisteredClients: process.env.MAX_REGISTERED_CLIENTS || undefined,
+    allowedRedirectHosts: process.env.ALLOWED_REDIRECT_HOSTS || undefined,
     trustProxy: process.env.TRUST_PROXY || undefined,
     corsOrigin: process.env.CORS_ORIGIN || undefined,
     fetchTimeoutMs: process.env.FETCH_TIMEOUT_MS || undefined,

--- a/apps/mcp-server/src/http-server.ts
+++ b/apps/mcp-server/src/http-server.ts
@@ -30,6 +30,8 @@ export interface HttpServerConfig {
   maxSessions?: number;
   sessionIdleTimeoutMs?: number;
   maxRegisteredClients?: number;
+  /** Allowlist of hostnames permitted for non-loopback https redirect URIs (empty = any https host). */
+  allowedRedirectHosts?: string[];
   corsOrigin?: string;
   shutdownTimeoutMs?: number;
   /**
@@ -70,6 +72,7 @@ export async function startHttpServer(
   const maxSessions = config.maxSessions ?? (Number(process.env.MAX_SESSIONS) || 10_000);
   const sessionIdleTimeoutMs = config.sessionIdleTimeoutMs ?? (Number(process.env.SESSION_IDLE_TIMEOUT_MS) || 30 * 60 * 1000);
   const maxRegisteredClients = config.maxRegisteredClients ?? (Number(process.env.MAX_REGISTERED_CLIENTS) || 10_000);
+  const redirectUriPolicy = { allowedHosts: config.allowedRedirectHosts ?? [] };
   const corsOrigin = config.corsOrigin ?? process.env.CORS_ORIGIN;
   const shutdownTimeoutMs = config.shutdownTimeoutMs ?? (Number(process.env.SHUTDOWN_TIMEOUT_MS) || 10_000);
   const openaiAppsChallengeToken = config.openaiAppsChallengeToken ?? process.env.OPENAI_APPS_CHALLENGE_TOKEN;
@@ -204,7 +207,7 @@ export async function startHttpServer(
           res.end(JSON.stringify({ error: "server_error", error_description: "Maximum number of registered clients reached" }));
           return;
         }
-        await handleRegister(req, res);
+        await handleRegister(req, res, redirectUriPolicy);
         return;
       }
       if (url.pathname === "/oauth/authorize" && req.method === "GET") {

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -33,6 +33,7 @@ async function main(): Promise<void> {
       maxSessions: httpConfig.maxSessions,
       sessionIdleTimeoutMs: httpConfig.sessionIdleTimeoutMs,
       maxRegisteredClients: httpConfig.maxRegisteredClients,
+      allowedRedirectHosts: httpConfig.allowedRedirectHosts,
       corsOrigin: httpConfig.corsOrigin,
       shutdownTimeoutMs: httpConfig.shutdownTimeoutMs,
       openaiAppsChallengeToken: httpConfig.openaiAppsChallengeToken,

--- a/apps/mcp-server/src/vercel-handler.ts
+++ b/apps/mcp-server/src/vercel-handler.ts
@@ -163,7 +163,7 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
       jsonError(res, 503, "server_error", "Maximum number of registered clients reached");
       return;
     }
-    await handleRegister(req, res);
+    await handleRegister(req, res, { allowedHosts: config.allowedRedirectHosts });
     return;
   }
   if (url.pathname === "/oauth/authorize" && req.method === "GET") {


### PR DESCRIPTION
## Summary

Open dynamic client registration (RFC 7591) is intentional for MCP clients, but the `/oauth/register` endpoint accepted **arbitrary** redirect URIs — only the scheme was checked. That leaves the open-DCR confused-deputy phishing surface wide open: an attacker can register an external `https` (or even cleartext `http`) redirect host, phish a logged-in Cal.com user through the proxy, and receive the victim's authorization code.

This PR constrains which redirect URIs may be registered, enforced in `handleRegister`:

- **Loopback** (`localhost` / `127.0.0.0/8` / `::1`) — always allowed, any scheme. The code never leaves the user's device, and desktop/native MCP clients rely on `http://127.0.0.1:<port>`.
- **Non-loopback** — must use `https` (no cleartext code exfiltration).
- **Non-loopback `https`** — can be restricted to a vetted allowlist via the new `ALLOWED_REDIRECT_HOSTS` env var (comma-separated hostnames). When unset, any `https` host is still accepted (open DCR preserved, non-breaking) but logged so operators can see the surface.

Wired through both entrypoints: the long-running HTTP server (`http-server.ts` → `index.ts`) and the Vercel serverless handler (`vercel-handler.ts`).

## Notes / scope

- This is **defense-in-depth (the "Fix 2" hardening)**. It is opt-in: with `ALLOWED_REDIRECT_HOSTS` unset, an attacker can still register an external `https` host. Set the allowlist in production to actually close the exfiltration route.
- It does **not** add a per-client consent screen at the proxy ("Fix 1"), which is the complete confused-deputy mitigation. Tracked as a follow-up.
- The reported `initial_access_token` requirement was intentionally **not** implemented — it would break legitimate open DCR for MCP clients.

## Config

```
ALLOWED_REDIRECT_HOSTS=claude.ai,chatgpt.com
```
Bare, comma-separated hostnames (no scheme/port/path). Exact host match, case-insensitive. Loopback never needs listing. Documented in `README.md` and `.env.example`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Full suite: 296 tests pass, incl. 11 new cases in `oauth-handlers.test.ts` covering loopback variants, cleartext-http rejection, scheme/URL validation, and allowlist enforcement (case-insensitivity + loopback bypassing the allowlist)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/companion/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->