### PR TITLE
chore(mobile): bump app version to 1.0.10

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "Cal.com",
     "slug": "calcom-companion",
     "scheme": ["calcom", "expo-wxt-app"],
-    "version": "1.0.9",
+    "version": "1.0.10",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## What changed

Bumps the Expo mobile app version from `1.0.9` to `1.0.10`.

## Why

Prepares the mobile app for the next patch release.

## Validation

- Parsed `apps/mobile/app.json` and verified `expo.version=1.0.10`
- Ran `biome ci apps/mobile/app.json`
- Ran the repository pre-commit formatter successfully
