### PR TITLE
ci(mobile): skip mobile jobs for non-mobile changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,36 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Changed Paths
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    outputs:
+      mobile: ${{ steps.mobile.outputs.mobile }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check mobile-affecting changes
+        id: mobile
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git diff --name-only "${{ github.event.pull_request.base.sha }}" "$GITHUB_SHA" > changed-files.txt
+          elif [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
+            git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA" > changed-files.txt
+          else
+            git diff --name-only "${{ github.event.before }}" "$GITHUB_SHA" > changed-files.txt
+          fi
+
+          if grep -Eq '^(apps/mobile(/|$)|bun\.lock$|package\.json$|\.github/workflows/ci\.yml$)' changed-files.txt; then
+            echo "mobile=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "mobile=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     name: Lint
     runs-on: blacksmith-2vcpu-ubuntu-2404
@@ -50,6 +80,8 @@ jobs:
 
   mobile-jest:
     name: Mobile Jest Tests
+    needs: changes
+    if: needs.changes.outputs.mobile == 'true'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
@@ -67,6 +99,8 @@ jobs:
 
   mobile-maestro-android:
     name: Mobile Maestro Android
+    needs: changes
+    if: needs.changes.outputs.mobile == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:


### PR DESCRIPTION
## Summary
- add a lightweight changed-path detector inside the CI workflow
- skip `Mobile Jest Tests` and `Mobile Maestro Android` when a PR does not touch mobile-affecting paths
- treat `apps/mobile/**`, `bun.lock`, root `package.json`, and `.github/workflows/ci.yml` as mobile-affecting

## Why
Non-mobile PRs can currently be blocked by mobile emulator flakes. This keeps mobile coverage for mobile/dependency/workflow changes while avoiding unrelated failures on MCP, CLI, extension, or chat-only PRs.

## Validation
- local regex smoke check for mobile and non-mobile paths
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml ok"'`\n- `git diff --check HEAD~1..HEAD`