### PR TITLE
ci(mobile): run jest tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,23 @@ jobs:
       - name: Type check
         run: bun run typecheck
 
+  mobile-jest:
+    name: Mobile Jest Tests
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.0
+          cache: true
+          cache-dependency-path: bun.lock
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Run mobile Jest tests
+        run: bun run mobile:test
+
   build:
     name: Build
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
## Summary
- Port the Mobile Jest Tests CI job from #125 onto `main`.
- Keep the job aligned with the existing Bun 1.3.0 setup, frozen install, Blacksmith runner, and 10 minute timeout pattern.
- Run `bun run mobile:test`, which is now available on `main` from #124.

## Context
PR #125 was merged into `codex/mobile-jest-foundation`, so its merge commit is not reachable from current `main`. This PR carries the same workflow change directly onto `main`.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parses"'`
- `bun run mobile:test`
- `git diff --check upstream/main...HEAD`