### PR TITLE
feat(mcp-server): add get_user_attribute_history tool

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -4,7 +4,7 @@ A **Model Context Protocol (MCP)** server that wraps the [Cal.com Platform API v
 
 ## Features
 
-- **54 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Booking Routing Trace, Routing Forms, Organizations, Teams, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- **55 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Booking Routing Trace, Routing Forms, Organizations, Teams, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
 - **Dual transport** — stdio for local dev tooling, StreamableHTTP for remote/production
 - **Dual auth** — API key for stdio (local dev), OAuth 2.1 Authorization Code + PKCE for HTTP (production)
 - **Per-user token storage** — encrypted at rest with AES-256-GCM in SQLite
@@ -181,7 +181,7 @@ The server acts as an intermediary: it issues its own access tokens to MCP clien
 - In-process rate limiting on all OAuth endpoints (token bucket per IP, configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX`)
 - Redirect URIs registered via dynamic client registration are constrained: loopback (`localhost` / `127.0.0.0/8` / `::1`) is always allowed, cleartext `http` to non-loopback hosts is always rejected, and non-loopback `https` hosts can be restricted to a vetted allowlist via `ALLOWED_REDIRECT_HOSTS` (recommended in production to limit the open-DCR phishing surface)
 
-## Tools (54)
+## Tools (55)
 
 Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specification/draft/server/tools#tool-annotations) — a human-readable `title` plus behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so MCP clients can render them appropriately and apply safety policies.
 
@@ -260,13 +260,14 @@ Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specifi
 |---|---|---|---|
 | `calculate_routing_form_slots` | Calculate Routing Form Slots | Create | Submit a routing form response and get available slots |
 
-### Organizations: Attributes (7)
+### Organizations: Attributes (8)
 | Tool | Title | Hint | Description |
 |---|---|---|---|
 | `get_org_attributes` | List Org Attributes | Read | List attributes defined for an organization |
 | `get_org_attribute` | Get Org Attribute | Read | Get a single organization attribute by ID |
 | `get_attribute_options` | List Attribute Options | Read | List available options for a select attribute |
 | `get_user_attributes` | Get User Attributes | Read | Get attribute options assigned to a user |
+| `get_user_attribute_history` | Get User Attribute History | Read | Get the attribute assignment history (audit log) for a user |
 | `assign_attribute_to_user` | Assign Attribute to User | Create | Assign an attribute option or value to a user |
 | `update_user_attribute` | Update User Attribute Assignment | Update | Update an existing user attribute assignment |
 | `unassign_attribute_from_user` | Unassign Attribute from User | Destructive | Remove an attribute option assignment from a user |

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -65,6 +65,8 @@ import {
   getOrgAttributeSchema,
   getOrgAttributes,
   getOrgAttributesSchema,
+  getUserAttributeHistory,
+  getUserAttributeHistorySchema,
   getUserAttributes,
   getUserAttributesSchema,
   unassignAttributeFromUser,
@@ -532,7 +534,7 @@ export function registerTools(server: McpServer): void {
     calculateRoutingFormSlots
   );
 
-  // ── Organizations: Attributes (7) ──
+  // ── Organizations: Attributes (8) ──
   server.registerTool(
     "get_org_attributes",
     {
@@ -576,6 +578,17 @@ export function registerTools(server: McpServer): void {
       annotations: READ_ONLY,
     },
     getUserAttributes
+  );
+  server.registerTool(
+    "get_user_attribute_history",
+    {
+      title: "Get User Attribute History",
+      description:
+        "Get the attribute assignment history (audit log) for a user within an organization. Returns a chronological log of attribute assignment changes (assigned, updated, unassigned). Supports pagination with limit (1-50) and cursor. Requires org admin role.",
+      inputSchema: getUserAttributeHistorySchema,
+      annotations: READ_ONLY,
+    },
+    getUserAttributeHistory
   );
   server.registerTool(
     "assign_attribute_to_user",

--- a/apps/mcp-server/src/server-instructions.ts
+++ b/apps/mcp-server/src/server-instructions.ts
@@ -21,7 +21,7 @@ CAPABILITIES — what you CAN do with the available tools:
 - Manage organization memberships
 - Manage team memberships and team invite links
 - List organization teams and list teams the authenticated user belongs to
-- Read organization attributes, list attribute options, and manage user attribute assignments
+- Read organization attributes, list attribute options, manage user attribute assignments, and view a user's attribute assignment history (audit log)
 
 LIMITATIONS — what you CANNOT do (do NOT attempt to use other tools for these):
 - Delete or remove attendees from a booking

--- a/apps/mcp-server/src/tools/organizations/attributes.test.ts
+++ b/apps/mcp-server/src/tools/organizations/attributes.test.ts
@@ -1,24 +1,26 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CalApiError } from "../../utils/errors.js";
 
 vi.mock("../../utils/api-client.js", () => ({ calApi: vi.fn() }));
 
 import { calApi } from "../../utils/api-client.js";
 import {
-  getOrgAttributes,
-  getOrgAttributesSchema,
-  getOrgAttribute,
-  getOrgAttributeSchema,
-  getAttributeOptions,
-  getAttributeOptionsSchema,
-  getUserAttributes,
-  getUserAttributesSchema,
   assignAttributeToUser,
   assignAttributeToUserSchema,
-  updateUserAttribute,
-  updateUserAttributeSchema,
+  getAttributeOptions,
+  getAttributeOptionsSchema,
+  getOrgAttribute,
+  getOrgAttributeSchema,
+  getOrgAttributes,
+  getOrgAttributesSchema,
+  getUserAttributeHistory,
+  getUserAttributeHistorySchema,
+  getUserAttributes,
+  getUserAttributesSchema,
   unassignAttributeFromUser,
   unassignAttributeFromUserSchema,
+  updateUserAttribute,
+  updateUserAttributeSchema,
 } from "./attributes.js";
 
 const mockCalApi = vi.mocked(calApi);
@@ -122,6 +124,56 @@ describe("getUserAttributes", () => {
   it("handles API errors", async () => {
     mockCalApi.mockRejectedValueOnce(new CalApiError(403, "Forbidden", {}));
     const result = await getUserAttributes({ orgId: 1, userId: 42 });
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("403");
+  });
+});
+
+describe("getUserAttributeHistory", () => {
+  it("exports getUserAttributeHistorySchema", () => {
+    expect(getUserAttributeHistorySchema).toBeDefined();
+  });
+  it("returns data on success", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: {} });
+    const result = await getUserAttributeHistory({ orgId: 1, userId: 42 });
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ status: "success", data: {} });
+  });
+  it("calls correct endpoint without query params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await getUserAttributeHistory({ orgId: 1, userId: 42 });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/assignments/42/history", {
+      params: {},
+    });
+  });
+  it("passes limit and cursor query params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success" });
+    await getUserAttributeHistory({
+      orgId: 1,
+      userId: 42,
+      limit: 10,
+      cursor: "018ff5cd-6dc4-7d57-bcbc-374702ca8b38",
+    });
+    expect(mockCalApi).toHaveBeenCalledWith("organizations/1/attributes/assignments/42/history", {
+      params: { limit: 10, cursor: "018ff5cd-6dc4-7d57-bcbc-374702ca8b38" },
+    });
+  });
+  it("enforces OpenAPI limit bounds", () => {
+    expect(getUserAttributeHistorySchema.limit.safeParse(0).success).toBe(false);
+    expect(getUserAttributeHistorySchema.limit.safeParse(1).success).toBe(true);
+    expect(getUserAttributeHistorySchema.limit.safeParse(50).success).toBe(true);
+    expect(getUserAttributeHistorySchema.limit.safeParse(51).success).toBe(false);
+    expect(getUserAttributeHistorySchema.limit.safeParse(1.5).success).toBe(false);
+  });
+  it("rejects a non-uuid cursor", () => {
+    expect(getUserAttributeHistorySchema.cursor.safeParse("not-a-uuid").success).toBe(false);
+    expect(
+      getUserAttributeHistorySchema.cursor.safeParse("018ff5cd-6dc4-7d57-bcbc-374702ca8b38").success
+    ).toBe(true);
+  });
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(403, "Forbidden", {}));
+    const result = await getUserAttributeHistory({ orgId: 1, userId: 42 });
     expect(result).toHaveProperty("isError", true);
     expect(result.content[0].text).toContain("403");
   });

--- a/apps/mcp-server/src/tools/organizations/attributes.ts
+++ b/apps/mcp-server/src/tools/organizations/attributes.ts
@@ -83,6 +83,48 @@ export async function getUserAttributes(params: { orgId: number; userId: number 
   }
 }
 
+// ── Read: Attribute Assignment History (audit log) ──
+
+export const getUserAttributeHistorySchema = {
+  orgId: z
+    .number()
+    .int()
+    .describe("Organization ID. Use get_me to obtain your organizationId — never guess."),
+  userId: z.number().int().describe("User ID whose attribute assignment history to retrieve."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .optional()
+    .describe("Maximum number of audit log entries to return (1-50, default 25)."),
+  cursor: z
+    .string()
+    .uuid()
+    .optional()
+    .describe("Cursor from the previous response, used to fetch the next page."),
+};
+
+export async function getUserAttributeHistory(params: {
+  orgId: number;
+  userId: number;
+  limit?: number;
+  cursor?: string;
+}) {
+  try {
+    const qp: Record<string, string | number | boolean | undefined> = {};
+    if (params.limit !== undefined) qp.limit = params.limit;
+    if (params.cursor !== undefined) qp.cursor = params.cursor;
+    const data = await calApi(
+      `organizations/${params.orgId}/attributes/assignments/${params.userId}/history`,
+      { params: qp }
+    );
+    return ok(data);
+  } catch (err) {
+    return handleError("get_user_attribute_history", err);
+  }
+}
+
 // ── Write: Assign / Update / Unassign ──
 
 export const assignAttributeToUserSchema = {


### PR DESCRIPTION
## Summary

Adds a read-only MCP tool `get_user_attribute_history` that exposes the attribute assignment audit log for a user, wrapping API v2:

```
GET /v2/organizations/{orgId}/attributes/assignments/{userId}/history
```

There was previously no way to view attribute change history via the MCP — only the 7 CRUD-style attribute tools. This fills that gap.

Zod schema mirrors the OpenAPI contract:

```ts
export const getUserAttributeHistorySchema = {
  orgId: z.number().int(),
  userId: z.number().int(),
  limit: z.number().int().min(1).max(50).optional(),   // OpenAPI: min 1, max 50, default 25
  cursor: z.string().uuid().optional(),                // OpenAPI: uuid cursor for pagination
};
```

Registered with `READ_ONLY` annotations. Also updated the discovery/metadata surfaces per the api-mcp-openapi-contract rule: README tool table + total count (54 → 55), and `server-instructions.ts` capabilities line.

Tests in `attributes.test.ts` cover happy path, endpoint/query-param construction, the `limit` min/max/integer bounds, uuid `cursor` validation, and the error path.


Link to Devin session: https://app.devin.ai/sessions/710f4109c7a34d6e8ebd45d4fd14e975
Requested by: @joeauyeung