### PR TITLE
fix(extension): harden booking URL handling

### DIFF
--- a/apps/extension/entrypoints/background/index.ts
+++ b/apps/extension/entrypoints/background/index.ts
@@ -11,6 +11,47 @@ const DEV_API_KEY = import.meta.env.EXPO_PUBLIC_CAL_API_KEY as string | undefine
 const IS_DEV_MODE = Boolean(DEV_API_KEY && DEV_API_KEY.length > 0);
 const BROWSER_TARGET = import.meta.env.BROWSER_TARGET || "chrome";
 
+function compactRedirectUrls(urls: Array<string | undefined>): string[] {
+  return urls.filter((url): url is string => Boolean(url?.trim()));
+}
+
+function getConfiguredOAuthRedirectUrls(): string[] {
+  const defaultRedirectUrls = compactRedirectUrls([
+    import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI,
+    import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_EU,
+  ]);
+
+  switch (BROWSER_TARGET) {
+    case "firefox":
+      return compactRedirectUrls([
+        import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_FIREFOX,
+        import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_FIREFOX_EU,
+        ...defaultRedirectUrls,
+      ]);
+    case "safari":
+      return compactRedirectUrls([
+        import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_SAFARI,
+        import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_SAFARI_EU,
+        ...defaultRedirectUrls,
+      ]);
+    case "edge":
+      return compactRedirectUrls([
+        import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_EDGE,
+        import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_EDGE_EU,
+        ...defaultRedirectUrls,
+      ]);
+    default:
+      return defaultRedirectUrls;
+  }
+}
+
+function getExpectedOAuthRedirectUrls(): string[] {
+  return compactRedirectUrls([
+    getIdentityAPI()?.getRedirectURL?.(),
+    ...getConfiguredOAuthRedirectUrls(),
+  ]);
+}
+
 const devLog = {
   log: (...args: unknown[]) => IS_DEV_MODE && console.log("[Cal.com]", ...args),
   warn: (...args: unknown[]) => IS_DEV_MODE && console.warn("[Cal.com]", ...args),
@@ -382,8 +423,8 @@ export default defineBackground(() => {
 
       if (message.action === "start-extension-oauth") {
         const authUrl = message.authUrl as string;
-        const expectedRedirectUrl = getIdentityAPI()?.getRedirectURL?.();
-        const authUrlValidation = validateExtensionOAuthAuthorizeUrl(authUrl, expectedRedirectUrl);
+        const expectedRedirectUrls = getExpectedOAuthRedirectUrls();
+        const authUrlValidation = validateExtensionOAuthAuthorizeUrl(authUrl, expectedRedirectUrls);
         if (!authUrlValidation.ok) {
           sendResponse({ success: false, error: authUrlValidation.reason });
           return true;
@@ -565,7 +606,7 @@ async function handleExtensionOAuth(authUrl: string): Promise<string> {
     devLog.log("Expected redirect URL:", expectedRedirectUrl);
     devLog.log("Auth URL redirect_uri:", redirectUri);
 
-    if (redirectUri && !redirectUri.startsWith(expectedRedirectUrl.replace(/\/$/, ""))) {
+    if (redirectUri && !validateExtensionOAuthAuthorizeUrl(authUrl, expectedRedirectUrl).ok) {
       devLog.warn(
         "MISMATCH! redirect_uri does not match expected URL.",
         "\nExpected:",

--- a/apps/extension/entrypoints/background/index.ts
+++ b/apps/extension/entrypoints/background/index.ts
@@ -1,5 +1,9 @@
 /// <reference types="chrome" />
 
+import {
+  validateExtensionOAuthAuthorizeUrl,
+  validateExtensionOAuthTokenEndpoint,
+} from "../../lib/utils";
 import type { Booking } from "../../types/bookings.types";
 import type { OAuthTokens } from "../../types/oauth";
 
@@ -378,6 +382,12 @@ export default defineBackground(() => {
 
       if (message.action === "start-extension-oauth") {
         const authUrl = message.authUrl as string;
+        const expectedRedirectUrl = getIdentityAPI()?.getRedirectURL?.();
+        const authUrlValidation = validateExtensionOAuthAuthorizeUrl(authUrl, expectedRedirectUrl);
+        if (!authUrlValidation.ok) {
+          sendResponse({ success: false, error: authUrlValidation.reason });
+          return true;
+        }
         const state = new URL(authUrl).searchParams.get("state");
 
         // Store state before starting OAuth to prevent race conditions
@@ -781,6 +791,11 @@ async function handleTokenExchange(
   tokenEndpoint: string,
   state?: string
 ): Promise<OAuthTokens> {
+  const tokenEndpointValidation = validateExtensionOAuthTokenEndpoint(tokenEndpoint);
+  if (!tokenEndpointValidation.ok) {
+    throw new Error(tokenEndpointValidation.reason);
+  }
+
   if (state) {
     await validateOAuthState(state);
   }

--- a/apps/extension/entrypoints/content.ts
+++ b/apps/extension/entrypoints/content.ts
@@ -1,7 +1,7 @@
 /// <reference types="chrome" />
 import { initGoogleCalendarIntegration } from "../lib/google-calendar";
 import { initLinkedInIntegration } from "../lib/linkedin";
-import { escapeHtml } from "../lib/utils";
+import { buildSafeBookingUrl, escapeHtml } from "../lib/utils";
 
 /**
  * Development-only logging utility for content scripts.
@@ -87,6 +87,10 @@ export default defineContentScript({
     `;
 
     iframeContainer.appendChild(iframe);
+
+    function postToCompanionIframe(iframeWindow: Window | null, message: unknown): void {
+      iframeWindow?.postMessage(message, new URL(iframe.src).origin);
+    }
 
     // Listen for messages from iframe to control width and handle OAuth
     window.addEventListener("message", (event) => {
@@ -188,36 +192,27 @@ export default defineContentScript({
               "Failed to communicate with background script:",
               chrome.runtime.lastError.message
             );
-            iframeWindow?.postMessage(
-              {
-                type: "cal-extension-oauth-result",
-                success: false,
-                error: `Extension communication failed: ${chrome.runtime.lastError.message}`,
-              },
-              "*"
-            );
+            postToCompanionIframe(iframeWindow, {
+              type: "cal-extension-oauth-result",
+              success: false,
+              error: `Extension communication failed: ${chrome.runtime.lastError.message}`,
+            });
             return;
           }
 
           // Forward the response back to iframe
           if (response.success) {
-            iframeWindow?.postMessage(
-              {
-                type: "cal-extension-oauth-result",
-                success: true,
-                responseUrl: response.responseUrl,
-              },
-              "*"
-            );
+            postToCompanionIframe(iframeWindow, {
+              type: "cal-extension-oauth-result",
+              success: true,
+              responseUrl: response.responseUrl,
+            });
           } else {
-            iframeWindow?.postMessage(
-              {
-                type: "cal-extension-oauth-result",
-                success: false,
-                error: response.error || "OAuth flow failed",
-              },
-              "*"
-            );
+            postToCompanionIframe(iframeWindow, {
+              type: "cal-extension-oauth-result",
+              success: false,
+              error: response.error || "OAuth flow failed",
+            });
           }
         }
       );
@@ -244,36 +239,27 @@ export default defineContentScript({
               "Failed to communicate with background script:",
               chrome.runtime.lastError.message
             );
-            iframeWindow?.postMessage(
-              {
-                type: "cal-extension-token-exchange-result",
-                success: false,
-                error: `Extension communication failed: ${chrome.runtime.lastError.message}`,
-              },
-              "*"
-            );
+            postToCompanionIframe(iframeWindow, {
+              type: "cal-extension-token-exchange-result",
+              success: false,
+              error: `Extension communication failed: ${chrome.runtime.lastError.message}`,
+            });
             return;
           }
 
           // Forward the response back to iframe
           if (response.success) {
-            iframeWindow?.postMessage(
-              {
-                type: "cal-extension-token-exchange-result",
-                success: true,
-                tokens: response.tokens,
-              },
-              "*"
-            );
+            postToCompanionIframe(iframeWindow, {
+              type: "cal-extension-token-exchange-result",
+              success: true,
+              tokens: response.tokens,
+            });
           } else {
-            iframeWindow?.postMessage(
-              {
-                type: "cal-extension-token-exchange-result",
-                success: false,
-                error: response.error || "Token exchange failed",
-              },
-              "*"
-            );
+            postToCompanionIframe(iframeWindow, {
+              type: "cal-extension-token-exchange-result",
+              success: false,
+              error: response.error || "Token exchange failed",
+            });
           }
         }
       );
@@ -290,25 +276,19 @@ export default defineContentScript({
             "Failed to communicate with background script:",
             chrome.runtime.lastError.message
           );
-          iframeWindow?.postMessage(
-            {
-              type: "cal-extension-sync-tokens-result",
-              success: false,
-              error: `Extension communication failed: ${chrome.runtime.lastError.message}`,
-            },
-            "*"
-          );
+          postToCompanionIframe(iframeWindow, {
+            type: "cal-extension-sync-tokens-result",
+            success: false,
+            error: `Extension communication failed: ${chrome.runtime.lastError.message}`,
+          });
           return;
         }
 
-        iframeWindow?.postMessage(
-          {
-            type: "cal-extension-sync-tokens-result",
-            success: response?.success ?? false,
-            error: response?.error,
-          },
-          "*"
-        );
+        postToCompanionIframe(iframeWindow, {
+          type: "cal-extension-sync-tokens-result",
+          success: response?.success ?? false,
+          error: response?.error,
+        });
       });
     }
 
@@ -319,25 +299,19 @@ export default defineContentScript({
             "Failed to communicate with background script:",
             chrome.runtime.lastError.message
           );
-          iframeWindow?.postMessage(
-            {
-              type: "cal-extension-clear-tokens-result",
-              success: false,
-              error: `Extension communication failed: ${chrome.runtime.lastError.message}`,
-            },
-            "*"
-          );
+          postToCompanionIframe(iframeWindow, {
+            type: "cal-extension-clear-tokens-result",
+            success: false,
+            error: `Extension communication failed: ${chrome.runtime.lastError.message}`,
+          });
           return;
         }
 
-        iframeWindow?.postMessage(
-          {
-            type: "cal-extension-clear-tokens-result",
-            success: response?.success ?? false,
-            error: response?.error,
-          },
-          "*"
-        );
+        postToCompanionIframe(iframeWindow, {
+          type: "cal-extension-clear-tokens-result",
+          success: response?.success ?? false,
+          error: response?.error,
+        });
       });
     }
 
@@ -453,7 +427,7 @@ export default defineContentScript({
 
       // Send message to iframe to reload cache
       if (iframe.contentWindow) {
-        iframe.contentWindow.postMessage({ type: "cal-companion-reload-cache" }, "*");
+        postToCompanionIframe(iframe.contentWindow, { type: "cal-companion-reload-cache" });
       }
     });
 
@@ -1089,11 +1063,7 @@ export default defineContentScript({
 
                   previewBtn.addEventListener("click", (e) => {
                     e.stopPropagation();
-                    const bookingUrl =
-                      eventType.bookingUrl ||
-                      `https://cal.com/${
-                        eventType.users?.[0]?.username || "user"
-                      }/${eventType.slug}`;
+                    const bookingUrl = buildSafeBookingUrl(eventType);
                     window.open(bookingUrl, "_blank");
                   });
                   previewBtn.addEventListener("mouseenter", () => {
@@ -1133,11 +1103,7 @@ export default defineContentScript({
                   copyBtn.addEventListener("click", (e) => {
                     e.stopPropagation();
                     // Copy to clipboard
-                    const bookingUrl =
-                      eventType.bookingUrl ||
-                      `https://cal.com/${
-                        eventType.users?.[0]?.username || "user"
-                      }/${eventType.slug}`;
+                    const bookingUrl = buildSafeBookingUrl(eventType);
                     navigator.clipboard
                       .writeText(bookingUrl)
                       .then(() => {
@@ -1265,7 +1231,7 @@ export default defineContentScript({
                       Something went wrong
                     </div>
                     <div style="font-size: 13px; color: #6B7280; margin-bottom: 16px;">
-                      ${errorMessage || "Failed to load event types"}
+                      ${escapeHtml(errorMessage || "Failed to load event types")}
                     </div>
                     <button class="cal-gmail-close-btn" style="
                       background: #F3F4F6;
@@ -1306,9 +1272,7 @@ export default defineContentScript({
             bookingUrl?: string;
           }): void {
             // Construct the Cal.com booking link
-            const bookingUrl =
-              eventType.bookingUrl ||
-              `https://cal.com/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
+            const bookingUrl = buildSafeBookingUrl(eventType);
 
             // Try to insert at cursor position in the compose field
             const inserted = insertTextAtCursor(bookingUrl);
@@ -1334,9 +1298,7 @@ export default defineContentScript({
             bookingUrl?: string;
           }): void {
             // Construct the Cal.com booking link
-            const bookingUrl =
-              eventType.bookingUrl ||
-              `https://cal.com/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
+            const bookingUrl = buildSafeBookingUrl(eventType);
 
             // Try to insert at cursor position in the compose field
             const inserted = insertTextAtCursor(bookingUrl);
@@ -1838,9 +1800,7 @@ export default defineContentScript({
 
               previewBtn.addEventListener("click", (e) => {
                 e.stopPropagation();
-                const bookingUrl =
-                  eventType.bookingUrl ||
-                  `https://cal.com/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
+                const bookingUrl = buildSafeBookingUrl(eventType);
                 window.open(bookingUrl, "_blank");
               });
               previewBtn.addEventListener("mouseenter", () => {
@@ -1880,9 +1840,7 @@ export default defineContentScript({
               copyBtn.addEventListener("click", (e) => {
                 e.stopPropagation();
                 // Copy to clipboard
-                const bookingUrl =
-                  eventType.bookingUrl ||
-                  `https://cal.com/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
+                const bookingUrl = buildSafeBookingUrl(eventType);
                 navigator.clipboard
                   .writeText(bookingUrl)
                   .then(() => {
@@ -2010,7 +1968,7 @@ export default defineContentScript({
                   Something went wrong
                 </div>
                 <div style="font-size: 13px; color: #6B7280; margin-bottom: 16px;">
-                  ${errorMessage || "Failed to load event types"}
+                  ${escapeHtml(errorMessage || "Failed to load event types")}
                 </div>
                 <button class="cal-linkedin-close-btn" style="
                   background: #F3F4F6;
@@ -2051,9 +2009,7 @@ export default defineContentScript({
         bookingUrl?: string;
       }) {
         // Construct the Cal.com booking link
-        const bookingUrl =
-          eventType.bookingUrl ||
-          `https://cal.com/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`;
+        const bookingUrl = buildSafeBookingUrl(eventType);
 
         // Try to insert at cursor position in the message field
         const inserted = insertTextAtCursor(bookingUrl);

--- a/apps/extension/entrypoints/content.ts
+++ b/apps/extension/entrypoints/content.ts
@@ -1292,32 +1292,6 @@ export default defineContentScript({
             }
           }
 
-          function _copyEventTypeLink(eventType: {
-            slug: string;
-            users?: Array<{ username?: string }>;
-            bookingUrl?: string;
-          }): void {
-            // Construct the Cal.com booking link
-            const bookingUrl = buildSafeBookingUrl(eventType);
-
-            // Try to insert at cursor position in the compose field
-            const inserted = insertTextAtCursor(bookingUrl);
-
-            if (inserted) {
-              showNotification("Link inserted", "success");
-            } else {
-              // Fallback: copy to clipboard if insertion fails
-              navigator.clipboard
-                .writeText(bookingUrl)
-                .then(() => {
-                  showNotification("Link copied!", "success");
-                })
-                .catch(() => {
-                  showNotification("Failed to copy link", "error");
-                });
-            }
-          }
-
           function insertTextAtCursor(text: string): boolean {
             // Find the active compose field
             // Gmail uses contenteditable divs for the compose body

--- a/apps/extension/env.d.ts
+++ b/apps/extension/env.d.ts
@@ -7,18 +7,22 @@ interface ImportMetaEnv {
   // Default OAuth config (Chrome/Brave)
   readonly EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID?: string;
   readonly EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI?: string;
+  readonly EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_EU?: string;
 
   // Firefox-specific OAuth config
   readonly EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID_FIREFOX?: string;
   readonly EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_FIREFOX?: string;
+  readonly EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_FIREFOX_EU?: string;
 
   // Safari-specific OAuth config
   readonly EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID_SAFARI?: string;
   readonly EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_SAFARI?: string;
+  readonly EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_SAFARI_EU?: string;
 
   // Edge-specific OAuth config
   readonly EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID_EDGE?: string;
   readonly EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_EDGE?: string;
+  readonly EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_EDGE_EU?: string;
 
   // Browser target set during build
   readonly BROWSER_TARGET?: "chrome" | "firefox" | "safari" | "edge";

--- a/apps/extension/lib/linkedin.ts
+++ b/apps/extension/lib/linkedin.ts
@@ -1,5 +1,5 @@
 /// <reference types="chrome" />
-import { escapeHtml } from "./utils";
+import { buildSafeBookingUrl, escapeHtml } from "./utils";
 
 // LinkedIn integration: inject a Cal.com scheduling button in LinkedIn messaging
 
@@ -666,10 +666,7 @@ export function initLinkedInIntegration() {
   }
 
   function buildBookingUrl(eventType: EventType): string {
-    return (
-      eventType.bookingUrl ||
-      `https://cal.com/${eventType.users?.[0]?.username || "user"}/${eventType.slug}`
-    );
+    return buildSafeBookingUrl(eventType);
   }
 
   function handleFetchError(error: unknown, menu: HTMLElement, tooltipsToCleanup: HTMLElement[]) {

--- a/apps/extension/lib/utils.test.ts
+++ b/apps/extension/lib/utils.test.ts
@@ -56,11 +56,46 @@ describe("validateExtensionOAuthAuthorizeUrl", () => {
     expect(result.ok).toBe(false);
   });
 
+  it("rejects redirect URIs that only share the extension redirect origin prefix", () => {
+    const result = validateExtensionOAuthAuthorizeUrl(
+      "https://app.cal.com/auth/oauth2/authorize?state=s&redirect_uri=https%3A%2F%2Fextension.example.evil.com%2Fcallback",
+      "https://extension.example"
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects redirect URIs that only share the extension redirect path prefix", () => {
+    const result = validateExtensionOAuthAuthorizeUrl(
+      "https://app.cal.com/auth/oauth2/authorize?state=s&redirect_uri=https%3A%2F%2Fextension.example%2Fcallback-extra",
+      "https://extension.example/callback"
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects authorize URLs when the extension redirect URL is unavailable", () => {
+    const result = validateExtensionOAuthAuthorizeUrl(
+      "https://app.cal.com/auth/oauth2/authorize?state=s&redirect_uri=https%3A%2F%2Fextension.example%2Fcallback"
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
   it("accepts Cal authorize URLs with matching extension redirects", () => {
     expect(
       validateExtensionOAuthAuthorizeUrl(
         "https://app.cal.com/auth/oauth2/authorize?state=s&redirect_uri=https%3A%2F%2Fextension.example%2Fcallback",
         "https://extension.example/callback"
+      )
+    ).toEqual({ ok: true });
+  });
+
+  it("accepts Cal authorize URLs matching any configured extension redirect", () => {
+    expect(
+      validateExtensionOAuthAuthorizeUrl(
+        "https://app.cal.com/auth/oauth2/authorize?state=s&redirect_uri=https%3A%2F%2Feu-extension.example%2Fcallback",
+        ["https://extension.example/callback", "https://eu-extension.example/callback"]
       )
     ).toEqual({ ok: true });
   });

--- a/apps/extension/lib/utils.test.ts
+++ b/apps/extension/lib/utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSafeBookingUrl,
+  validateExtensionOAuthAuthorizeUrl,
+  validateExtensionOAuthTokenEndpoint,
+} from "./utils";
+
+describe("buildSafeBookingUrl", () => {
+  it("accepts https Cal.com booking URLs", () => {
+    expect(
+      buildSafeBookingUrl({
+        slug: "intro",
+        users: [{ username: "alice" }],
+        bookingUrl: "https://cal.com/alice/intro?overlayCalendar=true",
+      })
+    ).toBe("https://cal.com/alice/intro?overlayCalendar=true");
+  });
+
+  it("falls back to an encoded Cal.com URL when the API returns an unsafe host", () => {
+    expect(
+      buildSafeBookingUrl({
+        slug: "team/intro",
+        users: [{ username: "alice@example.com" }],
+        bookingUrl: "https://evil.example/phish",
+      })
+    ).toBe("https://cal.com/alice%40example.com/team%2Fintro");
+  });
+
+  it("falls back when the API returns a javascript URL", () => {
+    expect(
+      buildSafeBookingUrl({
+        slug: "intro",
+        users: [{ username: "alice" }],
+        bookingUrl: "javascript:alert(1)",
+      })
+    ).toBe("https://cal.com/alice/intro");
+  });
+});
+
+describe("validateExtensionOAuthAuthorizeUrl", () => {
+  it("rejects authorize URLs outside Cal app origins", () => {
+    const result = validateExtensionOAuthAuthorizeUrl(
+      "https://evil.example/auth/oauth2/authorize?state=s&redirect_uri=https%3A%2F%2Fexample.com",
+      "https://extension.example/callback"
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects redirect URIs that do not match the browser identity redirect URL", () => {
+    const result = validateExtensionOAuthAuthorizeUrl(
+      "https://app.cal.com/auth/oauth2/authorize?state=s&redirect_uri=https%3A%2F%2Fevil.example%2Fcallback",
+      "https://extension.example/callback"
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts Cal authorize URLs with matching extension redirects", () => {
+    expect(
+      validateExtensionOAuthAuthorizeUrl(
+        "https://app.cal.com/auth/oauth2/authorize?state=s&redirect_uri=https%3A%2F%2Fextension.example%2Fcallback",
+        "https://extension.example/callback"
+      )
+    ).toEqual({ ok: true });
+  });
+});
+
+describe("validateExtensionOAuthTokenEndpoint", () => {
+  it("rejects token exchange endpoints outside Cal API origins", () => {
+    expect(validateExtensionOAuthTokenEndpoint("https://evil.example/oauth/token").ok).toBe(false);
+  });
+
+  it("accepts Cal API token endpoints", () => {
+    expect(validateExtensionOAuthTokenEndpoint("https://api.cal.com/v2/oauth/token")).toEqual({
+      ok: true,
+    });
+    expect(validateExtensionOAuthTokenEndpoint("https://api.cal.eu/v2/oauth/token")).toEqual({
+      ok: true,
+    });
+  });
+});

--- a/apps/extension/lib/utils.ts
+++ b/apps/extension/lib/utils.ts
@@ -60,7 +60,9 @@ function redirectUriMatchesExpected(redirectUri: string, expectedRedirectUrl: st
       actual.protocol === expected.protocol &&
       actual.hostname === expected.hostname &&
       actual.port === expected.port &&
-      normalizeRedirectPath(actual.pathname) === normalizeRedirectPath(expected.pathname)
+      normalizeRedirectPath(actual.pathname) === normalizeRedirectPath(expected.pathname) &&
+      actual.search === expected.search &&
+      actual.hash === expected.hash
     );
   } catch {
     return false;

--- a/apps/extension/lib/utils.ts
+++ b/apps/extension/lib/utils.ts
@@ -8,3 +8,97 @@ export function escapeHtml(text: string): string {
   div.textContent = text;
   return div.innerHTML;
 }
+
+const SAFE_BOOKING_HOSTS = new Set(["cal.com", "www.cal.com", "cal.eu", "www.cal.eu"]);
+const SAFE_OAUTH_APP_ORIGINS = new Set([
+  "https://app.cal.com",
+  "https://app.cal.eu",
+  "https://cal.com",
+  "https://cal.eu",
+]);
+const SAFE_OAUTH_API_ORIGINS = new Set(["https://api.cal.com", "https://api.cal.eu"]);
+
+export interface BookingLinkSource {
+  slug: string;
+  users?: Array<{ username?: string }>;
+  bookingUrl?: string;
+}
+
+export type UrlValidationResult = { ok: true } | { ok: false; reason: string };
+
+function isHttpsUrlOnHost(rawUrl: string, allowedHosts: Set<string>): boolean {
+  try {
+    const url = new URL(rawUrl);
+    return url.protocol === "https:" && allowedHosts.has(url.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+export function buildSafeBookingUrl(eventType: BookingLinkSource): string {
+  const rawBookingUrl = eventType.bookingUrl?.trim();
+  if (rawBookingUrl && isHttpsUrlOnHost(rawBookingUrl, SAFE_BOOKING_HOSTS)) {
+    return new URL(rawBookingUrl).toString();
+  }
+
+  const username = eventType.users?.[0]?.username || "user";
+  return `https://cal.com/${encodeURIComponent(username)}/${encodeURIComponent(eventType.slug)}`;
+}
+
+export function validateExtensionOAuthAuthorizeUrl(
+  authUrl: string,
+  expectedRedirectUrl?: string
+): UrlValidationResult {
+  let url: URL;
+  try {
+    url = new URL(authUrl);
+  } catch {
+    return { ok: false, reason: "Invalid OAuth authorize URL" };
+  }
+
+  if (url.protocol !== "https:" || !SAFE_OAUTH_APP_ORIGINS.has(url.origin)) {
+    return { ok: false, reason: "OAuth authorize URL must use a Cal.com app origin" };
+  }
+
+  if (url.pathname !== "/auth/oauth2/authorize") {
+    return { ok: false, reason: "OAuth authorize URL must use the Cal.com authorize path" };
+  }
+
+  const state = url.searchParams.get("state");
+  if (!state) {
+    return { ok: false, reason: "No state parameter in auth URL" };
+  }
+
+  const redirectUri = url.searchParams.get("redirect_uri");
+  if (!redirectUri) {
+    return { ok: false, reason: "redirect_uri not found in auth URL" };
+  }
+
+  if (expectedRedirectUrl) {
+    const expected = expectedRedirectUrl.replace(/\/$/, "");
+    if (!redirectUri.startsWith(expected)) {
+      return { ok: false, reason: "redirect_uri does not match extension redirect URL" };
+    }
+  }
+
+  return { ok: true };
+}
+
+export function validateExtensionOAuthTokenEndpoint(tokenEndpoint: string): UrlValidationResult {
+  let url: URL;
+  try {
+    url = new URL(tokenEndpoint);
+  } catch {
+    return { ok: false, reason: "Invalid OAuth token endpoint" };
+  }
+
+  if (url.protocol !== "https:" || !SAFE_OAUTH_API_ORIGINS.has(url.origin)) {
+    return { ok: false, reason: "OAuth token endpoint must use a Cal.com API origin" };
+  }
+
+  if (!url.pathname.endsWith("/oauth/token")) {
+    return { ok: false, reason: "OAuth token endpoint must use the Cal.com token path" };
+  }
+
+  return { ok: true };
+}

--- a/apps/extension/lib/utils.ts
+++ b/apps/extension/lib/utils.ts
@@ -9,6 +9,7 @@ export function escapeHtml(text: string): string {
   return div.innerHTML;
 }
 
+// Custom booking domains intentionally fall back until we have a trusted allowlist source.
 const SAFE_BOOKING_HOSTS = new Set(["cal.com", "www.cal.com", "cal.eu", "www.cal.eu"]);
 const SAFE_OAUTH_APP_ORIGINS = new Set([
   "https://app.cal.com",
@@ -45,9 +46,30 @@ export function buildSafeBookingUrl(eventType: BookingLinkSource): string {
   return `https://cal.com/${encodeURIComponent(username)}/${encodeURIComponent(eventType.slug)}`;
 }
 
+function normalizeRedirectPath(pathname: string): string {
+  const normalized = pathname.replace(/\/$/, "");
+  return normalized || "/";
+}
+
+function redirectUriMatchesExpected(redirectUri: string, expectedRedirectUrl: string): boolean {
+  try {
+    const actual = new URL(redirectUri);
+    const expected = new URL(expectedRedirectUrl);
+
+    return (
+      actual.protocol === expected.protocol &&
+      actual.hostname === expected.hostname &&
+      actual.port === expected.port &&
+      normalizeRedirectPath(actual.pathname) === normalizeRedirectPath(expected.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function validateExtensionOAuthAuthorizeUrl(
   authUrl: string,
-  expectedRedirectUrl?: string
+  expectedRedirectUrl?: string | string[]
 ): UrlValidationResult {
   let url: URL;
   try {
@@ -74,11 +96,16 @@ export function validateExtensionOAuthAuthorizeUrl(
     return { ok: false, reason: "redirect_uri not found in auth URL" };
   }
 
-  if (expectedRedirectUrl) {
-    const expected = expectedRedirectUrl.replace(/\/$/, "");
-    if (!redirectUri.startsWith(expected)) {
-      return { ok: false, reason: "redirect_uri does not match extension redirect URL" };
-    }
+  const expectedRedirectUrls = (
+    Array.isArray(expectedRedirectUrl) ? expectedRedirectUrl : [expectedRedirectUrl]
+  ).filter((url): url is string => Boolean(url?.trim()));
+
+  if (expectedRedirectUrls.length === 0) {
+    return { ok: false, reason: "Extension redirect URL is unavailable" };
+  }
+
+  if (!expectedRedirectUrls.some((expected) => redirectUriMatchesExpected(redirectUri, expected))) {
+    return { ok: false, reason: "redirect_uri does not match extension redirect URL" };
   }
 
   return { ok: true };

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -27,7 +27,8 @@
     "zip:edge:prod": "BUILD_FOR_STORE=true BROWSER_TARGET=edge wxt zip -b edge",
     "build:all": "bun run build && bun run build:firefox && bun run build:safari && bun run build:edge",
     "build:all:prod": "bun run build:prod && bun run build:firefox:prod && bun run build:safari:prod && bun run build:edge:prod",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "19.2.4",
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "@types/chrome": "0.1.31",
+    "vitest": "4.1.8",
     "wxt": "0.20.11"
   }
 }

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -149,6 +149,9 @@ export default defineConfig({
         "import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI": JSON.stringify(
           process.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI
         ),
+        "import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_EU": JSON.stringify(
+          process.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_EU
+        ),
 
         // Browser-specific OAuth config (resolved based on BROWSER_TARGET)
         "import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID_FIREFOX": JSON.stringify(
@@ -157,17 +160,26 @@ export default defineConfig({
         "import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_FIREFOX": JSON.stringify(
           process.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_FIREFOX
         ),
+        "import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_FIREFOX_EU": JSON.stringify(
+          process.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_FIREFOX_EU
+        ),
         "import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID_SAFARI": JSON.stringify(
           process.env.EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID_SAFARI
         ),
         "import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_SAFARI": JSON.stringify(
           process.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_SAFARI
         ),
+        "import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_SAFARI_EU": JSON.stringify(
+          process.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_SAFARI_EU
+        ),
         "import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID_EDGE": JSON.stringify(
           process.env.EXPO_PUBLIC_CALCOM_OAUTH_CLIENT_ID_EDGE
         ),
         "import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_EDGE": JSON.stringify(
           process.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_EDGE
+        ),
+        "import.meta.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_EDGE_EU": JSON.stringify(
+          process.env.EXPO_PUBLIC_CALCOM_OAUTH_REDIRECT_URI_EDGE_EU
         ),
 
         // Pre-resolved OAuth config for the build target (for convenience)

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
       },
       "devDependencies": {
         "@types/chrome": "0.1.31",
+        "vitest": "4.1.8",
         "wxt": "0.20.11",
       },
     },


### PR DESCRIPTION
## Summary

Hardens extension-controlled URLs by sanitizing booking links before preview/copy/insert, validating OAuth authorization and token endpoints, escaping rendered error text, and avoiding wildcard iframe `postMessage` replies.

## Reviewer notes

- Booking URLs are now limited to Cal.com-owned hosts: `cal.com`, `www.cal.com`, `cal.eu`, and `www.cal.eu`.
- Please confirm whether the extension needs to support custom domains or self-hosted booking hosts. If yes, we should add an explicit allowlist/config path before merging.
- OAuth authorization must resolve to the expected Cal.com app authorize route, and token exchange must use the expected Cal.com API token route.

## Validation

- `bun --filter extension test -- lib/utils.test.ts`
- `bun --filter extension typecheck`
- `bun --filter extension build`
- `git diff --check HEAD~1..HEAD`
