### PR TITLE
fix(chat): suppress org low credit warning

### DIFF
--- a/apps/chat/lib/agent-credits.test.ts
+++ b/apps/chat/lib/agent-credits.test.ts
@@ -1,7 +1,11 @@
 import { strictEqual } from "node:assert/strict";
 import { describe, it } from "node:test";
 import { CalcomApiError } from "./calcom/client";
-import { agentNoCreditsMessage, getAgentCreditBlockReason } from "./agent-credits";
+import {
+  agentNoCreditsMessage,
+  getAgentCreditBlockReason,
+  shouldShowLowCreditWarning,
+} from "./agent-credits";
 
 describe("agent credit errors", () => {
   it("asks Slack users to reconnect when the credit check lacks CREDITS_READ", () => {
@@ -23,5 +27,47 @@ describe("agent credit errors", () => {
     const error = new CalcomApiError("Service unavailable", 503);
 
     strictEqual(getAgentCreditBlockReason(error), "verification_failed");
+  });
+});
+
+describe("shouldShowLowCreditWarning", () => {
+  it("shows the warning only for credit-based users with a low balance", () => {
+    const zeroBalance = { monthlyRemaining: 0, additional: 0 };
+
+    strictEqual(
+      shouldShowLowCreditWarning(
+        { calcomOrganizationId: 42, calcomOrgIsPlatform: false },
+        zeroBalance
+      ),
+      false
+    );
+    strictEqual(
+      shouldShowLowCreditWarning(
+        { calcomOrganizationId: null, calcomOrgIsPlatform: null },
+        zeroBalance
+      ),
+      true
+    );
+    strictEqual(
+      shouldShowLowCreditWarning(
+        { calcomOrganizationId: 42, calcomOrgIsPlatform: true },
+        zeroBalance
+      ),
+      true
+    );
+    strictEqual(
+      shouldShowLowCreditWarning(
+        { calcomOrganizationId: 42, calcomOrgIsPlatform: null },
+        zeroBalance
+      ),
+      true
+    );
+    strictEqual(
+      shouldShowLowCreditWarning(
+        { calcomOrganizationId: null, calcomOrgIsPlatform: null },
+        { monthlyRemaining: 10, additional: 0 }
+      ),
+      false
+    );
   });
 });

--- a/apps/chat/lib/agent-credits.ts
+++ b/apps/chat/lib/agent-credits.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "chat";
 import { CalcomApiError, checkCredits } from "./calcom/client";
+import { isOrgPlanUser, type LinkedUser } from "./user-linking";
 
 export interface AgentCreditContext {
   platform: string;
@@ -31,6 +32,13 @@ export function getAgentCreditBlockReason(error: unknown): AgentCreditsBlockReas
   }
 
   return "verification_failed";
+}
+
+export function shouldShowLowCreditWarning(
+  linked: Pick<LinkedUser, "calcomOrganizationId" | "calcomOrgIsPlatform">,
+  balance: { monthlyRemaining: number; additional: number }
+): boolean {
+  return !isOrgPlanUser(linked) && balance.monthlyRemaining + balance.additional < 10;
 }
 
 export function agentNoCreditsMessage(platform: string, reason: AgentCreditsBlockReason): string {

--- a/apps/chat/lib/bot.ts
+++ b/apps/chat/lib/bot.ts
@@ -28,7 +28,7 @@ import {
 import { createHash } from "node:crypto";
 import type { LookupPlatformUserFn, UserContext } from "./agent";
 import { isAIRateLimitError, isAIToolCallError, runAgentStream } from "./agent";
-import { requireAgentCredits } from "./agent-credits";
+import { requireAgentCredits, shouldShowLowCreditWarning } from "./agent-credits";
 import { CalcomApiError, chargeCredits } from "./calcom/client";
 import { generateAuthUrl } from "./calcom/oauth";
 import { validateRequiredEnv } from "./env";
@@ -943,17 +943,15 @@ async function runAgentHandler(opts: AgentHandlerOptions): Promise<void> {
       log.info("Credits charged", { userId: opts.ctx.userId, externalRef, remaining: chargeResult.remainingBalance });
 
       // Warn if balance is running low
-      if (chargeResult.remainingBalance) {
+      if (chargeResult.remainingBalance && shouldShowLowCreditWarning(linked, chargeResult.remainingBalance)) {
         const remaining = chargeResult.remainingBalance.monthlyRemaining + chargeResult.remainingBalance.additional;
-        if (remaining < 10) {
-          const lowBalanceMsg = opts.ctx.platform === "slack"
-            ? `_Your AI credits are running low (${remaining} remaining). Visit <https://cal.com/settings/billing|cal.com/settings/billing> to purchase more._`
-            : `_Your AI credits are running low (${remaining} remaining). Visit [cal.com/settings/billing](https://cal.com/settings/billing) to purchase more._`;
-          if (opts.ctx.platform === "slack") {
-            await withSlackToken(opts.ctx.teamId, () => opts.thread.post(lowBalanceMsg));
-          } else {
-            await opts.thread.post(lowBalanceMsg);
-          }
+        const lowBalanceMsg = opts.ctx.platform === "slack"
+          ? `_Your AI credits are running low (${remaining} remaining). Visit <https://cal.com/settings/billing|cal.com/settings/billing> to purchase more._`
+          : `_Your AI credits are running low (${remaining} remaining). Visit [cal.com/settings/billing](https://cal.com/settings/billing) to purchase more._`;
+        if (opts.ctx.platform === "slack") {
+          await withSlackToken(opts.ctx.teamId, () => opts.thread.post(lowBalanceMsg));
+        } else {
+          await opts.thread.post(lowBalanceMsg);
         }
       }
     } catch (err) {

--- a/apps/chat/lib/user-linking.ts
+++ b/apps/chat/lib/user-linking.ts
@@ -94,7 +94,9 @@ export interface LinkedUser {
  * Platform (API-tier) orgs and free/individual users return false.
  * Existing Redis entries without org fields are treated as non-org (safe default).
  */
-export function isOrgPlanUser(linked: LinkedUser): boolean {
+export function isOrgPlanUser(
+  linked: Pick<LinkedUser, "calcomOrganizationId" | "calcomOrgIsPlatform">
+): boolean {
   return linked.calcomOrganizationId != null && linked.calcomOrgIsPlatform === false;
 }
 


### PR DESCRIPTION
## Summary

- Suppress the post-response low-credit purchase prompt for confirmed Organization and Enterprise users.
- Keep the existing credit gate and charge request unchanged.
- Preserve the low-credit prompt for individual, platform, and legacy accounts without confirmed organization entitlement.

Fixes ENG-3019
Fixes https://linear.app/calcom/issue/ENG-3019/suppress-misleading-companion-ai-low-credit-warning-for-organization

## Why

The credits API can report a visible prepaid balance of `0` for Organization/Enterprise users even when their plan entitlement allows AI access. The bot previously treated that balance alone as a signal to prompt users to purchase credits.

## Validation

- `bun test apps/chat/lib/agent-credits.test.ts apps/chat/lib/calcom/oauth.test.ts`
- `bun run typecheck:chat`
- `biome lint apps/chat/lib/agent-credits.ts apps/chat/lib/agent-credits.test.ts apps/chat/lib/bot.ts apps/chat/lib/user-linking.ts`