### PR TITLE
fix(mobile): preserve notification deep links on launch

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,10 +1,11 @@
 import { Ionicons } from "@expo/vector-icons";
-import { Tabs, useRouter, VectorIcon } from "expo-router";
+import { Tabs, useRouter, useSegments, VectorIcon } from "expo-router";
 import { NativeTabs } from "expo-router/unstable-native-tabs";
 import { useEffect, useRef } from "react";
 import type { ColorValue, ImageSourcePropType } from "react-native";
 import { Platform, useColorScheme } from "react-native";
 import { getRouteFromPreference, useUserPreferences } from "@/hooks/useUserPreferences";
+import { getInitialLandingRedirectDecision } from "@/utils/landing-page-navigation";
 
 // Type for vector icon families that support getImageSource
 type VectorIconFamily = {
@@ -13,6 +14,8 @@ type VectorIconFamily = {
 
 export default function TabLayout() {
   const router = useRouter();
+  const segments = useSegments();
+  const segmentKey = segments.join("/");
   const { preferences, isLoading } = useUserPreferences();
   const hasNavigated = useRef(false);
   const colorScheme = useColorScheme();
@@ -29,22 +32,34 @@ export default function TabLayout() {
   // Navigate to preferred landing page on first load
   // Since Bookings is the default first tab, we only navigate if preference is different
   useEffect(() => {
-    if (!isLoading && !hasNavigated.current) {
-      hasNavigated.current = true;
-
-      // Only navigate if preference is not the default (bookings)
-      if (preferences.landingPage !== "bookings") {
-        const route = getRouteFromPreference(preferences.landingPage);
-        console.log("[TabLayout] Navigating to preferred landing page:", route);
-
-        // Use a minimal delay to ensure NativeTabs is initialized
-        setTimeout(() => {
-          // biome-ignore lint/suspicious/noExplicitAny: expo-router types don't support dynamic route strings from preferences
-          router.navigate(route as any);
-        }, 50);
-      }
+    if (isLoading || hasNavigated.current) {
+      return;
     }
-  }, [isLoading, preferences.landingPage, router]);
+
+    const decision = getInitialLandingRedirectDecision({
+      landingPage: preferences.landingPage,
+      segments: segmentKey ? segmentKey.split("/") : [],
+    });
+
+    if (decision === "wait") {
+      return;
+    }
+
+    hasNavigated.current = true;
+
+    if (decision === "skip") {
+      return;
+    }
+
+    const route = getRouteFromPreference(preferences.landingPage);
+    console.log("[TabLayout] Navigating to preferred landing page:", route);
+
+    // Use a minimal delay to ensure NativeTabs is initialized
+    setTimeout(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: expo-router types don't support dynamic route strings from preferences
+      router.navigate(route as any);
+    }, 50);
+  }, [isLoading, preferences.landingPage, router, segmentKey]);
 
   if (Platform.OS === "web") {
     return <WebTabs colors={colors} />;

--- a/apps/mobile/utils/landing-page-navigation.test.js
+++ b/apps/mobile/utils/landing-page-navigation.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "@jest/globals";
+import { getInitialLandingRedirectDecision } from "@/utils/landing-page-navigation";
+
+describe("getInitialLandingRedirectDecision", () => {
+  test("redirects event-types preference from the tabs root", () => {
+    expect(
+      getInitialLandingRedirectDecision({
+        landingPage: "event-types",
+        segments: ["(tabs)"],
+      })
+    ).toBe("redirect");
+  });
+
+  test("redirects event-types preference from the default bookings index", () => {
+    expect(
+      getInitialLandingRedirectDecision({
+        landingPage: "event-types",
+        segments: ["(tabs)", "(bookings)"],
+      })
+    ).toBe("redirect");
+  });
+
+  test("redirects bookings unconfirmed preference from the default bookings index", () => {
+    expect(
+      getInitialLandingRedirectDecision({
+        landingPage: "bookings:unconfirmed",
+        segments: ["(tabs)", "(bookings)", "index"],
+      })
+    ).toBe("redirect");
+  });
+
+  test("skips redirect when bookings is already the preferred default", () => {
+    expect(
+      getInitialLandingRedirectDecision({
+        landingPage: "bookings",
+        segments: ["(tabs)", "(bookings)"],
+      })
+    ).toBe("skip");
+  });
+
+  test("skips redirect for booking detail notification deep links", () => {
+    expect(
+      getInitialLandingRedirectDecision({
+        landingPage: "event-types",
+        segments: ["(tabs)", "(bookings)", "booking-detail"],
+      })
+    ).toBe("skip");
+  });
+
+  test("waits while segments are empty or outside the tabs layout", () => {
+    expect(
+      getInitialLandingRedirectDecision({
+        landingPage: "event-types",
+        segments: [],
+      })
+    ).toBe("wait");
+
+    expect(
+      getInitialLandingRedirectDecision({
+        landingPage: "event-types",
+        segments: ["profile-sheet"],
+      })
+    ).toBe("wait");
+  });
+});

--- a/apps/mobile/utils/landing-page-navigation.ts
+++ b/apps/mobile/utils/landing-page-navigation.ts
@@ -1,0 +1,39 @@
+import type { LandingPage } from "@/hooks/useUserPreferences";
+
+export type InitialLandingRedirectDecision = "wait" | "skip" | "redirect";
+
+type InitialLandingRedirectDecisionInput = {
+  landingPage: LandingPage;
+  segments: readonly string[];
+};
+
+const TABS_SEGMENT = "(tabs)";
+const BOOKINGS_SEGMENT = "(bookings)";
+const INDEX_SEGMENT = "index";
+
+function isTabsRoot(segments: readonly string[]): boolean {
+  return segments.length === 1 && segments[0] === TABS_SEGMENT;
+}
+
+function isDefaultBookingsIndex(segments: readonly string[]): boolean {
+  return (
+    segments[0] === TABS_SEGMENT &&
+    segments[1] === BOOKINGS_SEGMENT &&
+    (segments.length === 2 || (segments.length === 3 && segments[2] === INDEX_SEGMENT))
+  );
+}
+
+export function getInitialLandingRedirectDecision({
+  landingPage,
+  segments,
+}: InitialLandingRedirectDecisionInput): InitialLandingRedirectDecision {
+  if (segments.length === 0 || segments[0] !== TABS_SEGMENT) {
+    return "wait";
+  }
+
+  if (!isTabsRoot(segments) && !isDefaultBookingsIndex(segments)) {
+    return "skip";
+  }
+
+  return landingPage === "bookings" ? "skip" : "redirect";
+}


### PR DESCRIPTION


https://github.com/user-attachments/assets/b381ecf7-77a3-49c8-9bbf-a572c83320eb





## Summary
- Prevent the first-page preference redirect from overriding explicit nested tab routes, such as booking-detail notification deep links.
- Add a pure landing redirect decision helper with Jest coverage for root, default bookings, unconfirmed bookings, and booking-detail paths.

## Test Plan
- `cd apps/mobile && bun run test -- landing-page-navigation`
- `bun --filter mobile typecheck`

## Manual Validation
- Tested locally with a temporary dummy booking notification hook, then removed the temporary code before publishing.
