### PR TITLE
fix(mobile): rename app display name from Calcom to Cal.com

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "Calcom",
+    "name": "Cal.com",
     "slug": "calcom-companion",
     "scheme": ["calcom", "expo-wxt-app"],
     "version": "1.0.8",


### PR DESCRIPTION
## Summary

The iPhone app title displayed as \"Calcom\" instead of \"Cal.com\". Updated `expo.name` in `apps/mobile/app.json` to the correct brand name.

Link to Devin session: https://app.devin.ai/sessions/d32174fec5be4028b40bbe7190ec9cc0
Requested by: @keithwillcode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the mobile app display name to Cal.com to match the brand and fix the iOS title. Updates `expo.name` in apps/mobile/app.json so the home screen and app switcher show the correct name.

<sup>Written for commit a0a60c360593c723db5ddae2bca7e88307a8689c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/calcom/companion/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

