### PR TITLE
fix(chat): guide users through credit scope reconnect

### DIFF
--- a/apps/chat/lib/agent-credits.test.ts
+++ b/apps/chat/lib/agent-credits.test.ts
@@ -1,0 +1,27 @@
+import { strictEqual } from "node:assert/strict";
+import { describe, it } from "node:test";
+import { CalcomApiError } from "./calcom/client";
+import { agentNoCreditsMessage, getAgentCreditBlockReason } from "./agent-credits";
+
+describe("agent credit errors", () => {
+  it("asks Slack users to reconnect when the credit check lacks CREDITS_READ", () => {
+    const error = new CalcomApiError(
+      "insufficient_scope: token does not have the required scopes. Required: CREDITS_READ.",
+      403
+    );
+
+    const reason = getAgentCreditBlockReason(error);
+
+    strictEqual(reason, "scope_upgrade_required");
+    strictEqual(
+      agentNoCreditsMessage("slack", reason),
+      "To use AI features, reconnect your Cal.com account by running `/cal unlink`, then `/cal link`."
+    );
+  });
+
+  it("keeps other credit-check failures on the generic verification path", () => {
+    const error = new CalcomApiError("Service unavailable", 503);
+
+    strictEqual(getAgentCreditBlockReason(error), "verification_failed");
+  });
+});

--- a/apps/chat/lib/agent-credits.ts
+++ b/apps/chat/lib/agent-credits.ts
@@ -15,13 +15,35 @@ interface RequireAgentCreditsParams {
   postNoCredits: (message: string) => Promise<unknown>;
 }
 
-type AgentCreditsBlockReason = "no_credits" | "verification_failed";
+export type AgentCreditsBlockReason =
+  | "no_credits"
+  | "scope_upgrade_required"
+  | "verification_failed";
+
+export function getAgentCreditBlockReason(error: unknown): AgentCreditsBlockReason {
+  if (
+    error instanceof CalcomApiError &&
+    error.statusCode === 403 &&
+    error.message.includes("insufficient_scope") &&
+    error.message.includes("CREDITS_READ")
+  ) {
+    return "scope_upgrade_required";
+  }
+
+  return "verification_failed";
+}
 
 export function agentNoCreditsMessage(platform: string, reason: AgentCreditsBlockReason): string {
   if (reason === "no_credits") {
     return platform === "slack"
       ? "You don't have AI credits available right now. Use `/cal help` to see the regular slash commands you can still use."
       : "You don't have AI credits available right now. Use /help to see the regular commands you can still use.";
+  }
+
+  if (reason === "scope_upgrade_required") {
+    return platform === "slack"
+      ? "To use AI features, reconnect your Cal.com account by running `/cal unlink`, then `/cal link`."
+      : "To use AI features, reconnect your Cal.com account by running /unlink, then /link.";
   }
 
   return platform === "slack"
@@ -97,7 +119,7 @@ export async function requireAgentCredits({
       statusCode: err instanceof CalcomApiError ? err.statusCode : undefined,
       code: err instanceof CalcomApiError ? err.code : undefined,
     });
-    await postNoCredits(agentNoCreditsMessage(ctx.platform, "verification_failed"));
+    await postNoCredits(agentNoCreditsMessage(ctx.platform, getAgentCreditBlockReason(err)));
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- Detect the exact missing `CREDITS_READ` OAuth-scope error in the AI credit gate.
- Tell affected Slack users to reconnect with `/cal unlink`, then `/cal link`.
- Preserve the existing no-credit and generic verification-error paths.

Fixes ENG-3017
Fixes https://linear.app/calcom/issue/ENG-3017/guide-companion-users-to-reconnect-after-missing-ai-credit-scope

## Why
Existing OAuth refresh tokens retain their original scopes after a deployment requests new permissions. Without this guidance, affected users receive an unhelpful generic credit-verification error.

## Validation
- `bun test apps/chat/lib/agent-credits.test.ts`
- `bun run typecheck:chat`
- `biome lint apps/chat/lib/agent-credits.ts apps/chat/lib/agent-credits.test.ts`