### PR TITLE
fix(mobile): validate external redirect URLs

### DIFF
--- a/apps/mobile/app/(tabs)/(event-types)/event-type-detail.tsx
+++ b/apps/mobile/app/(tabs)/(event-types)/event-type-detail.tsx
@@ -53,6 +53,7 @@ import {
   mapItemToApiLocation,
   validateLocationItem,
 } from "@/utils/locationHelpers";
+import { validateExternalRedirectUrl } from "@/utils/redirectUrlValidation";
 import { getCalAppUrl } from "@/utils/region";
 import { safeLogError } from "@/utils/safeLogger";
 
@@ -1204,6 +1205,12 @@ export default function EventTypeDetail() {
       }
     }
 
+    const redirectValidation = validateExternalRedirectUrl(successRedirectUrl);
+    if (!redirectValidation.valid) {
+      showErrorAlert("Error", redirectValidation.error || "Invalid redirect URL");
+      return;
+    }
+
     // Detect create vs update mode
     const isCreateMode = id === "new";
 
@@ -1278,6 +1285,7 @@ export default function EventTypeDetail() {
     currentFormState,
     eventTypeData,
     updateEventType,
+    successRedirectUrl,
   ]);
 
   const headerTitle = id === "new" ? "Create Event Type" : truncateTitle(title);

--- a/apps/mobile/utils/redirectUrlValidation.test.js
+++ b/apps/mobile/utils/redirectUrlValidation.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "@jest/globals";
+import { validateExternalRedirectUrl } from "./redirectUrlValidation";
+
+describe("validateExternalRedirectUrl", () => {
+  test("allows an empty redirect URL", () => {
+    expect(validateExternalRedirectUrl("")).toEqual({ valid: true });
+    expect(validateExternalRedirectUrl("   ")).toEqual({ valid: true });
+  });
+
+  test("allows https redirect URLs", () => {
+    expect(validateExternalRedirectUrl("https://example.com/thanks?booking=123")).toEqual({
+      valid: true,
+    });
+  });
+
+  test("allows http redirect URLs to match the web app schema", () => {
+    expect(validateExternalRedirectUrl("http://localhost:3000/thanks")).toEqual({ valid: true });
+    expect(validateExternalRedirectUrl("http://127.0.0.1:3000/thanks")).toEqual({ valid: true });
+    expect(validateExternalRedirectUrl("http://example.com/thanks")).toEqual({ valid: true });
+  });
+
+  test("rejects javascript and data URLs", () => {
+    expect(validateExternalRedirectUrl("javascript:alert(1)").valid).toBe(false);
+    expect(validateExternalRedirectUrl("data:text/html,<script>alert(1)</script>").valid).toBe(
+      false
+    );
+  });
+
+  test("rejects non-http redirect URLs", () => {
+    const result = validateExternalRedirectUrl("ftp://example.com/file");
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("HTTP");
+  });
+});

--- a/apps/mobile/utils/redirectUrlValidation.test.js
+++ b/apps/mobile/utils/redirectUrlValidation.test.js
@@ -30,6 +30,13 @@ describe("validateExternalRedirectUrl", () => {
     const result = validateExternalRedirectUrl("ftp://example.com/file");
 
     expect(result.valid).toBe(false);
-    expect(result.error).toContain("HTTP");
+    expect(result.error).toContain("http://");
+  });
+
+  test("rejects http URLs without an explicit double-slash prefix", () => {
+    expect(validateExternalRedirectUrl("https:example.com").valid).toBe(false);
+    expect(validateExternalRedirectUrl("http:example.com").valid).toBe(false);
+    expect(validateExternalRedirectUrl("https:/example.com").valid).toBe(false);
+    expect(validateExternalRedirectUrl("http:/example.com").valid).toBe(false);
   });
 });

--- a/apps/mobile/utils/redirectUrlValidation.ts
+++ b/apps/mobile/utils/redirectUrlValidation.ts
@@ -1,0 +1,22 @@
+export interface RedirectUrlValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+export function validateExternalRedirectUrl(value: string): RedirectUrlValidationResult {
+  const trimmed = value.trim();
+  if (!trimmed) return { valid: true };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { valid: false, error: "Redirect URL must be a valid URL." };
+  }
+
+  if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+    return { valid: true };
+  }
+
+  return { valid: false, error: "Redirect URL must use HTTP or HTTPS." };
+}

--- a/apps/mobile/utils/redirectUrlValidation.ts
+++ b/apps/mobile/utils/redirectUrlValidation.ts
@@ -7,6 +7,10 @@ export function validateExternalRedirectUrl(value: string): RedirectUrlValidatio
   const trimmed = value.trim();
   if (!trimmed) return { valid: true };
 
+  if (!/^https?:\/\//.test(trimmed)) {
+    return { valid: false, error: "Redirect URL must start with http:// or https://." };
+  }
+
   let parsed: URL;
   try {
     parsed = new URL(trimmed);


### PR DESCRIPTION
## Summary

Adds client-side validation for event-type success redirect URLs in the mobile app before create/update requests are submitted. The validator now mirrors the main web app schema for `successRedirectUrl`: empty values are allowed, `http://` and `https://` URLs are allowed, and non-http schemes like `javascript:`, `data:`, and `ftp:` are rejected.

## Main web app parity

Checked `/Users/dhairyashilshinde/work/calcom/cal` on `main`:

- `packages/prisma/zod-utils.ts` defines `successRedirectUrl` as empty string or a URL matching `^http(s)?://.*`.
- `apps/web/modules/event-types/components/tabs/confirmation/event-confirmation-tab.tsx` uses that redirect field and shows the approval warning flow.
- `packages/features/eventtypes/lib/successRedirectUrlAllowed.ts` and `packages/features/eventtypes/lib/getPublicEvent.ts` handle paid-plan/grandfathering/approval filtering.

So this mobile PR only rejects invalid/non-http URL schemes at the client boundary. It does not introduce a mobile-only HTTPS requirement.

## Reviewer notes

- Server-side validation/approval remains authoritative; this PR prevents the mobile client from sending obvious unsafe schemes.
- Web currently allows external `http://` redirect URLs, so mobile does too for consistency. If we want to require HTTPS, that should be changed centrally in the web/server schema first, then mobile can follow.

## Validation

- `bun --filter mobile test --runInBand utils/redirectUrlValidation.test.js`
- `bun --filter mobile typecheck`
- `git diff --check HEAD~1..HEAD`
