### PR TITLE
ci(mobile): run jest tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,23 @@ jobs:
       - name: Type check
         run: bun run typecheck
 
+  mobile-jest:
+    name: Mobile Jest Tests
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.0
+          cache: true
+          cache-dependency-path: bun.lock
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run mobile Jest tests
+        run: bun run mobile:test
+
   build:
     name: Build
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
## Summary
- Add a dedicated `Mobile Jest Tests` job to the existing CI workflow.
- Reuse the repo's Bun 1.3.0 setup, frozen install, Blacksmith runner, and 10 minute timeout pattern.
- Run `bun run mobile:test`, introduced by the base PR.

Linear: ENG-1925

Stacked on: #124 (`test(mobile): add jest foundation`)

## Required check note
This PR adds the status check that can be made blocking. After this workflow runs once, mark `Mobile Jest Tests` as required in GitHub branch protection/rulesets for `main`.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parses"'`
- `bun install --frozen-lockfile`
- `bun run mobile:test`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/calcom/companion/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
