### PR TITLE
feat(mcp-server): add org membership and routing form OAuth scopes

### DIFF
--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -53,12 +53,16 @@ const httpSchema = baseSchema.extend({
   calOAuthScopes: z
     .string()
     .default(
-      "EVENT_TYPE_READ EVENT_TYPE_WRITE BOOKING_READ BOOKING_WRITE SCHEDULE_READ SCHEDULE_WRITE APPS_READ APPS_WRITE PROFILE_READ PROFILE_WRITE",
+      "EVENT_TYPE_READ EVENT_TYPE_WRITE BOOKING_READ BOOKING_WRITE SCHEDULE_READ SCHEDULE_WRITE APPS_READ APPS_WRITE PROFILE_READ PROFILE_WRITE ORG_MEMBERSHIP_READ ORG_MEMBERSHIP_WRITE ORG_ROUTING_FORM_READ"
     ),
   rateLimitWindowMs: z.coerce.number().int().positive().default(60_000),
   rateLimitMax: z.coerce.number().int().positive().default(30),
   maxSessions: z.coerce.number().int().positive().default(10_000),
-  sessionIdleTimeoutMs: z.coerce.number().int().positive().default(30 * 60 * 1000),
+  sessionIdleTimeoutMs: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(30 * 60 * 1000),
   maxRegisteredClients: z.coerce.number().int().positive().default(10_000),
   trustProxy: z
     .enum(["true", "false", "1", "0"])
@@ -123,7 +127,9 @@ export function loadConfig(): AppConfig {
   if (transport === "http") {
     const result = httpSchema.safeParse(raw);
     if (!result.success) {
-      const issues = result.error.issues.map((i) => `  ${i.path.join(".")}: ${i.message}`).join("\n");
+      const issues = result.error.issues
+        .map((i) => `  ${i.path.join(".")}: ${i.message}`)
+        .join("\n");
       throw new Error(`Invalid HTTP mode configuration:\n${issues}`);
     }
     return result.data;


### PR DESCRIPTION
## Summary

The default `calOAuthScopes` in `config.ts` was missing org-level scopes, causing 403 errors for org admins when calling org tools — even though the user has ORG_ADMIN role, the OAuth token itself didn't request these permissions.

Added to the default scope string:
- `ORG_MEMBERSHIP_READ` — unblocks `get_org_memberships`, `get_org_membership`
- `ORG_MEMBERSHIP_WRITE` — unblocks `create_org_membership`, `update_org_membership`, `delete_org_membership`
- `ORG_ROUTING_FORM_READ` — unblocks `get_org_routing_forms`, `get_org_routing_form_responses`

**Note:** Existing users must re-authorize to pick up the new scopes — tokens issued before this change retain their original scope set.

Link to Devin session: https://app.devin.ai/sessions/a8c331fd09844fae994dba75204fceaf