### PR TITLE
chore(mobile): bump app version to 1.0.9

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Cal.com",
     "slug": "calcom-companion",
     "scheme": ["calcom", "expo-wxt-app"],
-    "version": "1.0.8",
+    "version": "1.0.9",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## What changed
- Bumped the Expo mobile app version in `apps/mobile/app.json` from `1.0.8` to `1.0.9`.

## Why
- Prepares the next mobile app version metadata bump.

## Validation
- `git diff --check -- apps/mobile/app.json`
- `python3 -m json.tool apps/mobile/app.json >/dev/null`
- `bunx biome ci apps/mobile/app.json`