### PR TITLE
ci(mobile): add iOS Maestro check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,81 @@ jobs:
           path: apps/mobile/maestro-results/android
           if-no-files-found: ignore
 
+  mobile-maestro-ios:
+    name: Mobile Maestro iOS
+    runs-on: macos-latest
+    timeout-minutes: 45
+    env:
+      CI: true
+      EXPO_NO_TELEMETRY: 1
+      MAESTRO_VERSION: 2.6.1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.0
+          cache: true
+          cache-dependency-path: bun.lock
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+      - name: Validate Maestro flow syntax
+        run: bun run mobile:e2e:check
+      - name: Generate iOS project
+        working-directory: apps/mobile
+        run: EXPO_NO_GIT_STATUS=1 bunx expo prebuild --platform ios --no-install
+      - name: Install CocoaPods dependencies
+        working-directory: apps/mobile/ios
+        run: pod install
+      - name: Build iOS simulator app
+        working-directory: apps/mobile
+        run: |
+          xcodebuild \
+            -workspace ios/Calcom.xcworkspace \
+            -scheme Calcom \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath ios/build \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            build
+          test -d ios/build/Build/Products/Release-iphonesimulator/Calcom.app
+      - name: Boot iOS simulator
+        run: |
+          xcrun simctl shutdown all || true
+          SIMULATOR_UDID="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ && /(Shutdown|Booted)/ { print $2; exit }')"
+          if [ -z "$SIMULATOR_UDID" ]; then
+            echo "No available iPhone simulator found"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "IOS_SIMULATOR_UDID=$SIMULATOR_UDID" >> "$GITHUB_ENV"
+          xcrun simctl boot "$SIMULATOR_UDID"
+          xcrun simctl bootstatus "$SIMULATOR_UDID" -b
+      - name: Run iOS Maestro smoke flows
+        run: |
+          xcrun simctl install "$IOS_SIMULATOR_UDID" apps/mobile/ios/build/Build/Products/Release-iphonesimulator/Calcom.app
+          mkdir -p apps/mobile/maestro-results/ios
+          maestro test -e APP_ID=com.cal.companion --exclude-tags=android-only --format JUNIT --output apps/mobile/maestro-results/ios/report.xml --test-output-dir apps/mobile/maestro-results/ios/artifacts --debug-output apps/mobile/maestro-results/ios/debug --flatten-debug-output apps/mobile/maestro
+      - name: Upload Maestro artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-maestro-ios
+          path: apps/mobile/maestro-results/ios
+          if-no-files-found: ignore
+
   build:
     name: Build
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,111 @@ jobs:
       - name: Run mobile Jest tests
         run: bun run mobile:test
 
+  mobile-maestro-android:
+    name: Mobile Maestro Android
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CI: true
+      EXPO_NO_TELEMETRY: 1
+      MAESTRO_VERSION: 2.6.1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.0
+          cache: true
+          cache-dependency-path: bun.lock
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+      - name: Validate Maestro flow syntax
+        run: bun run mobile:e2e:check
+      - name: Create CI Google services file
+        working-directory: apps/mobile
+        run: |
+          cat > google-services.ci.json <<'JSON'
+          {
+            "project_info": {
+              "project_number": "1",
+              "project_id": "cal-companion-ci",
+              "storage_bucket": "cal-companion-ci.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:1:android:ci",
+                  "android_client_info": {
+                    "package_name": "com.calcom.companion"
+                  }
+                },
+                "oauth_client": [],
+                "api_key": [
+                  {
+                    "current_key": "ci"
+                  }
+                ],
+                "services": {
+                  "appinvite_service": {
+                    "other_platform_oauth_client": []
+                  }
+                }
+              }
+            ],
+            "configuration_version": "1"
+          }
+          JSON
+          echo "GOOGLE_SERVICES_JSON=./google-services.ci.json" >> "$GITHUB_ENV"
+      - name: Generate Android project
+        working-directory: apps/mobile
+        run: EXPO_NO_GIT_STATUS=1 bunx expo prebuild --platform android --no-install
+      - name: Build Android release APK
+        working-directory: apps/mobile/android
+        run: ./gradlew assembleRelease -PreactNativeArchitectures=x86_64 --no-daemon
+      - name: Run Android Maestro smoke flows
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          disable-animations: true
+          script: |
+            adb install -r apps/mobile/android/app/build/outputs/apk/release/app-release.apk
+            cd apps/mobile
+            mkdir -p maestro-results/android
+            maestro test \
+              -e APP_ID=com.calcom.companion \
+              --exclude-tags=ios-only \
+              --format JUNIT \
+              --output maestro-results/android/report.xml \
+              --test-output-dir maestro-results/android/artifacts \
+              --debug-output maestro-results/android/debug \
+              --flatten-debug-output \
+              maestro
+      - name: Upload Maestro artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-maestro-android
+          path: apps/mobile/maestro-results/android
+          if-no-files-found: ignore
+
   build:
     name: Build
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,7 @@ jobs:
       CI: true
       EXPO_NO_TELEMETRY: 1
       MAESTRO_VERSION: 2.6.1
+      MAESTRO_DRIVER_STARTUP_TIMEOUT: 120000
     steps:
       - uses: actions/checkout@v4
       - name: Setup Bun
@@ -182,11 +183,27 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
+      - name: Configure iOS simulator
+        run: |
+          defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
+          defaults write com.apple.iphonesimulator SlowAnimations -bool false
+          defaults write com.apple.iphonesimulator PasteboardAutomaticSync -bool false
+      - name: Cache Maestro
+        id: cache-maestro-ios
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.maestro/bin
+            ~/.maestro/lib
+            ~/.maestro/deps
+          key: maestro-${{ runner.os }}-${{ env.MAESTRO_VERSION }}
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Install Maestro
+        if: steps.cache-maestro-ios.outputs.cache-hit != 'true'
+        run: curl -fsSL "https://get.maestro.mobile.dev" | bash
+      - name: Add Maestro to PATH
         run: |
-          curl -Ls "https://get.maestro.mobile.dev" | bash
           echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
       - name: Validate Maestro flow syntax
         run: bun run mobile:e2e:check
@@ -212,6 +229,7 @@ jobs:
             build
           test -d ios/build/Build/Products/Release-iphonesimulator/Calcom.app
       - name: Boot iOS simulator
+        timeout-minutes: 15
         run: |
           xcrun simctl shutdown all || true
           SIMULATOR_UDID="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ && /(Shutdown|Booted)/ { print $2; exit }')"
@@ -223,7 +241,10 @@ jobs:
           echo "IOS_SIMULATOR_UDID=$SIMULATOR_UDID" >> "$GITHUB_ENV"
           xcrun simctl boot "$SIMULATOR_UDID"
           xcrun simctl bootstatus "$SIMULATOR_UDID" -b
+          xcrun simctl spawn "$SIMULATOR_UDID" defaults write -g UIAnimationDragCoefficient -float 0.0001
+          xcrun simctl list devices | grep Booted
       - name: Run iOS Maestro smoke flows
+        timeout-minutes: 15
         run: |
           xcrun simctl install "$IOS_SIMULATOR_UDID" apps/mobile/ios/build/Build/Products/Release-iphonesimulator/Calcom.app
           mkdir -p apps/mobile/maestro-results/ios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,17 +151,8 @@ jobs:
           disable-animations: true
           script: |
             adb install -r apps/mobile/android/app/build/outputs/apk/release/app-release.apk
-            cd apps/mobile
-            mkdir -p maestro-results/android
-            maestro test \
-              -e APP_ID=com.calcom.companion \
-              --exclude-tags=ios-only \
-              --format JUNIT \
-              --output maestro-results/android/report.xml \
-              --test-output-dir maestro-results/android/artifacts \
-              --debug-output maestro-results/android/debug \
-              --flatten-debug-output \
-              maestro
+            mkdir -p apps/mobile/maestro-results/android
+            maestro test -e APP_ID=com.calcom.companion --exclude-tags=ios-only --format JUNIT --output apps/mobile/maestro-results/android/report.xml --test-output-dir apps/mobile/maestro-results/android/artifacts --debug-output apps/mobile/maestro-results/android/debug --flatten-debug-output apps/mobile/maestro
       - name: Upload Maestro artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,11 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.2.app
+          xcodebuild -version
+          xcrun simctl list runtimes | grep "iOS 26.2"
       - name: Configure iOS simulator
         run: |
           defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
             ~/.maestro/bin
             ~/.maestro/lib
             ~/.maestro/deps
-          key: maestro-${{ runner.os }}-${{ env.MAESTRO_VERSION }}
+          key: maestro-${{ runner.os }}-${{ runner.arch }}-${{ env.MAESTRO_VERSION }}
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Install Maestro
@@ -232,7 +232,7 @@ jobs:
         timeout-minutes: 15
         run: |
           xcrun simctl shutdown all || true
-          SIMULATOR_UDID="$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ && /(Shutdown|Booted)/ { print $2; exit }')"
+          SIMULATOR_UDID="$(xcrun simctl list devices available | awk '/iPhone/ && /(Shutdown|Booted)/ { if (match($0, /[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}/)) { print substr($0, RSTART, RLENGTH); exit } }')"
           if [ -z "$SIMULATOR_UDID" ]; then
             echo "No available iPhone simulator found"
             xcrun simctl list devices available

--- a/apps/mobile/maestro/README.md
+++ b/apps/mobile/maestro/README.md
@@ -45,6 +45,19 @@ The default `mobile:e2e` script runs the Maestro folder with the app ID from
 - iOS: `com.cal.companion`
 - Android: `com.calcom.companion`
 
+## CI
+
+The `Mobile Maestro Android` PR check builds a release Android APK from the
+generated native project, installs it on a GitHub-hosted emulator, and runs the
+current smoke flows with `APP_ID=com.calcom.companion`.
+
+The job also runs `bun run mobile:e2e:check` before building so YAML syntax
+failures are reported quickly. Runtime failures upload the JUnit report and
+Maestro debug artifacts as the `mobile-maestro-android` workflow artifact.
+
+The logged-out smoke build uses a CI-only dummy Google services file and does
+not require production Firebase secrets.
+
 ## Authoring Notes
 
 - Use Maestro MCP or `maestro hierarchy` to inspect the running screen before
@@ -54,5 +67,5 @@ The default `mobile:e2e` script runs the Maestro folder with the app ID from
 - Keep shared flows free of platform tags. Use `ios-only` or `android-only` only
   when a flow must be skipped on the other platform.
 - Do not add broad flows that duplicate Jest coverage.
-- Do not make Maestro blocking in CI until the flow has a reliable simulator or
-  Maestro Cloud runner with a known app binary and test data.
+- Keep blocking CI limited to reliable smoke coverage until authenticated flows
+  have stable test data and an auth strategy.

--- a/apps/mobile/maestro/README.md
+++ b/apps/mobile/maestro/README.md
@@ -51,9 +51,14 @@ The `Mobile Maestro Android` PR check builds a release Android APK from the
 generated native project, installs it on a GitHub-hosted emulator, and runs the
 current smoke flows with `APP_ID=com.calcom.companion`.
 
-The job also runs `bun run mobile:e2e:check` before building so YAML syntax
-failures are reported quickly. Runtime failures upload the JUnit report and
-Maestro debug artifacts as the `mobile-maestro-android` workflow artifact.
+The `Mobile Maestro iOS` PR check builds a simulator `.app` from the generated
+Xcode workspace, installs it on a GitHub-hosted iPhone simulator, and runs the
+current smoke flows with `APP_ID=com.cal.companion`.
+
+Both jobs run `bun run mobile:e2e:check` before building so YAML syntax failures
+are reported quickly. Runtime failures upload the JUnit report and Maestro
+debug artifacts as `mobile-maestro-android` or `mobile-maestro-ios` workflow
+artifacts.
 
 The logged-out smoke build uses a CI-only dummy Google services file and does
 not require production Firebase secrets.

--- a/apps/mobile/maestro/flows/smoke/launch-login.yaml
+++ b/apps/mobile/maestro/flows/smoke/launch-login.yaml
@@ -8,5 +8,5 @@ tags:
     visible: "Continue with Cal.com"
     timeout: 15000
 - assertVisible: "Data region"
-- assertVisible: "United States"
+- assertVisible: "United States.*"
 - assertVisible: "Continue with Cal.com"

--- a/apps/mobile/maestro/flows/smoke/launch-login.yaml
+++ b/apps/mobile/maestro/flows/smoke/launch-login.yaml
@@ -8,5 +8,14 @@ tags:
     visible: "Continue with Cal.com"
     timeout: 15000
 - assertVisible: "Data region"
-- assertVisible: "United States.*"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - assertVisible: "United States"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - assertVisible: "United States,.*"
 - assertVisible: "Continue with Cal.com"


### PR DESCRIPTION
## What changed
- Adds a `Mobile Maestro iOS` GitHub Actions job stacked on the Android Maestro CI foundation.
- Builds a Release iOS simulator `.app` from Expo prebuild output so the JS bundle is embedded before Maestro runs.
- Boots an available GitHub-hosted iPhone simulator, installs the app, and runs the existing smoke flows with `APP_ID=com.cal.companion`.
- Caches Maestro, uses fail-fast install flags, configures the simulator, disables iOS animations, and bounds the boot/run steps to reduce iOS runner flakes.
- Uploads JUnit/debug artifacts as `mobile-maestro-ios` and documents the iOS CI behavior.
- Loosens the default-region smoke assertion to match iOS picker accessibility text.

## Notes
- This PR is stacked on #134 because that Android CI foundation has not merged yet.
- The repo CI workflow currently runs only for PRs targeting `main`, so this stacked PR will get the full CI run after it is retargeted once #134 lands.
- The job excludes `android-only` flows and remains limited to the logged-out smoke flow.
- Follow-up/admin: add `Mobile Maestro iOS` as a required check once merged/enabled, same as Android.

## Reference check
- Compared against `/Users/dhairyashilshinde/work/Rocket.Chat.ReactNative` Maestro iOS CI.
- Pulled in the portable runner hardening pieces: Maestro cache, `curl -fsSL`, simulator keyboard/animation setup, startup timeout, and bounded boot/run steps.
- Left out Rocket.Chat-specific pieces: separate build artifact workflow, shard matrix, manual E2E approval, authenticated server preflight, and multi-round retry script.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parses"'`\n- `bun run mobile:e2e:check`\n- `git diff --check`\n- `EXPO_NO_GIT_STATUS=1 bunx expo prebuild --platform ios --no-install`\n- `pod install`\n- `xcodebuild -workspace ios/Calcom.xcworkspace -scheme Calcom -configuration Release -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath ios/build CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" build`\n- Local iOS Maestro smoke run against the built Release simulator `.app`: passed