### PR TITLE
feat(mcp-server): add get_event_type_history tool

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -181,7 +181,7 @@ The server acts as an intermediary: it issues its own access tokens to MCP clien
 - In-process rate limiting on all OAuth endpoints (token bucket per IP, configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX`)
 - Redirect URIs registered via dynamic client registration are constrained: loopback (`localhost` / `127.0.0.0/8` / `::1`) is always allowed, cleartext `http` to non-loopback hosts is always rejected, and non-loopback `https` hosts can be restricted to a vetted allowlist via `ALLOWED_REDIRECT_HOSTS` (recommended in production to limit the open-DCR phishing surface)
 
-## Tools (54)
+## Tools (55)
 
 Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specification/draft/server/tools#tool-annotations) — a human-readable `title` plus behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so MCP clients can render them appropriately and apply safety policies.
 

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -4,7 +4,7 @@ A **Model Context Protocol (MCP)** server that wraps the [Cal.com Platform API v
 
 ## Features
 
-- **54 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Booking Routing Trace, Routing Forms, Organizations, Teams, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- **55 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Booking Routing Trace, Routing Forms, Organizations, Teams, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
 - **Dual transport** — stdio for local dev tooling, StreamableHTTP for remote/production
 - **Dual auth** — API key for stdio (local dev), OAuth 2.1 Authorization Code + PKCE for HTTP (production)
 - **Per-user token storage** — encrypted at rest with AES-256-GCM in SQLite
@@ -200,11 +200,12 @@ Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specifi
 | `get_me` | Get My Profile | Read | Get authenticated user profile |
 | `update_me` | Update My Profile | Update | Update user profile |
 
-### Event Types (6)
+### Event Types (7)
 | Tool | Title | Hint | Description |
 |---|---|---|---|
 | `get_event_types` | List Event Types | Read | List all event types |
 | `get_event_type` | Get Event Type | Read | Get a specific event type by ID |
+| `get_event_type_history` | Get Event Type History | Read | Get the audit history (change log) for an event type |
 | `get_scheduling_config` | Get Scheduling Config | Read | Get scheduling configuration for a team event type |
 | `create_event_type` | Create Event Type | Create | Create a new event type |
 | `update_event_type` | Update Event Type | Update | Update an event type |

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -47,6 +47,8 @@ import {
   deleteEventType,
   deleteEventTypeSchema,
   getEventType,
+  getEventTypeHistory,
+  getEventTypeHistorySchema,
   getEventTypeSchema,
   getEventTypes,
   getEventTypesSchema,
@@ -211,7 +213,7 @@ export function registerTools(server: McpServer): void {
     updateMe
   );
 
-  // ── Event Types (6) ──
+  // ── Event Types (7) ──
   server.registerTool(
     "get_event_types",
     {
@@ -277,6 +279,17 @@ export function registerTools(server: McpServer): void {
       annotations: READ_ONLY,
     },
     getSchedulingConfig
+  );
+  server.registerTool(
+    "get_event_type_history",
+    {
+      title: "Get Event Type History",
+      description:
+        "Get the audit history (change log) for an event type by ID (use get_event_types to find IDs). Returns audit log entries showing what changed, who made the change, when, and the previous/new field values, ordered most recent first. Supports cursor pagination via limit (1-50, default 25) and cursor. Requires audit-history access to the event type — general read access alone is not sufficient.",
+      inputSchema: getEventTypeHistorySchema,
+      annotations: READ_ONLY,
+    },
+    getEventTypeHistory
   );
 
   // ── Bookings (10) ──

--- a/apps/mcp-server/src/server-instructions.ts
+++ b/apps/mcp-server/src/server-instructions.ts
@@ -7,6 +7,7 @@ export const SERVER_INSTRUCTIONS = `You are connected to the Cal.com MCP server.
 CAPABILITIES — what you CAN do with the available tools:
 - Manage the user's profile (get_me, update_me)
 - List, create, update, and delete event types
+- Get the audit history (change log) for an event type (get_event_type_history)
 - Get scheduling configuration for team event types (hosts, priorities, weights, groups, distribution settings for roundRobin; basic host info for collective/managed)
 - List, get, create, reschedule, cancel, and confirm bookings
 - Manage booking attendees (list, get, add)

--- a/apps/mcp-server/src/tools/event-types.test.ts
+++ b/apps/mcp-server/src/tools/event-types.test.ts
@@ -12,6 +12,8 @@ import {
   deleteEventType,
   deleteEventTypeSchema,
   getEventType,
+  getEventTypeHistory,
+  getEventTypeHistorySchema,
   getEventTypeSchema,
   getEventTypes,
   getEventTypesSchema,
@@ -174,6 +176,67 @@ describe("deleteEventType", () => {
     await deleteEventType({ eventTypeId: 42 });
 
     expect(mockCalApi).toHaveBeenCalledWith("event-types/42", { method: "DELETE" });
+  });
+});
+
+describe("getEventTypeHistory schema", () => {
+  it("exports getEventTypeHistorySchema with eventTypeId, limit and cursor", () => {
+    expect(getEventTypeHistorySchema.eventTypeId).toBeDefined();
+    expect(getEventTypeHistorySchema.limit).toBeDefined();
+    expect(getEventTypeHistorySchema.cursor).toBeDefined();
+  });
+
+  it("requires eventTypeId to be an integer", () => {
+    expect(getEventTypeHistorySchema.eventTypeId.safeParse(42).success).toBe(true);
+    expect(getEventTypeHistorySchema.eventTypeId.safeParse(1.5).success).toBe(false);
+    expect(getEventTypeHistorySchema.eventTypeId.safeParse("abc").success).toBe(false);
+  });
+
+  it("enforces OpenAPI limit bounds (1-50)", () => {
+    expect(getEventTypeHistorySchema.limit.safeParse(0).success).toBe(false);
+    expect(getEventTypeHistorySchema.limit.safeParse(1).success).toBe(true);
+    expect(getEventTypeHistorySchema.limit.safeParse(50).success).toBe(true);
+    expect(getEventTypeHistorySchema.limit.safeParse(51).success).toBe(false);
+    expect(getEventTypeHistorySchema.limit.safeParse(1.5).success).toBe(false);
+    expect(getEventTypeHistorySchema.limit.safeParse(undefined).success).toBe(true);
+  });
+
+  it("enforces the cursor max length (2048)", () => {
+    expect(getEventTypeHistorySchema.cursor.safeParse("abc").success).toBe(true);
+    expect(getEventTypeHistorySchema.cursor.safeParse("a".repeat(2048)).success).toBe(true);
+    expect(getEventTypeHistorySchema.cursor.safeParse("a".repeat(2049)).success).toBe(false);
+    expect(getEventTypeHistorySchema.cursor.safeParse(undefined).success).toBe(true);
+  });
+});
+
+describe("getEventTypeHistory", () => {
+  it("calls the correct API path with no query params", async () => {
+    mockCalApi.mockResolvedValueOnce({ eventTypeId: 42, auditLogs: [] });
+
+    const result = await getEventTypeHistory({ eventTypeId: 42 });
+
+    expect(mockCalApi).toHaveBeenCalledWith("event-types/42/history", { params: {} });
+    expect(JSON.parse(result.content[0].text)).toHaveProperty("eventTypeId", 42);
+  });
+
+  it("passes limit and cursor query params", async () => {
+    mockCalApi.mockResolvedValueOnce({ eventTypeId: 42, auditLogs: [] });
+
+    await getEventTypeHistory({ eventTypeId: 42, limit: 10, cursor: "abc" });
+
+    const [path, opts] = mockCalApi.mock.calls[0];
+    expect(path).toBe("event-types/42/history");
+    const params = (opts as { params: Record<string, unknown> }).params;
+    expect(params).toHaveProperty("limit", 10);
+    expect(params).toHaveProperty("cursor", "abc");
+  });
+
+  it("handles errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(404, "Event type not found", {}));
+
+    const result = await getEventTypeHistory({ eventTypeId: 99 });
+
+    expect(result).toHaveProperty("isError", true);
   });
 });
 

--- a/apps/mcp-server/src/tools/event-types.ts
+++ b/apps/mcp-server/src/tools/event-types.ts
@@ -482,6 +482,43 @@ export async function deleteEventType(params: { eventTypeId: number }) {
   }
 }
 
+export const getEventTypeHistorySchema = {
+  eventTypeId: z
+    .number()
+    .int()
+    .describe("Event type ID whose audit history to fetch. Use get_event_types to find this."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .optional()
+    .describe("Number of audit log entries to return (1-50). Defaults to 25."),
+  cursor: z
+    .string()
+    .max(2048)
+    .optional()
+    .describe(
+      "Pagination cursor. Pass the `pagination.nextCursor` value from the previous response to fetch the next page. Omit for the first page."
+    ),
+};
+
+export async function getEventTypeHistory(params: {
+  eventTypeId: number;
+  limit?: number;
+  cursor?: string;
+}) {
+  try {
+    const qp: Record<string, string | number | undefined> = {};
+    if (params.limit !== undefined) qp.limit = params.limit;
+    if (params.cursor !== undefined) qp.cursor = params.cursor;
+    const data = await calApi(`event-types/${params.eventTypeId}/history`, { params: qp });
+    return ok(data);
+  } catch (err) {
+    return handleError("get_event_type_history", err);
+  }
+}
+
 export const getSchedulingConfigSchema = {
   eventTypeId: z
     .number()


### PR DESCRIPTION
## Summary

Adds a `get_event_type_history` MCP tool wrapping the `GET /v2/event-types/:eventTypeId/history` API v2 endpoint (added in calcom/cal#3283), so LLM clients can retrieve an event type's audit change log.

The tool mirrors the endpoint's OpenAPI contract per the `api-mcp-openapi-contract` rule:

```ts
export const getEventTypeHistorySchema = {
  eventTypeId: z.number().int(),          // path param
  limit: z.number().int().min(1).max(50).optional(),  // default 25, max 50
  cursor: z.string().max(2048).optional(),            // opaque pagination cursor
};

// GET event-types/{eventTypeId}/history?limit&cursor
// event-types already resolves to cal-api-version 2024-06-14 (config.ts), matching the endpoint.
```

Registered as `READ_ONLY` and included in discovery/metadata alongside the change:
- `register-tools.ts` — registers the tool (Event Types 6 → 7)
- `README.md` — Event Types table (+ tool count 54 → 55)
- `server-instructions.ts` — capability line
- `event-types.test.ts` — schema bound tests (limit 1–50, cursor ≤2048, int eventTypeId) + request-shape / error-path tests

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] N/A I have updated the developer docs in /docs if this PR makes changes that would require a documentation change. If N/A, write N/A here and check the checkbox.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

`bun --filter @calcom/mcp-server test` (315 tests pass) and `bun --filter @calcom/mcp-server typecheck`. Call the `get_event_type_history` tool with an `eventTypeId` you have audit-history access to; it returns audit log entries with `pagination.nextCursor`/`hasMore` for paging.

Link to Devin session: https://app.devin.ai/sessions/5379009f1b06419081ce46c2a31c6495
Requested by: @joeauyeung