### PR TITLE
docs(agents): add mobile testing rules

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -10,6 +10,13 @@
 
 - [api-mcp-openapi-contract](rules/api-mcp-openapi-contract.md) — align `apps/mcp-server` tools with the Cal.com API v2 OpenAPI contract.
 
+### Testing
+
+- [testing-mobile](rules/testing-mobile.md) — choose the right test layer for `apps/mobile` changes.
+- [testing-mobile-jest](rules/testing-mobile-jest.md) — write Expo/Jest and React Native Testing Library tests for `apps/mobile`.
+- [testing-mobile-maestro](rules/testing-mobile-maestro.md) — write Maestro E2E flows for installed mobile app journeys.
+- [testing-mobile-ai-authoring](rules/testing-mobile-ai-authoring.md) — use AI to generate mobile tests safely.
+
 ### Reference
 
 - [reference-local-cal-api](rules/reference-local-cal-api.md) — how to locate the local `/cal` API v2 OpenAPI spec.

--- a/.agents/rules/testing-mobile-ai-authoring.md
+++ b/.agents/rules/testing-mobile-ai-authoring.md
@@ -1,0 +1,105 @@
+---
+title: Use AI to Author Companion Mobile Tests Safely
+impact: MEDIUM
+impactDescription: Helps developers and agents generate useful tests without accepting brittle output
+tags: testing, mobile, ai, jest, maestro
+---
+
+# Use AI to Author Companion Mobile Tests Safely
+
+**Impact: MEDIUM (helps developers and agents generate useful tests without
+accepting brittle output)**
+
+Use this rule when a developer or AI agent uses prompts to generate tests for
+`apps/mobile`. AI can help people who are new to Jest or Maestro, but generated
+tests still need repo context, deterministic data, and verification.
+
+## Instructions for AI agents
+
+If you are the AI agent receiving one of these prompts:
+
+1. Read [testing-mobile](testing-mobile.md) first, then read
+   [testing-mobile-jest](testing-mobile-jest.md) or
+   [testing-mobile-maestro](testing-mobile-maestro.md) based on the requested
+   layer.
+2. Inspect the repo context before generating tests.
+3. Ask for missing secrets, devices, or seeded data only when the test cannot be
+   designed without them.
+4. Explain the test layer choice before writing the test.
+5. Include the verification command with the generated test.
+6. If the repo lacks the necessary test runner, config, or scripts, say that and
+   propose the smallest setup change instead of inventing commands.
+7. When generating Maestro flows, use Maestro MCP for screen inspection,
+   selector discovery, flow prototyping, and debugging when it is available.
+   Do not let MCP output replace repo-aware test design or code review.
+
+## Jest prompt template
+
+Give the agent:
+
+- The changed file or PR diff.
+- The nearest existing tests for the same area.
+- The behavior that should be protected.
+- Any relevant hooks, service functions, cache keys, or native modules.
+
+```text
+Write or update Jest tests for this apps/mobile change.
+
+Context:
+- Changed files: <paths or diff>
+- Existing nearby tests: <paths>
+- Behavior to prove: <specific user-visible or logic behavior>
+
+Requirements:
+- Use jest-expo and @testing-library/react-native patterns.
+- Do not create new bun:test tests for apps/mobile.
+- Do not use DOM-only React Testing Library APIs.
+- Mock native modules, router boundaries, network calls, and storage explicitly.
+- Prefer behavior assertions over implementation details.
+- Explain why Jest is the right layer instead of Maestro.
+- Include the exact command I should run to verify the test.
+```
+
+## Maestro prompt template
+
+Give the agent:
+
+- The user journey to cover.
+- The target platform or whether the flow must run on both iOS and Android.
+- The app IDs from `apps/mobile/app.json`.
+- Stable text, accessibility labels, or test IDs already present.
+- Any login, seed data, or backend assumptions.
+
+```text
+Write or update a Maestro flow for this apps/mobile journey.
+
+Context:
+- Journey: <start screen -> action -> expected result>
+- Platform: <iOS, Android, or both>
+- App IDs: iOS com.cal.companion, Android com.calcom.companion
+- Existing selectors or screen text: <paste from inspect_screen when available>
+
+Requirements:
+- Keep the flow focused on one critical user journey.
+- Use stable testID/accessibility selectors where available.
+- Use Maestro MCP inspect_screen output when available before choosing
+  selectors.
+- Use visible text only for user-visible copy or native dialogs.
+- Avoid index selectors unless there is no stable alternative.
+- Use platform branches for native iOS/Android differences.
+- Include the exact local or cloud command I should run to verify the flow.
+```
+
+## Acceptance checklist
+
+Before accepting AI-generated tests, check:
+
+1. The agent explained why the test belongs in Jest or Maestro.
+2. The test can run deterministically without private local state.
+3. Mobile unit/component tests use Jest patterns, not `bun:test`.
+4. React Native tests do not import DOM-only testing utilities.
+5. Maestro MCP is used only for inspection, authoring assistance, and
+   debugging, not for deciding the product coverage strategy.
+6. Maestro selectors are copied from code or `inspect_screen`, not guessed from
+   screenshots.
+7. The verification command exists in the repo or is added in the same PR.

--- a/.agents/rules/testing-mobile-jest.md
+++ b/.agents/rules/testing-mobile-jest.md
@@ -1,0 +1,100 @@
+---
+title: Write Companion Mobile Jest Tests with Expo and React Native Testing Library
+impact: HIGH
+impactDescription: Keeps mobile logic and component behavior covered by fast deterministic tests
+tags: testing, mobile, expo, react-native, jest, jest-expo
+---
+
+# Write Companion Mobile Jest Tests with Expo and React Native Testing Library
+
+**Impact: HIGH (keeps mobile logic and component behavior covered by fast
+deterministic tests)**
+
+Use this rule when adding or updating unit and component tests for `apps/mobile`.
+Expo's documented unit-test path is **Jest with `jest-expo`**. Component tests
+should use **`@testing-library/react-native`**, not DOM-focused
+`@testing-library/react`.
+
+Jest is the target runner for mobile unit/component tests. Bun is still the repo
+package manager, but agents must not create new `bun:test` mobile tests. If a
+mobile area still has `bun:test` coverage, migrate that coverage to Jest when
+working on the Jest foundation or call out the migration gap explicitly.
+
+## Agent checklist
+
+Before writing Jest tests:
+
+1. Inspect `apps/mobile/package.json` and nearby test files. Do not assume the
+   Jest runner, config, or scripts exist until they are present in the repo.
+2. Find the smallest behavior that needs protection.
+3. Prefer a pure function test when the behavior is logic-only.
+4. Use React Native Testing Library only when rendering the component adds real
+   confidence.
+5. Mock native modules, storage, router boundaries, network calls, and time
+   explicitly.
+6. Run the exact verification command for the changed tests. If the command does
+   not exist yet, add it in the same PR or report that setup is missing.
+
+When setting up the Jest foundation, convert the existing high-value mobile
+`bun:test` files instead of preserving a long-term second runner. A temporary
+dual-runner state is acceptable only as an explicit migration step.
+
+## What belongs in Jest
+
+Prefer Jest for:
+
+- Pure logic, formatting, date math, validation, filtering, and parser helpers.
+- API payload construction and response normalization.
+- React Query cache updates, mutation side effects, and optimistic UI logic.
+- Booking action visibility or enablement rules.
+- Component behavior that can be rendered with React Native Testing Library.
+
+Do not push these cases into Maestro unless the behavior only appears in the
+installed app or depends on real navigation/native controls.
+
+## React Native Testing Library expectations
+
+When adding component tests:
+
+1. Put tests near the code they cover unless a local pattern says otherwise.
+2. Prefer user-observable behavior over internal state or implementation details.
+3. Query components by role, label, text, or test ID in that order.
+4. Use `userEvent` or React Native Testing Library interactions for user actions.
+5. Clear mocks between tests so one test cannot leak state into another.
+6. Keep snapshots small; avoid large UI snapshots as the main proof.
+
+**Incorrect (tests implementation details and browser-only tooling):**
+
+```typescript
+import { render, screen } from "@testing-library/react";
+
+expect(component.state.isSaving).toBe(false);
+expect(screen.getByTestId("save-button")).toBeInTheDocument();
+```
+
+**Correct (tests React Native behavior through accessible UI):**
+
+```typescript
+import { render, screen, userEvent } from "@testing-library/react-native";
+
+const user = userEvent.setup();
+render(<SaveButton onSave={onSave} />);
+
+await user.press(screen.getByRole("button", { name: "Save" }));
+
+expect(onSave).toHaveBeenCalledTimes(1);
+```
+
+## Mocking expectations
+
+Mock only what crosses the test boundary:
+
+- Native modules such as SecureStore, notifications, haptics, web browser, and
+  platform APIs.
+- Expo Router/navigation boundaries when the test is not about routing itself.
+- Network calls and Cal.com API services.
+- Async storage, query persistence, and time-sensitive behavior.
+
+Avoid mocks that replace the component under test with a simpler fake surface.
+If a component is hard to test without broad mocks, first look for extractable
+logic that can be covered by a pure Jest test.

--- a/.agents/rules/testing-mobile-maestro.md
+++ b/.agents/rules/testing-mobile-maestro.md
@@ -1,0 +1,142 @@
+---
+title: Write Companion Mobile Maestro E2E Flows
+impact: HIGH
+impactDescription: Keeps critical installed-app journeys stable across iOS and Android
+tags: testing, mobile, expo, react-native, maestro, e2e
+---
+
+# Write Companion Mobile Maestro E2E Flows
+
+**Impact: HIGH (keeps critical installed-app journeys stable across iOS and
+Android)**
+
+Use this rule when adding or updating Maestro flows for `apps/mobile`. Maestro
+should cover critical user journeys in the installed app, not every logic branch
+that Jest can prove faster.
+
+## Agent checklist
+
+Before writing Maestro flows:
+
+1. Inspect `apps/mobile/app.json`, existing flow files, and run scripts. Do not
+   assume Maestro is wired until the repo contains the flow folder and scripts.
+2. Use the Maestro MCP server's `inspect_screen` tool, when available, or
+   code-level `testID`/accessibility labels for selectors. Do not guess
+   selectors from screenshots.
+3. Decide whether the flow must run on iOS, Android, or both.
+4. Keep the flow focused on one critical journey.
+5. Use platform branches for real native differences.
+6. Run the exact local or cloud verification command. If a simulator, emulator,
+   app binary, seed data, or cloud credential is missing, report that blocker.
+
+## Using Maestro MCP
+
+Use the Maestro MCP server as an authoring and debugging assistant, not as the
+source of product test strategy.
+
+Prefer Maestro MCP for:
+
+- Inspecting the current screen hierarchy before choosing selectors.
+- Copying exact visible text, accessibility labels, and IDs from the running
+  app.
+- Prototyping a focused YAML flow against a simulator or emulator.
+- Validating flow syntax and reproducing failures locally.
+- Debugging iOS/Android selector or native-dialog differences.
+
+Do not use Maestro MCP to invent broad E2E coverage, guess app state, choose
+business-critical journeys without repo context, or accept generated YAML
+without code review.
+
+## Learning references
+
+Use Maestro's official examples overview when a flow needs a pattern that is not
+obvious from the command reference: https://docs.maestro.dev/examples.
+
+The examples are useful for learning patterns such as native Android system
+interactions, onboarding forms, nested flows, scrolling, clipboard checks, and
+JavaScript helpers. Do not copy app-specific example flows into Companion.
+Translate only the relevant pattern into a small, deterministic flow for
+`apps/mobile`.
+
+## What belongs in Maestro
+
+Prefer Maestro for:
+
+- App launch, authentication/session readiness, and tab navigation.
+- Cross-screen flows such as Bookings list -> detail -> action sheet.
+- Event type, availability, and settings journeys that depend on navigation,
+  native controls, or installed app behavior.
+- iOS/Android parity checks where platform-specific files or native UI are used.
+
+Do not add Maestro flows for tiny edge cases that Jest can prove faster and more
+deterministically.
+
+## App IDs and deep links
+
+Use the app IDs from `apps/mobile/app.json`:
+
+- iOS bundle ID: `com.cal.companion`.
+- Android package: `com.calcom.companion`.
+
+For cross-platform flows, prefer passing the app ID through the runner:
+
+```yaml
+appId: ${APP_ID}
+---
+- launchApp
+```
+
+Deep links should use app schemes from `apps/mobile/app.json`, such as
+`calcom://...` or `expo-wxt-app://...`, not the bundle ID or package name.
+
+## Selector expectations
+
+Prefer stable `testID` or accessibility selectors for repeated app elements. Use
+visible text for native dialogs because app-level test IDs cannot target system
+UI. Avoid index selectors unless there is no stable alternative.
+
+If a critical flow needs a stable selector and the app does not expose one, add
+a `testID` or accessibility label in app code instead of using a fragile
+text/index selector. Add these hooks for repeated controls or critical journey
+steps, not random one-off edge cases.
+
+When selector syntax is unclear, check Maestro's official selector reference:
+https://docs.maestro.dev/reference/selectors. Use it for supported selector
+types and composition rules; still prefer selectors copied from code or
+`inspect_screen` over guessed values.
+
+**Incorrect (fragile index selector and platform assumption):**
+
+```yaml
+appId: com.cal.companion
+---
+- launchApp
+- tapOn:
+    text: "Edit"
+    index: 1
+```
+
+**Correct (stable selector supplied by app code or screen inspection):**
+
+```yaml
+appId: ${APP_ID}
+---
+- launchApp
+- tapOn:
+    id: "booking-actions-button"
+```
+
+## iOS and Android gotchas
+
+Mobile E2E tests must account for native storage and routing behavior:
+
+- `launchApp.clearState` does not clear iOS Keychain data. Tokens stored through
+  SecureStore can survive app state resets, so do not assume iOS starts logged
+  out after `clearState`.
+- Add or use an auth/session-ready marker before Maestro interacts with
+  authenticated tabs. Cold starts can render after the test runner is ready.
+- Use `runFlow.when.platform` for iOS/Android differences instead of pretending
+  native controls behave identically.
+- Tests that depend on server data need deterministic seed data, a stable test
+  account, or a mock API. Do not rely on whatever data happens to exist locally.
+- Upload screenshots, videos, or logs from CI when a flow fails.

--- a/.agents/rules/testing-mobile.md
+++ b/.agents/rules/testing-mobile.md
@@ -1,0 +1,102 @@
+---
+title: Choose the Right Test Layer for Companion Mobile Changes
+impact: HIGH
+impactDescription: Routes mobile changes to the right Jest, Maestro, or documentation workflow
+tags: testing, mobile, expo, react-native, jest, maestro, ci
+---
+
+# Choose the Right Test Layer for Companion Mobile Changes
+
+**Impact: HIGH (routes mobile changes to the right Jest, Maestro, or
+documentation workflow)**
+
+`apps/mobile` is the Expo React Native app for iOS and Android. When changing
+mobile behavior, agents must choose the smallest test layer that proves the
+behavior and keeps PR checks reliable.
+
+For unit and component tests, the long-term target is **Jest only**. Bun remains
+the repo package manager and script runner, but `bun:test` should not be the
+mobile test framework once the Jest foundation exists.
+
+This is the entrypoint rule. Read the detailed rule that matches the work:
+
+- [testing-mobile-jest](testing-mobile-jest.md) for unit and component tests.
+- [testing-mobile-maestro](testing-mobile-maestro.md) for installed-app E2E
+  flows.
+- [testing-mobile-ai-authoring](testing-mobile-ai-authoring.md) when a human or
+  AI agent is using prompts to generate mobile tests.
+
+## Agent operating procedure
+
+When this rule applies, the agent must do this before writing or changing tests:
+
+1. Inspect the changed `apps/mobile` files, nearby tests, and relevant package
+   scripts/config. Do not assume Jest or Maestro is already wired unless the repo
+   contains the runner, config, and scripts.
+2. Classify the behavior as logic, component behavior, navigation/user journey,
+   platform-specific native behavior, or CI/test infrastructure.
+3. Choose Jest or Maestro using the rules below and state the reason in the PR
+   summary or final response.
+4. Add the smallest test that protects the behavior. Do not create broad
+   coverage matrices, new runbooks, or E2E suites unless the task asks for them.
+5. Run the exact verification command for the changed tests. If verification
+   cannot run because setup, credentials, devices, or CI infrastructure are
+   missing, say exactly what is missing.
+
+## Test infrastructure direction
+
+When changing mobile test infrastructure:
+
+- Use `jest`, `jest-expo`, and `@testing-library/react-native` for
+  unit/component tests.
+- Do not add new `bun:test` tests under `apps/mobile`.
+- If existing `bun:test` mobile tests are present, migrate them to Jest as part
+  of the Jest foundation work or explicitly call out any short-lived migration
+  gap. Do not leave mobile Bun tests silently outside the PR-blocking path.
+- The first Jest foundation PR should prove at least one Jest test runs locally.
+- A CI PR should make the mobile Jest script blocking only after the script,
+  config, and first representative tests are stable.
+
+## Choose the right layer
+
+Prefer Jest for:
+
+- Pure logic, formatting, date math, validation, filtering, and parser helpers.
+- API payload construction and response normalization.
+- React Query cache updates, mutation side effects, and optimistic UI logic.
+- Booking action visibility or enablement rules.
+- Component behavior that can be rendered with React Native Testing Library.
+
+Prefer Maestro for:
+
+- App launch, authentication/session readiness, and tab navigation.
+- Cross-screen flows such as Bookings list -> detail -> action sheet.
+- Event type, availability, and settings journeys that depend on navigation,
+  native controls, or installed app behavior.
+- iOS/Android parity checks where platform-specific files or native UI are used.
+
+Do not add Maestro flows for tiny edge cases that Jest can prove faster and more
+deterministically. Broad E2E suites become slow and flaky when they duplicate
+logic-level tests.
+
+## Required PR behavior
+
+When a mobile PR changes behavior:
+
+1. Add or update Jest tests for logic and component behavior. Follow
+   [testing-mobile-jest](testing-mobile-jest.md).
+2. Add or update Maestro only when the change affects a critical user journey.
+   Follow [testing-mobile-maestro](testing-mobile-maestro.md).
+3. Explain in the PR when a behavior change does not need Maestro coverage.
+4. Keep iOS and Android coverage in mind, especially when touching `.ios.tsx`,
+   `.android.tsx`, native modules, widgets, notifications, or deep links.
+
+When returning work, include:
+
+- The test layer chosen and why.
+- The files changed.
+- The verification command and result.
+- If no test was added for a mobile behavior change, the reason.
+
+The goal is not maximum test count. The goal is high-confidence, blocking checks
+that developers trust enough to keep enabled on every PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,12 @@ Note: Biome's `files.includes` in `biome.json` only covers `js/jsx/ts/tsx/json`,
 so `bun run format` / `format:check` do **not** touch Markdown. Validate docs with
 `git diff --check` (whitespace) and a manual read.
 
+## When Touching Mobile App Tests
+
+Before adding or changing tests for `apps/mobile`, start with
+[.agents/rules/testing-mobile.md](.agents/rules/testing-mobile.md). It routes
+agents to the correct Jest, Maestro, or AI-assisted authoring rule.
+
 ## When Touching MCP Tools
 
 Before adding or changing tools in `apps/mcp-server` that wrap Cal.com API v2,
@@ -38,10 +44,15 @@ To locate the OpenAPI spec, see
 
 ## Scope of These Rules
 
-The `.agents/rules` here are intentionally narrow. The MCP/OpenAPI rules apply
-**only** to `apps/mcp-server` (and other API-v2-wrapping code). They do **not**
-apply to unrelated `apps/chat`, `apps/mobile`, `apps/extension`, or `packages/cli`
-work — don't burden those areas with MCP-specific constraints.
+The `.agents/rules` here are intentionally narrow and scoped by area.
+
+The mobile testing rules apply to `apps/mobile` test strategy, Jest
+unit/component tests, Maestro E2E flows, and AI-assisted mobile test authoring.
+
+The MCP/OpenAPI rules apply **only** to `apps/mcp-server` (and other
+API-v2-wrapping code). They do **not** apply to unrelated `apps/chat`,
+`apps/mobile`, `apps/extension`, or `packages/cli` work — don't burden those
+areas with MCP-specific constraints.
 
 ## Extended Documentation
 


### PR DESCRIPTION
## Summary

- Add agent-native rules for choosing the right mobile test layer in `apps/mobile`.
- Document Jest as the long-term unit/component runner, with no new `bun:test` mobile tests once the Jest foundation exists.
- Add Maestro guidance for MCP-assisted authoring, stable selectors, iOS/Android differences, and AI-assisted test generation.

## Validation

- `git diff --cached --check`
- Trailing-whitespace scan across the changed Markdown files

Note: the pre-commit hook was bypassed for this docs-only commit because lint-staged invokes Biome on Markdown files, while this repo's Biome config ignores Markdown. The Markdown checks above were run manually.