### PR TITLE
fix(hooks): run lint-staged from repo root

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-cd companion
-npx lint-staged
+bunx lint-staged

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packages/*"
   ],
   "scripts": {
+    "prepare": "husky",
     "mobile": "cd apps/mobile && bunx expo start",
     "mobile:ios": "cd apps/mobile && bunx expo run:ios",
     "mobile:android": "cd apps/mobile && bunx expo run:android",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "5.9.3"
   },
   "lint-staged": {
-    "**/*.{js,jsx,ts,tsx,json,css,md}": [
+    "**/*.{js,jsx,ts,tsx,json}": [
       "biome format --write"
     ]
   },


### PR DESCRIPTION
## Summary

- Remove the incorrect ``cd companion`` from `.husky/pre-commit`, which fails because this repo root *is* companion (there is no nested directory).
- Run ``bunx lint-staged`` from the monorepo root so pre-commit formatting works for new contributors.
- Add a root ``prepare`` script (``husky``) so hooks are installed on ``bun install``.

## Context

Part of #151.

## Test plan

- [x] Verified pre-commit runs ``lint-staged`` successfully on commit from repo root
- [x] Confirmed staged JSON is formatted by Biome via lint-staged
- [ ] CI passes on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the pre-commit hook to run `lint-staged` from the repo root via `bunx`, add a root `prepare` script for `husky`, and remove the stray `cd companion` so formatting runs on commit (part of #151). Also align `lint-staged` globs with `Biome` (js/jsx/ts/tsx/json only) to avoid failures on docs-only commits.

<sup>Written for commit cb274b91319dc72c2279a1d98ec601626958af90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/calcom/companion/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

