### PR TITLE
fix(mcp-server): serve OAuth metadata at path-aware well-known URLs

### DIFF
--- a/apps/mcp-server/src/auth/oauth-metadata.test.ts
+++ b/apps/mcp-server/src/auth/oauth-metadata.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { buildAuthorizationServerMetadata, buildProtectedResourceMetadata } from "./oauth-metadata.js";
+import {
+  buildAuthorizationServerMetadata,
+  buildProtectedResourceMetadata,
+  matchOAuthMetadataPath,
+} from "./oauth-metadata.js";
 
 const config = { serverUrl: "https://mcp.example.com" };
 
@@ -23,5 +27,54 @@ describe("buildProtectedResourceMetadata", () => {
     expect(metadata.resource).toBe("https://mcp.example.com");
     expect(metadata.authorization_servers).toEqual(["https://mcp.example.com"]);
     expect(metadata.bearer_methods_supported).toEqual(["header"]);
+  });
+});
+
+describe("matchOAuthMetadataPath", () => {
+  it("matches the root authorization-server well-known path", () => {
+    expect(matchOAuthMetadataPath("/.well-known/oauth-authorization-server")).toBe(
+      "authorization-server"
+    );
+  });
+
+  it("matches the root protected-resource well-known path", () => {
+    expect(matchOAuthMetadataPath("/.well-known/oauth-protected-resource")).toBe(
+      "protected-resource"
+    );
+  });
+
+  it("matches path-aware variants with the well-known before the /mcp path (RFC 9728/8414)", () => {
+    expect(matchOAuthMetadataPath("/.well-known/oauth-protected-resource/mcp")).toBe(
+      "protected-resource"
+    );
+    expect(matchOAuthMetadataPath("/.well-known/oauth-authorization-server/mcp")).toBe(
+      "authorization-server"
+    );
+  });
+
+  it("matches path-aware variants with the well-known after the /mcp path", () => {
+    expect(matchOAuthMetadataPath("/mcp/.well-known/oauth-protected-resource")).toBe(
+      "protected-resource"
+    );
+    expect(matchOAuthMetadataPath("/mcp/.well-known/oauth-authorization-server")).toBe(
+      "authorization-server"
+    );
+  });
+
+  it("tolerates trailing slashes", () => {
+    expect(matchOAuthMetadataPath("/.well-known/oauth-protected-resource/")).toBe(
+      "protected-resource"
+    );
+    expect(matchOAuthMetadataPath("/.well-known/oauth-protected-resource/mcp/")).toBe(
+      "protected-resource"
+    );
+  });
+
+  it("does not match unrelated paths", () => {
+    expect(matchOAuthMetadataPath("/mcp")).toBeUndefined();
+    expect(matchOAuthMetadataPath("/")).toBeUndefined();
+    expect(matchOAuthMetadataPath("/oauth/register")).toBeUndefined();
+    expect(matchOAuthMetadataPath("/.well-known/openid-configuration")).toBeUndefined();
+    expect(matchOAuthMetadataPath("/.well-known/oauth-protected-resource/other")).toBeUndefined();
   });
 });

--- a/apps/mcp-server/src/auth/oauth-metadata.ts
+++ b/apps/mcp-server/src/auth/oauth-metadata.ts
@@ -12,7 +12,9 @@ export interface OAuthServerConfig {
  * Build OAuth Authorization Server metadata per RFC 8414.
  * Returned at GET /.well-known/oauth-authorization-server
  */
-export function buildAuthorizationServerMetadata(config: OAuthServerConfig): Record<string, unknown> {
+export function buildAuthorizationServerMetadata(
+  config: OAuthServerConfig
+): Record<string, unknown> {
   const serverUrl = config.serverUrl.replace(/\/+$/, "");
   return {
     issuer: serverUrl,
@@ -41,4 +43,44 @@ export function buildProtectedResourceMetadata(config: OAuthServerConfig): Recor
     authorization_servers: [serverUrl],
     bearer_methods_supported: ["header"],
   };
+}
+
+/** Kind of OAuth discovery metadata a request path maps to. */
+export type OAuthMetadataKind = "authorization-server" | "protected-resource";
+
+const OAUTH_METADATA_NAMES: Record<OAuthMetadataKind, string> = {
+  "authorization-server": "oauth-authorization-server",
+  "protected-resource": "oauth-protected-resource",
+};
+
+/**
+ * Match a request path against the OAuth discovery well-known locations.
+ *
+ * MCP clients derive the well-known URL from the server URL they were given.
+ * When that URL carries a path (e.g. `https://mcp.cal.com/mcp`), clients probe
+ * the "path-aware" layouts from RFC 9728 (protected resource) and RFC 8414
+ * (authorization server) in addition to the plain root layout:
+ *
+ *   - `/.well-known/<name>`       (root)
+ *   - `/.well-known/<name>/mcp`   (well-known inserted before the resource path)
+ *   - `/mcp/.well-known/<name>`   (well-known appended after the resource path)
+ *
+ * We serve identical metadata for all three so discovery succeeds whether the
+ * user configured the base URL or the `/mcp` endpoint. Returning 404 for the
+ * `/mcp`-scoped variants breaks connectors (e.g. Claude) that only probe the
+ * path-aware URL, surfacing as "Couldn't register with cal.com's sign-in service".
+ */
+export function matchOAuthMetadataPath(pathname: string): OAuthMetadataKind | undefined {
+  const normalized = pathname.replace(/\/+$/, "") || "/";
+  for (const kind of Object.keys(OAUTH_METADATA_NAMES) as OAuthMetadataKind[]) {
+    const name = OAUTH_METADATA_NAMES[kind];
+    if (
+      normalized === `/.well-known/${name}` ||
+      normalized === `/.well-known/${name}/mcp` ||
+      normalized === `/mcp/.well-known/${name}`
+    ) {
+      return kind;
+    }
+  }
+  return undefined;
 }

--- a/apps/mcp-server/src/http-server.ts
+++ b/apps/mcp-server/src/http-server.ts
@@ -7,6 +7,7 @@ import { SERVER_INSTRUCTIONS } from "./server-instructions.js";
 import {
   buildAuthorizationServerMetadata,
   buildProtectedResourceMetadata,
+  matchOAuthMetadataPath,
 } from "./auth/oauth-metadata.js";
 import {
   handleRegister,
@@ -66,31 +67,39 @@ const startedAt = Date.now();
 
 export async function startHttpServer(
   registerTools: (server: McpServer) => void,
-  config: HttpServerConfig,
+  config: HttpServerConfig
 ): Promise<void> {
   const { port, oauthConfig } = config;
   const maxSessions = config.maxSessions ?? (Number(process.env.MAX_SESSIONS) || 10_000);
-  const sessionIdleTimeoutMs = config.sessionIdleTimeoutMs ?? (Number(process.env.SESSION_IDLE_TIMEOUT_MS) || 30 * 60 * 1000);
-  const maxRegisteredClients = config.maxRegisteredClients ?? (Number(process.env.MAX_REGISTERED_CLIENTS) || 10_000);
+  const sessionIdleTimeoutMs =
+    config.sessionIdleTimeoutMs ?? (Number(process.env.SESSION_IDLE_TIMEOUT_MS) || 30 * 60 * 1000);
+  const maxRegisteredClients =
+    config.maxRegisteredClients ?? (Number(process.env.MAX_REGISTERED_CLIENTS) || 10_000);
   const redirectUriPolicy = { allowedHosts: config.allowedRedirectHosts ?? [] };
   const corsOrigin = config.corsOrigin ?? process.env.CORS_ORIGIN;
-  const shutdownTimeoutMs = config.shutdownTimeoutMs ?? (Number(process.env.SHUTDOWN_TIMEOUT_MS) || 10_000);
-  const openaiAppsChallengeToken = config.openaiAppsChallengeToken ?? process.env.OPENAI_APPS_CHALLENGE_TOKEN;
+  const shutdownTimeoutMs =
+    config.shutdownTimeoutMs ?? (Number(process.env.SHUTDOWN_TIMEOUT_MS) || 10_000);
+  const openaiAppsChallengeToken =
+    config.openaiAppsChallengeToken ?? process.env.OPENAI_APPS_CHALLENGE_TOKEN;
 
   await initDb();
 
-  const rateLimitWindowMs = config.rateLimitWindowMs ?? (Number(process.env.RATE_LIMIT_WINDOW_MS) || 60_000);
+  const rateLimitWindowMs =
+    config.rateLimitWindowMs ?? (Number(process.env.RATE_LIMIT_WINDOW_MS) || 60_000);
   const rateLimitMax = config.rateLimitMax ?? (Number(process.env.RATE_LIMIT_MAX) || 30);
   const oauthRateLimiter = new RateLimiter({ windowMs: rateLimitWindowMs, max: rateLimitMax });
   oauthRateLimiter.startGc();
   const mcpRateLimiter = new RateLimiter({ windowMs: rateLimitWindowMs, max: rateLimitMax * 3 });
   mcpRateLimiter.startGc();
 
-  const cleanupInterval = setInterval(() => {
-    cleanupExpired().catch((err) => {
-      logger.error("Cleanup error", { error: String(err) });
-    });
-  }, 5 * 60 * 1000);
+  const cleanupInterval = setInterval(
+    () => {
+      cleanupExpired().catch((err) => {
+        logger.error("Cleanup error", { error: String(err) });
+      });
+    },
+    5 * 60 * 1000
+  );
 
   const sessions = new Map<
     string,
@@ -148,16 +157,20 @@ export async function startHttpServer(
       try {
         await sql`SELECT 1`;
         dbOk = true;
-      } catch { /* db not healthy */ }
+      } catch {
+        /* db not healthy */
+      }
       const status = dbOk ? "ok" : "degraded";
       const code = dbOk ? 200 : 503;
       res.writeHead(code, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({
-        status,
-        sessions: sessions.size,
-        db: dbOk ? "ok" : "error",
-        uptime: Math.floor((Date.now() - startedAt) / 1000),
-      }));
+      res.end(
+        JSON.stringify({
+          status,
+          sessions: sessions.size,
+          db: dbOk ? "ok" : "error",
+          uptime: Math.floor((Date.now() - startedAt) / 1000),
+        })
+      );
       return;
     }
 
@@ -179,13 +192,17 @@ export async function startHttpServer(
     }
 
     // ── OAuth metadata endpoints ──
-    if (url.pathname === "/.well-known/oauth-authorization-server" && req.method === "GET") {
+    // Served at both the root well-known locations and their `/mcp`-scoped
+    // path-aware variants so connectors that probe the path-aware URL (per
+    // RFC 9728 / RFC 8414) can complete discovery.
+    const metadataKind = req.method === "GET" ? matchOAuthMetadataPath(url.pathname) : undefined;
+    if (metadataKind === "authorization-server") {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(asMetadata));
       return;
     }
 
-    if (url.pathname === "/.well-known/oauth-protected-resource" && req.method === "GET") {
+    if (metadataKind === "protected-resource") {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(prMetadata));
       return;
@@ -204,7 +221,12 @@ export async function startHttpServer(
         const currentCount = await countRegisteredClients();
         if (currentCount >= maxRegisteredClients) {
           res.writeHead(503, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "server_error", error_description: "Maximum number of registered clients reached" }));
+          res.end(
+            JSON.stringify({
+              error: "server_error",
+              error_description: "Maximum number of registered clients reached",
+            })
+          );
           return;
         }
         await handleRegister(req, res, redirectUriPolicy);
@@ -244,7 +266,9 @@ export async function startHttpServer(
           "Content-Type": "application/json",
           "WWW-Authenticate": `Bearer resource_metadata="${oauthConfig.serverUrl}/.well-known/oauth-protected-resource"`,
         });
-        res.end(JSON.stringify({ error: "unauthorized", error_description: "Bearer token required" }));
+        res.end(
+          JSON.stringify({ error: "unauthorized", error_description: "Bearer token required" })
+        );
         return;
       }
 
@@ -255,7 +279,12 @@ export async function startHttpServer(
             "Content-Type": "application/json",
             "WWW-Authenticate": `Bearer resource_metadata="${oauthConfig.serverUrl}/.well-known/oauth-protected-resource"`,
           });
-          res.end(JSON.stringify({ error: "invalid_token", error_description: "Invalid or expired access token" }));
+          res.end(
+            JSON.stringify({
+              error: "invalid_token",
+              error_description: "Invalid or expired access token",
+            })
+          );
           return;
         }
         const sessionId = req.headers["mcp-session-id"] as string | undefined;
@@ -276,13 +305,20 @@ export async function startHttpServer(
 
       const existingSession = sessionId ? sessions.get(sessionId) : undefined;
       if (sessionId && existingSession) {
-        const freshHeaders = bearerToken ? await resolveCalAuthHeaders(bearerToken, oauthConfig) : undefined;
+        const freshHeaders = bearerToken
+          ? await resolveCalAuthHeaders(bearerToken, oauthConfig)
+          : undefined;
         if (!freshHeaders) {
           res.writeHead(401, {
             "Content-Type": "application/json",
             "WWW-Authenticate": `Bearer resource_metadata="${oauthConfig.serverUrl}/.well-known/oauth-protected-resource"`,
           });
-          res.end(JSON.stringify({ error: "invalid_token", error_description: "Cal.com token expired and could not be refreshed" }));
+          res.end(
+            JSON.stringify({
+              error: "invalid_token",
+              error_description: "Cal.com token expired and could not be refreshed",
+            })
+          );
           return;
         }
         existingSession.lastActivityAt = Date.now();
@@ -306,7 +342,12 @@ export async function startHttpServer(
         // Enforce max sessions limit
         if (sessions.size >= maxSessions) {
           res.writeHead(503, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "server_error", error_description: "Maximum number of sessions reached" }));
+          res.end(
+            JSON.stringify({
+              error: "server_error",
+              error_description: "Maximum number of sessions reached",
+            })
+          );
           return;
         }
 
@@ -316,7 +357,12 @@ export async function startHttpServer(
             "Content-Type": "application/json",
             "WWW-Authenticate": `Bearer resource_metadata="${oauthConfig.serverUrl}/.well-known/oauth-protected-resource"`,
           });
-          res.end(JSON.stringify({ error: "invalid_token", error_description: "Invalid or expired access token" }));
+          res.end(
+            JSON.stringify({
+              error: "invalid_token",
+              error_description: "Invalid or expired access token",
+            })
+          );
           return;
         }
 
@@ -331,7 +377,7 @@ export async function startHttpServer(
           },
           {
             instructions: SERVER_INSTRUCTIONS,
-          },
+          }
         );
 
         registerTools(server);
@@ -354,7 +400,12 @@ export async function startHttpServer(
 
         const newSessionId = transport.sessionId;
         if (newSessionId) {
-          sessions.set(newSessionId, { transport, server, calAuthHeaders, lastActivityAt: Date.now() });
+          sessions.set(newSessionId, {
+            transport,
+            server,
+            calAuthHeaders,
+            lastActivityAt: Date.now(),
+          });
           logger.info("New session created", { sessionId: newSessionId });
         }
         return;
@@ -395,9 +446,11 @@ export async function startHttpServer(
       Array.from(sessions.entries()).map(async ([id, session]) => {
         try {
           await session.transport.close();
-        } catch { /* best effort */ }
+        } catch {
+          /* best effort */
+        }
         sessions.delete(id);
-      }),
+      })
     );
 
     const timeout = new Promise<void>((resolve) => setTimeout(resolve, shutdownTimeoutMs));
@@ -409,9 +462,13 @@ export async function startHttpServer(
   };
 
   process.on("SIGINT", () => {
-    shutdown().then(() => process.exit(0)).catch(() => process.exit(1));
+    shutdown()
+      .then(() => process.exit(0))
+      .catch(() => process.exit(1));
   });
   process.on("SIGTERM", () => {
-    shutdown().then(() => process.exit(0)).catch(() => process.exit(1));
+    shutdown()
+      .then(() => process.exit(0))
+      .catch(() => process.exit(1));
   });
 }

--- a/apps/mcp-server/src/vercel-handler.ts
+++ b/apps/mcp-server/src/vercel-handler.ts
@@ -7,6 +7,7 @@ import { authContext } from "./auth/context.js";
 import {
   buildAuthorizationServerMetadata,
   buildProtectedResourceMetadata,
+  matchOAuthMetadataPath,
 } from "./auth/oauth-metadata.js";
 import {
   handleAuthorize,
@@ -74,7 +75,11 @@ function oauthConfigFromHttpConfig(config: HttpConfig): OAuthConfig {
   };
 }
 
-function setCorsHeaders(req: IncomingMessage, res: ServerResponse, corsOrigin: string | undefined): void {
+function setCorsHeaders(
+  req: IncomingMessage,
+  res: ServerResponse,
+  corsOrigin: string | undefined
+): void {
   // Credentialed requests (Authorization header) require an explicit origin,
   // not "*". Fall back to echoing the request's Origin header.
   const origin = corsOrigin ?? req.headers.origin ?? "*";
@@ -85,7 +90,7 @@ function setCorsHeaders(req: IncomingMessage, res: ServerResponse, corsOrigin: s
   // preflight fails with "header not allowed".
   res.setHeader(
     "Access-Control-Allow-Headers",
-    "Content-Type, Authorization, Mcp-Session-Id, mcp-protocol-version, last-event-id",
+    "Content-Type, Authorization, Mcp-Session-Id, mcp-protocol-version, last-event-id"
   );
   res.setHeader("Access-Control-Expose-Headers", "Mcp-Session-Id");
   res.setHeader("Access-Control-Allow-Credentials", "true");
@@ -145,12 +150,16 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
   }
 
   // ── OAuth metadata ──
-  if (url.pathname === "/.well-known/oauth-authorization-server" && req.method === "GET") {
+  // Served at both the root well-known locations and their `/mcp`-scoped
+  // path-aware variants so connectors that probe the path-aware URL (per
+  // RFC 9728 / RFC 8414) can complete discovery.
+  const metadataKind = req.method === "GET" ? matchOAuthMetadataPath(url.pathname) : undefined;
+  if (metadataKind === "authorization-server") {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(buildAuthorizationServerMetadata({ serverUrl: oauthConfig.serverUrl })));
     return;
   }
-  if (url.pathname === "/.well-known/oauth-protected-resource" && req.method === "GET") {
+  if (metadataKind === "protected-resource") {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(buildProtectedResourceMetadata({ serverUrl: oauthConfig.serverUrl })));
     return;
@@ -205,7 +214,9 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
         "Content-Type": "application/json",
         "WWW-Authenticate": `Bearer resource_metadata="${oauthConfig.serverUrl.replace(/\/+$/, "")}/.well-known/oauth-protected-resource"`,
       });
-      res.end(JSON.stringify({ error: "unauthorized", error_description: "Bearer token required" }));
+      res.end(
+        JSON.stringify({ error: "unauthorized", error_description: "Bearer token required" })
+      );
       return;
     }
 
@@ -215,7 +226,12 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
         "Content-Type": "application/json",
         "WWW-Authenticate": `Bearer resource_metadata="${oauthConfig.serverUrl.replace(/\/+$/, "")}/.well-known/oauth-protected-resource"`,
       });
-      res.end(JSON.stringify({ error: "invalid_token", error_description: "Invalid or expired access token" }));
+      res.end(
+        JSON.stringify({
+          error: "invalid_token",
+          error_description: "Invalid or expired access token",
+        })
+      );
       return;
     }
 
@@ -232,7 +248,12 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
     // mode — no error, it just skips the standalone stream.
     if (req.method === "GET") {
       res.writeHead(405, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "method_not_allowed", error_description: "SSE stream not supported in serverless mode" }));
+      res.end(
+        JSON.stringify({
+          error: "method_not_allowed",
+          error_description: "SSE stream not supported in serverless mode",
+        })
+      );
       return;
     }
 
@@ -265,7 +286,9 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
       return;
     }
 
-    const messages: JSONRPCMessage[] = (Array.isArray(rawMessage) ? rawMessage : [rawMessage]) as JSONRPCMessage[];
+    const messages: JSONRPCMessage[] = (
+      Array.isArray(rawMessage) ? rawMessage : [rawMessage]
+    ) as JSONRPCMessage[];
 
     // JSON-RPC requests have an `id` field; notifications do not.
     const requestIds = messages
@@ -282,7 +305,9 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
     // -- 2. Build minimal Transport --------------------------------------------
     const collectedResponses = new Map<string | number, JSONRPCMessage>();
     let resolveAll!: () => void;
-    const allDone = new Promise<void>((r) => { resolveAll = r; });
+    const allDone = new Promise<void>((r) => {
+      resolveAll = r;
+    });
 
     const transport: Transport = {
       // These callbacks are set by McpServer.connect() before start() returns.
@@ -290,8 +315,12 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
       onclose: undefined,
       onerror: undefined,
 
-      async start() { /* nothing to set up */ },
-      async close() { transport.onclose?.(); },
+      async start() {
+        /* nothing to set up */
+      },
+      async close() {
+        transport.onclose?.();
+      },
 
       async send(msg: JSONRPCMessage) {
         // Only capture responses (they have `id` + `result`/`error`, but no `method`);
@@ -306,7 +335,7 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
     // -- 3. Connect McpServer and drive messages --------------------------------
     const server = new McpServer(
       { name: "calcom-mcp-server", version: "0.1.0" },
-      { instructions: SERVER_INSTRUCTIONS },
+      { instructions: SERVER_INSTRUCTIONS }
     );
     registerTools(server);
     await server.connect(transport);
@@ -322,7 +351,10 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
         await Promise.race([
           allDone,
           new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error(`MCP handler timed out after ${timeoutMs} ms`)), timeoutMs),
+            setTimeout(
+              () => reject(new Error(`MCP handler timed out after ${timeoutMs} ms`)),
+              timeoutMs
+            )
           ),
         ]);
       });
@@ -333,7 +365,7 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
     // -- 4. Return JSON --------------------------------------------------------
     const responsePayload = Array.isArray(rawMessage)
       ? requestIds.map((id) => collectedResponses.get(id) ?? null)
-      : collectedResponses.get(requestIds[0]) ?? null;
+      : (collectedResponses.get(requestIds[0]) ?? null);
 
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(responsePayload));


### PR DESCRIPTION
## Summary

Fixes MCP clients (e.g. Claude) failing to connect to `https://mcp.cal.com/mcp` with **"Couldn't register with cal.com's sign-in service."**

When the connector URL carries a path (`/mcp`), clients derive the OAuth discovery URLs per RFC 9728 (protected resource) / RFC 8414 (authorization server) as **path-aware** variants. The server only served metadata at the bare root paths and returned **404** for the `/mcp`-scoped forms, so discovery failed before authorization ever started.

Axiom (`cal-companion-mcp`, last 7d) showed thousands of 404s on exactly these paths, while the root paths returned 200:
- `/.well-known/oauth-protected-resource/mcp` → 404 (~2,330)
- `/mcp/.well-known/oauth-protected-resource` → 404 (~1,746)
- `/.well-known/oauth-authorization-server/mcp` → 404 (~670)
- `/mcp/.well-known/oauth-authorization-server` → 404 (~452)

The fix serves the **same** metadata at all three layouts for each document, via a shared matcher:

```ts
// oauth-metadata.ts
matchOAuthMetadataPath(pathname) // -> "authorization-server" | "protected-resource" | undefined
// matches, for each <name> in {oauth-authorization-server, oauth-protected-resource}:
//   /.well-known/<name>          (root)
//   /.well-known/<name>/mcp      (well-known before the resource path — RFC 9728/8414)
//   /mcp/.well-known/<name>      (well-known after the resource path)
```

Both request entry points (`vercel-handler.ts`, `http-server.ts`) now route via this matcher instead of exact-string equality:

```diff
-  if (url.pathname === "/.well-known/oauth-authorization-server" && req.method === "GET") { ...AS metadata }
-  if (url.pathname === "/.well-known/oauth-protected-resource" && req.method === "GET") { ...PRM }
+  const metadataKind = req.method === "GET" ? matchOAuthMetadataPath(url.pathname) : undefined;
+  if (metadataKind === "authorization-server") { ...AS metadata }
+  if (metadataKind === "protected-resource") { ...PRM }
```

Metadata **content is unchanged** (`resource`/`issuer` stay the base URL), so already-connected clients are unaffected; this only stops returning 404 on the path-aware discovery URLs.

## Notes
- Some `biome format` line-wrapping churn appears in the two handler files because they were previously committed unformatted against the repo's `lineWidth: 100`; the logical change is the metadata routing only.
- Tests added in `oauth-metadata.test.ts` covering all matched layouts, trailing slashes, and non-matches. Full suite: 328 passing. `typecheck` + `lint` clean.

Closes ENG-2252
https://linear.app/calcom/issue/ENG-2252

Link to Devin session: https://app.devin.ai/sessions/41abfbf2d7c84d4f93def858f41138be
Requested by: @joeauyeung