### PR TITLE
fix(mcp-server): serve path-aware OAuth metadata

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -111,7 +111,7 @@ This starts a StreamableHTTP server with OAuth 2.1 authentication:
 
 **OAuth 2.1 endpoints:**
 - `GET  /.well-known/oauth-authorization-server` — Authorization server metadata (RFC 8414)
-- `GET  /.well-known/oauth-protected-resource` — Protected resource metadata (RFC 9728)
+- `GET  /.well-known/oauth-protected-resource/mcp` — Protected resource metadata for the canonical `/mcp` endpoint (RFC 9728)
 - `POST /oauth/register` — Dynamic client registration (RFC 7591)
 - `GET  /oauth/authorize` — Start authorization flow (redirects to Cal.com)
 - `GET  /oauth/callback` — Cal.com OAuth callback (exchanges code for tokens)

--- a/apps/mcp-server/src/auth/oauth-metadata.test.ts
+++ b/apps/mcp-server/src/auth/oauth-metadata.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { buildAuthorizationServerMetadata, buildProtectedResourceMetadata } from "./oauth-metadata.js";
+import {
+  buildAuthorizationServerMetadata,
+  buildProtectedResourceMetadata,
+  getMcpResourceUrl,
+  getProtectedResourceMetadataUrl,
+} from "./oauth-metadata.js";
 
 const config = { serverUrl: "https://mcp.example.com" };
 
@@ -23,5 +28,22 @@ describe("buildProtectedResourceMetadata", () => {
     expect(metadata.resource).toBe("https://mcp.example.com");
     expect(metadata.authorization_servers).toEqual(["https://mcp.example.com"]);
     expect(metadata.bearer_methods_supported).toEqual(["header"]);
+  });
+
+  it("identifies the canonical /mcp endpoint when it is the protected resource", () => {
+    const resourceUrl = getMcpResourceUrl(config.serverUrl);
+    const metadata = buildProtectedResourceMetadata(config, resourceUrl);
+
+    expect(resourceUrl).toBe("https://mcp.example.com/mcp");
+    expect(metadata.resource).toBe("https://mcp.example.com/mcp");
+    expect(metadata.authorization_servers).toEqual(["https://mcp.example.com"]);
+  });
+});
+
+describe("getProtectedResourceMetadataUrl", () => {
+  it("inserts the metadata path before the /mcp resource path", () => {
+    expect(getProtectedResourceMetadataUrl("https://mcp.example.com/mcp")).toBe(
+      "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+    );
   });
 });

--- a/apps/mcp-server/src/auth/oauth-metadata.ts
+++ b/apps/mcp-server/src/auth/oauth-metadata.ts
@@ -8,11 +8,30 @@ export interface OAuthServerConfig {
   serverUrl: string;
 }
 
+/** Return the canonical protected resource URL for this server's MCP endpoint. */
+export function getMcpResourceUrl(serverUrl: string): string {
+  return `${serverUrl.replace(/\/+$/, "")}/mcp`;
+}
+
+/**
+ * Derive the RFC 9728 metadata URL for a protected resource.
+ *
+ * For a resource at `https://mcp.example.com/mcp`, metadata lives at
+ * `https://mcp.example.com/.well-known/oauth-protected-resource/mcp`.
+ */
+export function getProtectedResourceMetadataUrl(resourceUrl: string): string {
+  const resource = new URL(resourceUrl);
+  const resourcePath = resource.pathname === "/" ? "" : resource.pathname;
+  return `${resource.origin}/.well-known/oauth-protected-resource${resourcePath}${resource.search}`;
+}
+
 /**
  * Build OAuth Authorization Server metadata per RFC 8414.
  * Returned at GET /.well-known/oauth-authorization-server
  */
-export function buildAuthorizationServerMetadata(config: OAuthServerConfig): Record<string, unknown> {
+export function buildAuthorizationServerMetadata(
+  config: OAuthServerConfig
+): Record<string, unknown> {
   const serverUrl = config.serverUrl.replace(/\/+$/, "");
   return {
     issuer: serverUrl,
@@ -31,13 +50,13 @@ export function buildAuthorizationServerMetadata(config: OAuthServerConfig): Rec
  * Build Protected Resource Metadata per RFC 9728.
  * Returned at GET /.well-known/oauth-protected-resource
  */
-export function buildProtectedResourceMetadata(config: OAuthServerConfig): Record<string, unknown> {
+export function buildProtectedResourceMetadata(
+  config: OAuthServerConfig,
+  resourceUrl = config.serverUrl
+): Record<string, unknown> {
   const serverUrl = config.serverUrl.replace(/\/+$/, "");
   return {
-    // resource is the server identifier (base URL). Per RFC 9728 §3 the client constructs
-    // the discovery URL as "https://host/.well-known/oauth-protected-resource" — no path
-    // suffix — so resource must stay as the base URL, not the /mcp endpoint path.
-    resource: serverUrl,
+    resource: resourceUrl.replace(/\/+$/, ""),
     authorization_servers: [serverUrl],
     bearer_methods_supported: ["header"],
   };

--- a/apps/mcp-server/src/http-server.ts
+++ b/apps/mcp-server/src/http-server.ts
@@ -15,6 +15,8 @@ import {
 import {
   buildAuthorizationServerMetadata,
   buildProtectedResourceMetadata,
+  getMcpResourceUrl,
+  getProtectedResourceMetadataUrl,
 } from "./auth/oauth-metadata.js";
 import { SERVER_INSTRUCTIONS } from "./server-instructions.js";
 import { endPool, initDb, sql } from "./storage/db.js";
@@ -57,7 +59,7 @@ export interface HttpServerConfig {
  *   GET  /health — Health check
  *   GET  /.well-known/openai-apps-challenge — OpenAI Apps domain verification token
  *   GET  /.well-known/oauth-authorization-server — OAuth AS metadata
- *   GET  /.well-known/oauth-protected-resource — Protected resource metadata
+ *   GET  /.well-known/oauth-protected-resource/mcp — MCP protected resource metadata
  *   POST /oauth/register — Dynamic client registration
  *   GET  /oauth/authorize — Start OAuth flow (redirects to Cal.com)
  *   GET  /oauth/callback — Cal.com OAuth callback
@@ -133,6 +135,13 @@ export async function startHttpServer(
 
   const asMetadata = buildAuthorizationServerMetadata({ serverUrl: oauthConfig.serverUrl });
   const prMetadata = buildProtectedResourceMetadata({ serverUrl: oauthConfig.serverUrl });
+  const mcpResourceUrl = getMcpResourceUrl(oauthConfig.serverUrl);
+  const mcpResourceMetadataUrl = getProtectedResourceMetadataUrl(mcpResourceUrl);
+  const mcpResourceMetadataPath = new URL(mcpResourceMetadataUrl).pathname;
+  const mcpPrMetadata = buildProtectedResourceMetadata(
+    { serverUrl: oauthConfig.serverUrl },
+    mcpResourceUrl
+  );
 
   /** Add CORS headers if configured. */
   function setCorsHeaders(res: import("node:http").ServerResponse): void {
@@ -204,6 +213,12 @@ export async function startHttpServer(
       return;
     }
 
+    if (url.pathname === mcpResourceMetadataPath && req.method === "GET") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(mcpPrMetadata));
+      return;
+    }
+
     // ── OAuth flow endpoints (rate-limited) ──
     if (url.pathname.startsWith("/oauth/")) {
       const clientIp = getClientIp(req);
@@ -260,7 +275,7 @@ export async function startHttpServer(
       if (!bearerToken) {
         res.writeHead(401, {
           "Content-Type": "application/json",
-          "WWW-Authenticate": `Bearer resource_metadata="${oauthConfig.serverUrl}/.well-known/oauth-protected-resource"`,
+          "WWW-Authenticate": `Bearer resource_metadata="${mcpResourceMetadataUrl}"`,
         });
         res.end(
           JSON.stringify({ error: "unauthorized", error_description: "Bearer token required" })
@@ -273,7 +288,7 @@ export async function startHttpServer(
         if (!calAuthHeaders) {
           res.writeHead(401, {
             "Content-Type": "application/json",
-            "WWW-Authenticate": `Bearer resource_metadata="${oauthConfig.serverUrl}/.well-known/oauth-protected-resource"`,
+            "WWW-Authenticate": `Bearer resource_metadata="${mcpResourceMetadataUrl}"`,
           });
           res.end(
             JSON.stringify({
@@ -307,7 +322,7 @@ export async function startHttpServer(
         if (!freshHeaders) {
           res.writeHead(401, {
             "Content-Type": "application/json",
-            "WWW-Authenticate": `Bearer resource_metadata="${oauthConfig.serverUrl}/.well-known/oauth-protected-resource"`,
+            "WWW-Authenticate": `Bearer resource_metadata="${mcpResourceMetadataUrl}"`,
           });
           res.end(
             JSON.stringify({
@@ -351,7 +366,7 @@ export async function startHttpServer(
         if (!calAuthHeaders) {
           res.writeHead(401, {
             "Content-Type": "application/json",
-            "WWW-Authenticate": `Bearer resource_metadata="${oauthConfig.serverUrl}/.well-known/oauth-protected-resource"`,
+            "WWW-Authenticate": `Bearer resource_metadata="${mcpResourceMetadataUrl}"`,
           });
           res.end(
             JSON.stringify({

--- a/apps/mcp-server/src/vercel-handler.test.ts
+++ b/apps/mcp-server/src/vercel-handler.test.ts
@@ -73,6 +73,26 @@ describe("Vercel OAuth metadata", () => {
     });
   });
 
+  it("serves metadata that identifies the root protected resource", async () => {
+    const { default: handler } = await import("./vercel-handler.js");
+    const response = createResponse();
+
+    await handler(
+      {
+        method: "GET",
+        url: "/.well-known/oauth-protected-resource",
+        headers: { host: "mcp.example.com" },
+      } as IncomingMessage,
+      response
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      resource: "https://mcp.example.com",
+      authorization_servers: ["https://mcp.example.com"],
+    });
+  });
+
   it("challenges an unauthenticated /mcp request with path-aware metadata", async () => {
     const { default: handler } = await import("./vercel-handler.js");
     const response = createResponse();
@@ -89,6 +109,25 @@ describe("Vercel OAuth metadata", () => {
     expect(response.statusCode).toBe(401);
     expect(response.headers["WWW-Authenticate"]).toBe(
       'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource/mcp"'
+    );
+  });
+
+  it("challenges an unauthenticated root request with root metadata", async () => {
+    const { default: handler } = await import("./vercel-handler.js");
+    const response = createResponse();
+
+    await handler(
+      {
+        method: "GET",
+        url: "/",
+        headers: { host: "mcp.example.com" },
+      } as IncomingMessage,
+      response
+    );
+
+    expect(response.statusCode).toBe(401);
+    expect(response.headers["WWW-Authenticate"]).toBe(
+      'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"'
     );
   });
 });

--- a/apps/mcp-server/src/vercel-handler.test.ts
+++ b/apps/mcp-server/src/vercel-handler.test.ts
@@ -1,0 +1,94 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  initDb: vi.fn().mockResolvedValue(undefined),
+  loadConfig: vi.fn(() => ({
+    transport: "http",
+    serverUrl: "https://mcp.example.com",
+    calOAuthClientId: "client-id",
+    calOAuthClientSecret: "client-secret",
+    calApiBaseUrl: "https://api.cal.com",
+    calAppBaseUrl: "https://app.cal.com",
+    calOAuthScopes: "PROFILE_READ",
+    corsOrigin: undefined,
+    allowedRedirectHosts: [],
+    allowOpenRedirectRegistration: false,
+    maxRegisteredClients: 10_000,
+  })),
+}));
+
+vi.mock("./config.js", () => ({ loadConfig: mocks.loadConfig }));
+vi.mock("./storage/db.js", () => ({ initDb: mocks.initDb, sql: vi.fn() }));
+
+function createResponse(): ServerResponse & {
+  body: string;
+  headers: Record<string, string>;
+  statusCode: number;
+} {
+  const response = {
+    body: "",
+    headers: {},
+    statusCode: 0,
+    setHeader: vi.fn(),
+    writeHead(statusCode: number, headers?: Record<string, string>): void {
+      response.statusCode = statusCode;
+      Object.assign(response.headers, headers);
+    },
+    end(body = ""): void {
+      response.body = String(body);
+    },
+  };
+  return response as unknown as ServerResponse & {
+    body: string;
+    headers: Record<string, string>;
+    statusCode: number;
+  };
+}
+
+describe("Vercel OAuth metadata", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.initDb.mockClear();
+    mocks.loadConfig.mockClear();
+  });
+
+  it("serves metadata that identifies the canonical /mcp protected resource", async () => {
+    const { default: handler } = await import("./vercel-handler.js");
+    const response = createResponse();
+
+    await handler(
+      {
+        method: "GET",
+        url: "/.well-known/oauth-protected-resource/mcp",
+        headers: { host: "mcp.example.com" },
+      } as IncomingMessage,
+      response
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      resource: "https://mcp.example.com/mcp",
+      authorization_servers: ["https://mcp.example.com"],
+    });
+  });
+
+  it("challenges an unauthenticated /mcp request with path-aware metadata", async () => {
+    const { default: handler } = await import("./vercel-handler.js");
+    const response = createResponse();
+
+    await handler(
+      {
+        method: "GET",
+        url: "/mcp",
+        headers: { host: "mcp.example.com" },
+      } as IncomingMessage,
+      response
+    );
+
+    expect(response.statusCode).toBe(401);
+    expect(response.headers["WWW-Authenticate"]).toBe(
+      'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource/mcp"'
+    );
+  });
+});

--- a/apps/mcp-server/src/vercel-handler.ts
+++ b/apps/mcp-server/src/vercel-handler.ts
@@ -16,6 +16,8 @@ import {
 import {
   buildAuthorizationServerMetadata,
   buildProtectedResourceMetadata,
+  getMcpResourceUrl,
+  getProtectedResourceMetadataUrl,
 } from "./auth/oauth-metadata.js";
 import { type HttpConfig, loadConfig } from "./config.js";
 import { registerTools } from "./register-tools.js";
@@ -103,6 +105,9 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
   }
 
   const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  const mcpResourceUrl = getMcpResourceUrl(oauthConfig.serverUrl);
+  const mcpResourceMetadataUrl = getProtectedResourceMetadataUrl(mcpResourceUrl);
+  const mcpResourceMetadataPath = new URL(mcpResourceMetadataUrl).pathname;
 
   // ── Health check ──
   if (url.pathname === "/health") {
@@ -145,6 +150,15 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
   if (url.pathname === "/.well-known/oauth-protected-resource" && req.method === "GET") {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(buildProtectedResourceMetadata({ serverUrl: oauthConfig.serverUrl })));
+    return;
+  }
+  if (url.pathname === mcpResourceMetadataPath && req.method === "GET") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify(
+        buildProtectedResourceMetadata({ serverUrl: oauthConfig.serverUrl }, mcpResourceUrl)
+      )
+    );
     return;
   }
 
@@ -192,13 +206,17 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
   }
 
   if (url.pathname === "/mcp" || url.pathname === "/") {
+    const resourceMetadataUrl =
+      url.pathname === "/mcp"
+        ? mcpResourceMetadataUrl
+        : getProtectedResourceMetadataUrl(oauthConfig.serverUrl);
     const authHeader = req.headers.authorization;
     const bearerToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined;
 
     if (!bearerToken) {
       res.writeHead(401, {
         "Content-Type": "application/json",
-        "WWW-Authenticate": `Bearer resource_metadata="${oauthConfig.serverUrl.replace(/\/+$/, "")}/.well-known/oauth-protected-resource"`,
+        "WWW-Authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"`,
       });
       res.end(
         JSON.stringify({ error: "unauthorized", error_description: "Bearer token required" })
@@ -210,7 +228,7 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
     if (!calAuthHeaders) {
       res.writeHead(401, {
         "Content-Type": "application/json",
-        "WWW-Authenticate": `Bearer resource_metadata="${oauthConfig.serverUrl.replace(/\/+$/, "")}/.well-known/oauth-protected-resource"`,
+        "WWW-Authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"`,
       });
       res.end(
         JSON.stringify({


### PR DESCRIPTION
## Summary

- Serve RFC 9728 protected-resource metadata at `/.well-known/oauth-protected-resource/mcp`.
- Identify `https://mcp.cal.com/mcp` as the canonical protected resource and challenge unauthenticated `/mcp` requests with its metadata URL.
- Retain root metadata compatibility and document the canonical endpoint.

## Root cause

The server previously exposed only root-level protected-resource metadata and identified the host root as the resource. MCP clients configured with `/mcp` therefore received a 404 during path-aware OAuth discovery before dynamic client registration.

## Validation

- `bun --filter @calcom/mcp-server test` (348 passing)
- `bun --filter @calcom/mcp-server lint`
- `bun --filter @calcom/mcp-server typecheck`
- `bun --filter @calcom/mcp-server build`
- Independent read-only code review
