### PR TITLE
fix(mobile): use unconfirmed badge for pending requests

### DIFF
--- a/apps/mobile/components/booking-list-item/BookingListItem.ios.tsx
+++ b/apps/mobile/components/booking-list-item/BookingListItem.ios.tsx
@@ -189,11 +189,7 @@ export const BookingListItem: React.FC<BookingListItemProps> = ({
                 formattedDate={formattedDate}
                 formattedTimeRange={formattedTimeRange}
               />
-              <BadgesRow
-                isPending={isPending}
-                isPendingPayment={isPendingPayment}
-                showPendingHostConfirmation={requestActionState.showPendingHostConfirmation}
-              />
+              <BadgesRow isPending={isPending} isPendingPayment={isPendingPayment} />
               <BookingTitle
                 title={booking.title}
                 isCancelled={isCancelled}

--- a/apps/mobile/components/booking-list-item/BookingListItem.tsx
+++ b/apps/mobile/components/booking-list-item/BookingListItem.tsx
@@ -192,11 +192,7 @@ export const BookingListItem: React.FC<BookingListItemProps> = ({
         android_ripple={{ color: isDark ? "rgba(255, 255, 255, 0.1)" : "rgba(0, 0, 0, 0.1)" }}
       >
         <TimeAndDateRow formattedDate={formattedDate} formattedTimeRange={formattedTimeRange} />
-        <BadgesRow
-          isPending={isPending}
-          isPendingPayment={isPendingPayment}
-          showPendingHostConfirmation={requestActionState.showPendingHostConfirmation}
-        />
+        <BadgesRow isPending={isPending} isPendingPayment={isPendingPayment} />
         <BookingTitle title={booking.title} isCancelled={isCancelled} isRejected={isRejected} />
         <BookingDescription description={booking.description} />
         <HostAndAttendees

--- a/apps/mobile/components/booking-list-item/BookingListItemParts.tsx
+++ b/apps/mobile/components/booking-list-item/BookingListItemParts.tsx
@@ -4,6 +4,7 @@ import { SvgImage } from "@/components/SvgImage";
 import { getColors } from "@/constants/colors";
 import type { Booking } from "@/services/calcom";
 import { showErrorAlert } from "@/utils/alerts";
+import { BOOKING_REQUEST_BADGE_LABEL } from "@/utils/booking-request-actions";
 import type { BookingListItemData } from "./useBookingListItemData";
 
 interface TimeAndDateRowProps {
@@ -25,14 +26,9 @@ export function TimeAndDateRow({ formattedDate, formattedTimeRange }: TimeAndDat
 interface BadgesRowProps {
   isPending: boolean;
   isPendingPayment?: boolean;
-  showPendingHostConfirmation?: boolean;
 }
 
-export function BadgesRow({
-  isPending,
-  isPendingPayment,
-  showPendingHostConfirmation,
-}: BadgesRowProps) {
+export function BadgesRow({ isPending, isPendingPayment }: BadgesRowProps) {
   return (
     <View className="mb-3 flex-row flex-wrap items-center">
       {isPendingPayment ? (
@@ -42,9 +38,7 @@ export function BadgesRow({
       ) : null}
       {isPending ? (
         <View className="mb-1 mr-2 rounded bg-cal-accent-warning px-2 py-0.5">
-          <Text className="text-xs font-medium text-white">
-            {showPendingHostConfirmation ? "Pending host confirmation" : "Unconfirmed"}
-          </Text>
+          <Text className="text-xs font-medium text-white">{BOOKING_REQUEST_BADGE_LABEL}</Text>
         </View>
       ) : null}
     </View>

--- a/apps/mobile/components/booking-list-item/RecurringBookingListItem.ios.tsx
+++ b/apps/mobile/components/booking-list-item/RecurringBookingListItem.ios.tsx
@@ -11,6 +11,7 @@ import type { Booking } from "@/services/calcom";
 import { showErrorAlert } from "@/utils/alerts";
 import { getBookingActions } from "@/utils/booking-actions";
 import {
+  BOOKING_REQUEST_BADGE_LABEL,
   getBookingRequestBulkActionState,
   isBookingRequestPending,
 } from "@/utils/booking-request-actions";
@@ -97,7 +98,7 @@ export const RecurringBookingListItem: React.FC<RecurringBookingListItemProps> =
       }),
     [group.bookings, userId, userEmail]
   );
-  const { canConfirmAll, canRejectAll, showPendingHostConfirmation } = bulkRequestActionState;
+  const { canConfirmAll, canRejectAll } = bulkRequestActionState;
 
   const colorScheme = useColorScheme();
   const isDark = colorScheme === "dark";
@@ -235,9 +236,7 @@ export const RecurringBookingListItem: React.FC<RecurringBookingListItemProps> =
                 paddingVertical: 2,
               }}
             >
-              <Text className="text-xs font-medium text-white">
-                {showPendingHostConfirmation ? "Pending host confirmation" : "Unconfirmed"}
-              </Text>
+              <Text className="text-xs font-medium text-white">{BOOKING_REQUEST_BADGE_LABEL}</Text>
             </View>
           )}
         </View>

--- a/apps/mobile/components/booking-list-item/RecurringBookingListItem.tsx
+++ b/apps/mobile/components/booking-list-item/RecurringBookingListItem.tsx
@@ -16,6 +16,7 @@ import type { Booking } from "@/services/calcom";
 import { showErrorAlert } from "@/utils/alerts";
 import { getBookingActions } from "@/utils/booking-actions";
 import {
+  BOOKING_REQUEST_BADGE_LABEL,
   getBookingRequestBulkActionState,
   isBookingRequestPending,
 } from "@/utils/booking-request-actions";
@@ -117,7 +118,7 @@ export const RecurringBookingListItem: React.FC<RecurringBookingListItemProps> =
       }),
     [group.bookings, userId, userEmail]
   );
-  const { canConfirmAll, canRejectAll, showPendingHostConfirmation } = bulkRequestActionState;
+  const { canConfirmAll, canRejectAll } = bulkRequestActionState;
 
   type DropdownAction = {
     label: string;
@@ -236,9 +237,7 @@ export const RecurringBookingListItem: React.FC<RecurringBookingListItemProps> =
           {/* Unconfirmed Badge */}
           {group.hasUnconfirmed && (
             <View className="rounded bg-cal-accent-warning px-2 py-0.5">
-              <Text className="text-xs font-medium text-white">
-                {showPendingHostConfirmation ? "Pending host confirmation" : "Unconfirmed"}
-              </Text>
+              <Text className="text-xs font-medium text-white">{BOOKING_REQUEST_BADGE_LABEL}</Text>
             </View>
           )}
         </View>

--- a/apps/mobile/components/screens/BookingDetailRequestActions.test.js
+++ b/apps/mobile/components/screens/BookingDetailRequestActions.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "@jest/globals";
 import {
+  BOOKING_REQUEST_BADGE_LABEL,
   getBookingRequestActionState,
   getBookingRequestBulkActionState,
   isBookingRequestPending,
@@ -145,7 +146,7 @@ describe("getBookingRequestActionState", () => {
     });
   });
 
-  test("shows pending host confirmation when the current user cannot respond to the request", () => {
+  test("marks attendee-facing requests as awaiting a host response", () => {
     const booking = createBooking({
       attendees: [
         {
@@ -168,5 +169,9 @@ describe("getBookingRequestActionState", () => {
       canReject: false,
       showPendingHostConfirmation: true,
     });
+  });
+
+  test("defines the booking request badge label as unconfirmed", () => {
+    expect(BOOKING_REQUEST_BADGE_LABEL).toBe("Unconfirmed");
   });
 });

--- a/apps/mobile/components/screens/BookingDetailScreen.ios.tsx
+++ b/apps/mobile/components/screens/BookingDetailScreen.ios.tsx
@@ -13,16 +13,16 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AppPressable } from "@/components/AppPressable";
-import {
-  BookingDetailRequestActions,
-  getBookingRequestActionState,
-} from "@/components/screens/BookingDetailRequestActions";
+import { BookingDetailRequestActions } from "@/components/screens/BookingDetailRequestActions";
 import { useAuth } from "@/contexts/AuthContext";
 import { useCancelBooking, useConfirmBooking, useDeclineBooking } from "@/hooks/useBookings";
 import type { Booking } from "@/services/calcom";
 import { showErrorAlert, showSuccessAlert } from "@/utils/alerts";
 import { getBookingPaymentStatus } from "@/utils/booking-payment-status";
-import { isBookingRequestPending } from "@/utils/booking-request-actions";
+import {
+  BOOKING_REQUEST_BADGE_LABEL,
+  isBookingRequestPending,
+} from "@/utils/booking-request-actions";
 
 const CopyButton = ({
   text,
@@ -437,11 +437,6 @@ export function BookingDetailScreen({
   const normalizedStatus = booking.status.toLowerCase();
   const { isPendingPayment } = getBookingPaymentStatus(booking);
   const isUnconfirmed = isBookingRequestPending(booking);
-  const bookingRequestActionState = getBookingRequestActionState({
-    booking,
-    currentUserId: userInfo?.id,
-    currentUserEmail: userInfo?.email,
-  });
 
   const getAttendeeStatusIcon = (attendee: { noShow?: boolean; absent?: boolean }) => {
     const isNoShow = attendee.noShow || attendee.absent;
@@ -553,9 +548,7 @@ export function BookingDetailScreen({
               {isUnconfirmed ? (
                 <View className="mb-1 mr-2 rounded bg-cal-accent-warning px-2 py-0.5">
                   <Text className="text-xs font-medium text-white">
-                    {bookingRequestActionState.showPendingHostConfirmation
-                      ? "Pending host confirmation"
-                      : "Unconfirmed"}
+                    {BOOKING_REQUEST_BADGE_LABEL}
                   </Text>
                 </View>
               ) : null}

--- a/apps/mobile/components/screens/BookingDetailScreen.tsx
+++ b/apps/mobile/components/screens/BookingDetailScreen.tsx
@@ -20,10 +20,7 @@ import { AppPressable } from "@/components/AppPressable";
 import { BookingActionsModal } from "@/components/BookingActionsModal";
 import { FullScreenModal } from "@/components/FullScreenModal";
 import { HeaderButtonWrapper } from "@/components/HeaderButtonWrapper";
-import {
-  BookingDetailRequestActions,
-  getBookingRequestActionState,
-} from "@/components/screens/BookingDetailRequestActions";
+import { BookingDetailRequestActions } from "@/components/screens/BookingDetailRequestActions";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -50,7 +47,10 @@ import { showErrorAlert, showInfoAlert, showSuccessAlert } from "@/utils/alerts"
 import { getMeetingUrl } from "@/utils/booking";
 import { type BookingActionsResult, getBookingActions } from "@/utils/booking-actions";
 import { getBookingPaymentStatus } from "@/utils/booking-payment-status";
-import { isBookingRequestPending } from "@/utils/booking-request-actions";
+import {
+  BOOKING_REQUEST_BADGE_LABEL,
+  isBookingRequestPending,
+} from "@/utils/booking-request-actions";
 import { openInAppBrowser } from "@/utils/browser";
 
 const CopyButton = ({
@@ -633,11 +633,6 @@ export function BookingDetailScreen({
   const normalizedStatus = booking.status.toLowerCase();
   const { isPendingPayment } = getBookingPaymentStatus(booking);
   const isUnconfirmed = isBookingRequestPending(booking);
-  const bookingRequestActionState = getBookingRequestActionState({
-    booking,
-    currentUserId: userInfo?.id,
-    currentUserEmail: userInfo?.email,
-  });
 
   const getAttendeeStatusIcon = (attendee: { noShow?: boolean; absent?: boolean }) => {
     const isNoShow = attendee.noShow || attendee.absent;
@@ -821,9 +816,7 @@ export function BookingDetailScreen({
                 {isUnconfirmed ? (
                   <View className="mb-1 mr-2 rounded bg-cal-accent-warning px-2 py-0.5">
                     <Text className="text-xs font-medium text-white">
-                      {bookingRequestActionState.showPendingHostConfirmation
-                        ? "Pending host confirmation"
-                        : "Unconfirmed"}
+                      {BOOKING_REQUEST_BADGE_LABEL}
                     </Text>
                   </View>
                 ) : null}

--- a/apps/mobile/utils/booking-request-actions.ts
+++ b/apps/mobile/utils/booking-request-actions.ts
@@ -28,6 +28,8 @@ type BookingRequestBulkActionStateParams = {
   now?: Date;
 };
 
+export const BOOKING_REQUEST_BADGE_LABEL = "Unconfirmed";
+
 const getBookingStatus = (booking: Booking): string => booking.status?.toLowerCase() || "";
 
 const getBookingEndTime = (booking: Booking): string => booking.endTime || booking.end || "";


### PR DESCRIPTION
## What changed

- Updated mobile pending booking request badges to always display `Unconfirmed` instead of `Pending host confirmation`.
- Applied the copy consistently across booking list rows, recurring booking rows, and booking detail screens.
- Removed now-unused badge-only host-confirmation state plumbing while preserving confirm/reject permission gating.

## Verification

- `bun test apps/mobile/components/screens/BookingDetailRequestActions.test.js`
- `bun --filter mobile test --runInBand`
- `bun --filter mobile typecheck`
- `bunx biome check apps/mobile/utils/booking-request-actions.ts apps/mobile/components/booking-list-item/BookingListItemParts.tsx apps/mobile/components/booking-list-item/BookingListItem.tsx apps/mobile/components/booking-list-item/BookingListItem.ios.tsx apps/mobile/components/booking-list-item/RecurringBookingListItem.tsx apps/mobile/components/booking-list-item/RecurringBookingListItem.ios.tsx apps/mobile/components/screens/BookingDetailScreen.tsx apps/mobile/components/screens/BookingDetailScreen.ios.tsx apps/mobile/components/screens/BookingDetailRequestActions.test.js`
- `git diff --check`
- `rg -n "Pending host confirmation" apps/mobile` (no matches)