### PR TITLE
fix(hooks): run pre-commit from repo root

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-cd companion
 npx lint-staged


### PR DESCRIPTION
## Summary
- remove the stale `cd companion` from the Husky pre-commit hook
- keep the existing `npx lint-staged` command running from the repository root

## Why
Addresses the Husky hook portion of #151. This repository is already the `companion` root, so the nested `companion/` directory does not exist and the hook prints a directory error before lint-staged runs.

## Verification
- `sh .husky/pre-commit`
- `./.husky/pre-commit`
- `git diff --check`

## Notes
Kept this scoped to the hook failure only. The README/script alignment called out in #151 can stay as a separate PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `husky` pre-commit hook to run from the repo root. Removes the stale `cd companion` so `lint-staged` runs without directory errors; addresses the hook failure in Linear #151.

<sup>Written for commit ac4f9be25ed0bc676ca3172044bc96753e2cf1ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/calcom/companion/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

