### PR TITLE
feat(mcp): add CRM sync errors tool

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -4,7 +4,7 @@ A **Model Context Protocol (MCP)** server that wraps the [Cal.com Platform API v
 
 ## Features
 
-- **55 tools** covering Bookings, Event Types, Schedules, Availability, Calendars, Conferencing, Booking Routing Trace, Routing Forms, Organizations, Teams, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- **56 tools** covering Bookings, Event Types, CRM Sync Errors, Schedules, Availability, Calendars, Conferencing, Booking Routing Trace, Routing Forms, Organizations, Teams, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
 - **Dual transport** — stdio for local dev tooling, StreamableHTTP for remote/production
 - **Dual auth** — API key for stdio (local dev), OAuth 2.1 Authorization Code + PKCE for HTTP (production)
 - **Per-user token storage** — encrypted at rest with AES-256-GCM in SQLite
@@ -181,7 +181,7 @@ The server acts as an intermediary: it issues its own access tokens to MCP clien
 - In-process rate limiting on all OAuth endpoints (token bucket per IP, configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX`)
 - Redirect URIs registered via dynamic client registration are constrained: loopback (`localhost` / `127.0.0.0/8` / `::1`) is always allowed, cleartext `http` to non-loopback hosts is always rejected, and non-loopback `https` hosts can be restricted to a vetted allowlist via `ALLOWED_REDIRECT_HOSTS` (recommended in production to limit the open-DCR phishing surface)
 
-## Tools (55)
+## Tools (56)
 
 Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specification/draft/server/tools#tool-annotations) — a human-readable `title` plus behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so MCP clients can render them appropriately and apply safety policies.
 
@@ -200,11 +200,12 @@ Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specifi
 | `get_me` | Get My Profile | Read | Get authenticated user profile |
 | `update_me` | Update My Profile | Update | Update user profile |
 
-### Event Types (7)
+### Event Types (8)
 | Tool | Title | Hint | Description |
 |---|---|---|---|
 | `get_event_types` | List Event Types | Read | List all event types |
 | `get_event_type` | Get Event Type | Read | Get a specific event type by ID |
+| `get_crm_sync_errors` | List CRM Sync Errors | Read | List active/current CRM sync errors for an event type and app slug; optionally include dismissed historical errors |
 | `get_event_type_history` | Get Event Type History | Read | Get the audit history (change log) for an event type |
 | `get_scheduling_config` | Get Scheduling Config | Read | Get scheduling configuration for a team event type |
 | `create_event_type` | Create Event Type | Create | Create a new event type |

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -46,6 +46,8 @@ import {
   createEventTypeSchema,
   deleteEventType,
   deleteEventTypeSchema,
+  getCrmSyncErrors,
+  getCrmSyncErrorsSchema,
   getEventType,
   getEventTypeHistory,
   getEventTypeHistorySchema,
@@ -215,7 +217,7 @@ export function registerTools(server: McpServer): void {
     updateMe
   );
 
-  // ── Event Types (7) ──
+  // ── Event Types (8) ──
   server.registerTool(
     "get_event_types",
     {
@@ -237,6 +239,17 @@ export function registerTools(server: McpServer): void {
       annotations: READ_ONLY,
     },
     getEventType
+  );
+  server.registerTool(
+    "get_crm_sync_errors",
+    {
+      title: "List CRM Sync Errors",
+      description:
+        "List CRM sync errors for an event type and CRM app slug, such as salesforce. By default returns active/current errors only; set includeDismissed=true to include dismissed historical errors. Use eventTypeId plus appSlug, not credentialId. Supports cursor pagination via limit (1-100, default 50) and cursor. Requires read access to the event type.",
+      inputSchema: getCrmSyncErrorsSchema,
+      annotations: READ_ONLY,
+    },
+    getCrmSyncErrors
   );
   server.registerTool(
     "create_event_type",

--- a/apps/mcp-server/src/server-instructions.ts
+++ b/apps/mcp-server/src/server-instructions.ts
@@ -8,6 +8,7 @@ CAPABILITIES — what you CAN do with the available tools:
 - Manage the user's profile (get_me, update_me)
 - List, create, update, and delete event types
 - Get the audit history (change log) for an event type (get_event_type_history)
+- List CRM sync errors for an event type and CRM app slug (get_crm_sync_errors)
 - Get scheduling configuration for team event types (hosts, priorities, weights, groups, distribution settings for roundRobin; basic host info for collective/managed)
 - List, get, create, reschedule, cancel, and confirm bookings
 - Manage booking attendees (list, get, add)
@@ -37,7 +38,7 @@ LIMITATIONS — what you CANNOT do (do NOT attempt to use other tools for these)
 
 RULES:
 1. If a user asks for something not listed under CAPABILITIES, tell them clearly: "The Cal.com integration doesn't support [action] yet." Do NOT call a different tool hoping it might work.
-2. NEVER guess or fabricate IDs, emails, names, phone numbers, or time zones. If you don't have a value, either use the appropriate discovery tool (e.g., get_me, get_event_types, get_bookings, get_org_team_bookings, get_org_user_bookings, get_org_memberships, get_team_memberships, get_org_teams, get_my_teams, get_org_attributes, get_attribute_options, get_user_attributes) or ask the user.
+2. NEVER guess or fabricate IDs, emails, names, phone numbers, app slugs, or time zones. If you don't have a value, either use the appropriate discovery tool (e.g., get_me, get_event_types, get_event_type, get_bookings, get_org_team_bookings, get_org_user_bookings, get_org_memberships, get_team_memberships, get_org_teams, get_my_teams, get_org_attributes, get_attribute_options, get_user_attributes) or ask the user.
 3. Before creating or rescheduling a booking, ALWAYS check availability first using get_availability.
 4. For destructive actions (delete event type, cancel booking, delete schedule, delete organization membership, delete team membership, unassign attribute from user), confirm with the user before proceeding.
 5. All date/time values sent to the API must be in UTC ISO 8601 format.`;

--- a/apps/mcp-server/src/tools/event-types.test.ts
+++ b/apps/mcp-server/src/tools/event-types.test.ts
@@ -11,6 +11,8 @@ import {
   createEventTypeSchema,
   deleteEventType,
   deleteEventTypeSchema,
+  getCrmSyncErrors,
+  getCrmSyncErrorsSchema,
   getEventType,
   getEventTypeHistory,
   getEventTypeHistorySchema,
@@ -43,6 +45,14 @@ describe("event-types schemas", () => {
     expect(getEventTypeSchema.eventTypeId).toBeDefined();
   });
 
+  it("exports getCrmSyncErrorsSchema with eventTypeId, appSlug and pagination params", () => {
+    expect(getCrmSyncErrorsSchema.eventTypeId).toBeDefined();
+    expect(getCrmSyncErrorsSchema.appSlug).toBeDefined();
+    expect(getCrmSyncErrorsSchema.includeDismissed).toBeDefined();
+    expect(getCrmSyncErrorsSchema.cursor).toBeDefined();
+    expect(getCrmSyncErrorsSchema.limit).toBeDefined();
+  });
+
   it("exports createEventTypeSchema with required and optional fields", () => {
     expect(createEventTypeSchema.title).toBeDefined();
     expect(createEventTypeSchema.slug).toBeDefined();
@@ -68,6 +78,92 @@ describe("event-types schemas", () => {
 
   it("exports deleteEventTypeSchema", () => {
     expect(deleteEventTypeSchema.eventTypeId).toBeDefined();
+  });
+});
+
+describe("getCrmSyncErrors schema", () => {
+  it("requires eventTypeId to be an integer", () => {
+    expect(getCrmSyncErrorsSchema.eventTypeId.safeParse(42).success).toBe(true);
+    expect(getCrmSyncErrorsSchema.eventTypeId.safeParse(1.5).success).toBe(false);
+    expect(getCrmSyncErrorsSchema.eventTypeId.safeParse("abc").success).toBe(false);
+  });
+
+  it("requires a non-empty appSlug", () => {
+    expect(getCrmSyncErrorsSchema.appSlug.safeParse("salesforce").success).toBe(true);
+    expect(getCrmSyncErrorsSchema.appSlug.safeParse("").success).toBe(false);
+  });
+
+  it("enforces OpenAPI limit bounds (1-100)", () => {
+    expect(getCrmSyncErrorsSchema.limit.safeParse(0).success).toBe(false);
+    expect(getCrmSyncErrorsSchema.limit.safeParse(1).success).toBe(true);
+    expect(getCrmSyncErrorsSchema.limit.safeParse(100).success).toBe(true);
+    expect(getCrmSyncErrorsSchema.limit.safeParse(101).success).toBe(false);
+    expect(getCrmSyncErrorsSchema.limit.safeParse(1.5).success).toBe(false);
+    expect(getCrmSyncErrorsSchema.limit.safeParse(undefined).success).toBe(true);
+  });
+});
+
+describe("getCrmSyncErrors", () => {
+  it("calls the correct API path with required query params", async () => {
+    const mockResponse = {
+      status: "success",
+      data: [
+        {
+          id: "019ea850-efc7-7a48-8508-aed31b72ce68",
+          credentialId: 123,
+          eventTypeId: 49,
+          appSlug: "salesforce",
+          timestamp: "2026-06-08T17:38:57.107Z",
+          errorCode: "FIELD_CUSTOM_VALIDATION_EXCEPTION",
+          errorMessage: "Validation rule blocked this update",
+          droppedFields: ["Custom_Field__c"],
+          dismissedAt: null,
+        },
+      ],
+      pagination: {
+        nextCursor: null,
+        hasMore: false,
+      },
+    };
+    mockCalApi.mockResolvedValueOnce(mockResponse);
+
+    const result = await getCrmSyncErrors({ eventTypeId: 49, appSlug: "salesforce" });
+
+    expect(mockCalApi).toHaveBeenCalledWith("event-types/49/crm-sync-errors", {
+      params: { appSlug: "salesforce" },
+    });
+    expect(JSON.parse(result.content[0].text)).toEqual(mockResponse);
+  });
+
+  it("passes optional history and pagination query params", async () => {
+    mockCalApi.mockResolvedValueOnce({ status: "success", data: [], pagination: {} });
+
+    await getCrmSyncErrors({
+      eventTypeId: 49,
+      appSlug: "salesforce",
+      includeDismissed: true,
+      cursor: "eyJ2IjoxLCJzb3J0VXVpZCI6IjAxOWVhODUwIn0",
+      limit: 25,
+    });
+
+    const [path, opts] = mockCalApi.mock.calls[0];
+    expect(path).toBe("event-types/49/crm-sync-errors");
+    const params = (opts as { params: Record<string, unknown> }).params;
+    expect(params).toEqual({
+      appSlug: "salesforce",
+      includeDismissed: true,
+      cursor: "eyJ2IjoxLCJzb3J0VXVpZCI6IjAxOWVhODUwIn0",
+      limit: 25,
+    });
+  });
+
+  it("handles API errors", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(403, "Forbidden", {}));
+
+    const result = await getCrmSyncErrors({ eventTypeId: 49, appSlug: "salesforce" });
+
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("403");
   });
 });
 

--- a/apps/mcp-server/src/tools/event-types.test.ts
+++ b/apps/mcp-server/src/tools/event-types.test.ts
@@ -135,7 +135,7 @@ describe("getCrmSyncErrors", () => {
     expect(JSON.parse(result.content[0].text)).toEqual(mockResponse);
   });
 
-  it("passes optional history and pagination query params", async () => {
+  it("passes optional includeDismissed and pagination query params", async () => {
     mockCalApi.mockResolvedValueOnce({ status: "success", data: [], pagination: {} });
 
     await getCrmSyncErrors({

--- a/apps/mcp-server/src/tools/event-types.ts
+++ b/apps/mcp-server/src/tools/event-types.ts
@@ -60,6 +60,60 @@ export async function getEventType(params: { eventTypeId: number }) {
   }
 }
 
+export const getCrmSyncErrorsSchema = {
+  eventTypeId: z
+    .number()
+    .int()
+    .describe("Event type ID whose CRM sync errors to fetch. Use get_event_types to find this."),
+  appSlug: z
+    .string()
+    .min(1)
+    .describe("CRM app slug connected to the event type, for example `salesforce`."),
+  includeDismissed: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, returns dismissed historical errors as well as active errors. Defaults to false."
+    ),
+  cursor: z
+    .string()
+    .optional()
+    .describe(
+      "Opaque cursor from `pagination.nextCursor`. Omit to fetch the first page of CRM sync errors."
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("Maximum number of CRM sync errors to return (1-100). Defaults to 50."),
+};
+
+export async function getCrmSyncErrors(params: {
+  eventTypeId: number;
+  appSlug: string;
+  includeDismissed?: boolean;
+  cursor?: string;
+  limit?: number;
+}) {
+  try {
+    const qp: Record<string, string | number | boolean | undefined> = {
+      appSlug: params.appSlug,
+    };
+    if (params.includeDismissed !== undefined) qp.includeDismissed = params.includeDismissed;
+    if (params.cursor !== undefined) qp.cursor = params.cursor;
+    if (params.limit !== undefined) qp.limit = params.limit;
+
+    const data = await calApi(`event-types/${params.eventTypeId}/crm-sync-errors`, {
+      params: qp,
+    });
+    return ok(data);
+  } catch (err) {
+    return handleError("get_crm_sync_errors", err);
+  }
+}
+
 export const createEventTypeSchema = {
   title: z.string().describe("Event type title"),
   slug: z.string().describe("URL-friendly slug (e.g. '30min')"),


### PR DESCRIPTION
## Summary

Fixes https://linear.app/calcom/issue/ENG-1702/add-mcp-tool-for-sync-and-error-visibility

API V2 endpoint was merged https://github.com/calcom/cal/pull/4005 

- Add get_crm_sync_errors MCP tool for GET /v2/event-types/{eventTypeId}/crm-sync-errors
- Mirror API v2 input contract: eventTypeId, appSlug, includeDismissed, cursor, limit 1-100
- Register the tool, update server instructions, README counts/table, and add focused tests

