### PR TITLE
ci(mobile): add Android Maestro check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,111 @@ jobs:
       - name: Run mobile Jest tests
         run: bun run mobile:test
 
+  mobile-maestro-android:
+    name: Mobile Maestro Android
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CI: true
+      EXPO_NO_TELEMETRY: 1
+      MAESTRO_VERSION: 2.6.1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.0
+          cache: true
+          cache-dependency-path: bun.lock
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+      - name: Validate Maestro flow syntax
+        run: bun run mobile:e2e:check
+      - name: Create CI Google services file
+        working-directory: apps/mobile
+        run: |
+          cat > google-services.ci.json <<'JSON'
+          {
+            "project_info": {
+              "project_number": "1",
+              "project_id": "cal-companion-ci",
+              "storage_bucket": "cal-companion-ci.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:1:android:ci",
+                  "android_client_info": {
+                    "package_name": "com.calcom.companion"
+                  }
+                },
+                "oauth_client": [],
+                "api_key": [
+                  {
+                    "current_key": "ci"
+                  }
+                ],
+                "services": {
+                  "appinvite_service": {
+                    "other_platform_oauth_client": []
+                  }
+                }
+              }
+            ],
+            "configuration_version": "1"
+          }
+          JSON
+          echo "GOOGLE_SERVICES_JSON=./google-services.ci.json" >> "$GITHUB_ENV"
+      - name: Generate Android project
+        working-directory: apps/mobile
+        run: EXPO_NO_GIT_STATUS=1 bunx expo prebuild --platform android --no-install
+      - name: Build Android release APK
+        working-directory: apps/mobile/android
+        run: ./gradlew assembleRelease -PreactNativeArchitectures=x86_64 --no-daemon
+      - name: Run Android Maestro smoke flows
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          disable-animations: true
+          script: |
+            adb install -r apps/mobile/android/app/build/outputs/apk/release/app-release.apk
+            cd apps/mobile
+            mkdir -p maestro-results/android
+            maestro test \
+              -e APP_ID=com.calcom.companion \
+              --exclude-tags=ios-only \
+              --format JUNIT \
+              --output maestro-results/android/report.xml \
+              --test-output-dir maestro-results/android/artifacts \
+              --debug-output maestro-results/android/debug \
+              --flatten-debug-output \
+              maestro
+      - name: Upload Maestro artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-maestro-android
+          path: apps/mobile/maestro-results/android
+          if-no-files-found: ignore
+
   build:
     name: Build
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,17 +151,8 @@ jobs:
           disable-animations: true
           script: |
             adb install -r apps/mobile/android/app/build/outputs/apk/release/app-release.apk
-            cd apps/mobile
-            mkdir -p maestro-results/android
-            maestro test \
-              -e APP_ID=com.calcom.companion \
-              --exclude-tags=ios-only \
-              --format JUNIT \
-              --output maestro-results/android/report.xml \
-              --test-output-dir maestro-results/android/artifacts \
-              --debug-output maestro-results/android/debug \
-              --flatten-debug-output \
-              maestro
+            mkdir -p apps/mobile/maestro-results/android
+            maestro test -e APP_ID=com.calcom.companion --exclude-tags=ios-only --format JUNIT --output apps/mobile/maestro-results/android/report.xml --test-output-dir apps/mobile/maestro-results/android/artifacts --debug-output apps/mobile/maestro-results/android/debug --flatten-debug-output apps/mobile/maestro
       - name: Upload Maestro artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/apps/mobile/maestro/README.md
+++ b/apps/mobile/maestro/README.md
@@ -45,6 +45,19 @@ The default `mobile:e2e` script runs the Maestro folder with the app ID from
 - iOS: `com.cal.companion`
 - Android: `com.calcom.companion`
 
+## CI
+
+The `Mobile Maestro Android` PR check builds a release Android APK from the
+generated native project, installs it on a GitHub-hosted emulator, and runs the
+current smoke flows with `APP_ID=com.calcom.companion`.
+
+The job also runs `bun run mobile:e2e:check` before building so YAML syntax
+failures are reported quickly. Runtime failures upload the JUnit report and
+Maestro debug artifacts as the `mobile-maestro-android` workflow artifact.
+
+The logged-out smoke build uses a CI-only dummy Google services file and does
+not require production Firebase secrets.
+
 ## Authoring Notes
 
 - Use Maestro MCP or `maestro hierarchy` to inspect the running screen before
@@ -54,5 +67,5 @@ The default `mobile:e2e` script runs the Maestro folder with the app ID from
 - Keep shared flows free of platform tags. Use `ios-only` or `android-only` only
   when a flow must be skipped on the other platform.
 - Do not add broad flows that duplicate Jest coverage.
-- Do not make Maestro blocking in CI until the flow has a reliable simulator or
-  Maestro Cloud runner with a known app binary and test data.
+- Keep blocking CI limited to reliable smoke coverage until authenticated flows
+  have stable test data and an auth strategy.


### PR DESCRIPTION
## What changed

- Adds a `Mobile Maestro Android` GitHub Actions job for the mobile smoke flow.
- Builds a release APK from Expo prebuild output so the JS bundle is embedded before Maestro runs.
- Runs Maestro on a GitHub-hosted Android emulator with JUnit/debug artifacts uploaded.
- Documents the CI behavior and CI-only dummy Google services file in the Maestro README.

## Notes

- The CI job uses `APP_ID=com.calcom.companion` and excludes `ios-only` flows.
- The dummy `google-services.ci.json` is generated during CI only; no production Firebase secrets are introduced.
- Follow-up: the current repo ruleset appears to require only `Build`, `Type Check`, and `Lint`. An admin still needs to add `Mobile Maestro Android` as a required check for this to truly block merges.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parses"'`
- `bun run mobile:e2e:check`
- `bun --filter mobile typecheck`
- `bun run mobile:test -- --runInBand`
- `EXPO_NO_GIT_STATUS=1 bunx expo prebuild --platform android --no-install`
- `./gradlew assembleRelease -PreactNativeArchitectures=x86_64 --no-daemon`
- `git diff --check`
