### PR TITLE
fix(mcp-server): keep root MCP requests on OAuth

### DIFF
--- a/apps/mcp-server/src/vercel-handler.root.test.ts
+++ b/apps/mcp-server/src/vercel-handler.root.test.ts
@@ -1,0 +1,75 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  initDb: vi.fn().mockResolvedValue(undefined),
+  loadConfig: vi.fn(() => ({
+    transport: "http",
+    serverUrl: "https://mcp.example.com",
+    calOAuthClientId: "client-id",
+    calOAuthClientSecret: "client-secret",
+    calApiBaseUrl: "https://api.cal.com",
+    calAppBaseUrl: "https://app.cal.com",
+    calOAuthScopes: "PROFILE_READ",
+    corsOrigin: undefined,
+    allowedRedirectHosts: [],
+    allowOpenRedirectRegistration: false,
+    maxRegisteredClients: 10_000,
+  })),
+}));
+
+vi.mock("./config.js", () => ({ loadConfig: mocks.loadConfig }));
+vi.mock("./storage/db.js", () => ({ initDb: mocks.initDb, sql: vi.fn() }));
+
+function createResponse(): ServerResponse & {
+  body: string;
+  headers: Record<string, string>;
+  statusCode: number;
+} {
+  const response = {
+    body: "",
+    headers: {},
+    statusCode: 0,
+    setHeader: vi.fn(),
+    writeHead(statusCode: number, headers?: Record<string, string>): void {
+      response.statusCode = statusCode;
+      Object.assign(response.headers, headers);
+    },
+    end(body = ""): void {
+      response.body = String(body);
+    },
+  };
+  return response as unknown as ServerResponse & {
+    body: string;
+    headers: Record<string, string>;
+    statusCode: number;
+  };
+}
+
+describe("Vercel root MCP endpoint", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.initDb.mockClear();
+    mocks.loadConfig.mockClear();
+  });
+
+  it("challenges an HTML-accepting root request instead of redirecting to docs", async () => {
+    const { default: handler } = await import("./vercel-handler.js");
+    const response = createResponse();
+
+    await handler(
+      {
+        method: "GET",
+        url: "/",
+        headers: { accept: "text/html", host: "mcp.example.com" },
+      } as IncomingMessage,
+      response
+    );
+
+    expect(response.statusCode).toBe(401);
+    expect(response.headers.Location).toBeUndefined();
+    expect(response.headers["WWW-Authenticate"]).toBe(
+      'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"'
+    );
+  });
+});

--- a/apps/mcp-server/src/vercel-handler.ts
+++ b/apps/mcp-server/src/vercel-handler.ts
@@ -181,16 +181,6 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
   // ── MCP (stateless) ──
   // Accept both /mcp (canonical) and / (base URL) so that Claude.ai works whether
   // the user enters "https://mcp.cal.com" or "https://mcp.cal.com/mcp".
-  // Redirect browsers visiting the root URL to the documentation page.
-  if (url.pathname === "/") {
-    const accept = req.headers.accept ?? "";
-    if (req.method === "GET" && !req.headers.authorization && accept.includes("text/html")) {
-      res.writeHead(302, { Location: "https://cal.com/docs/mcp-server" });
-      res.end();
-      return;
-    }
-  }
-
   if (url.pathname === "/mcp" || url.pathname === "/") {
     const authHeader = req.headers.authorization;
     const bearerToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined;


### PR DESCRIPTION
## Summary

Prevents the supported root MCP URL from redirecting HTML-accepting clients to the documentation page. Root requests now receive the existing OAuth 401 challenge, while `/mcp` remains canonical.

## Root cause

A `GET /` with `Accept: text/html` returned `302 Location: https://cal.com/docs/mcp-server`. Claude could follow that redirect and try to use the HTML page as an MCP server.

This is separate from #166, which covers path-aware OAuth protected-resource discovery at `/mcp`.

## Validation

- `bun --filter @calcom/mcp-server test`
- `bun --filter @calcom/mcp-server lint`
- `bun --filter @calcom/mcp-server typecheck`
- `bun --filter @calcom/mcp-server build`