### PR TITLE
feat(mcp): add out-of-office tools

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -183,7 +183,7 @@ The server acts as an intermediary: it issues its own access tokens to MCP clien
 - In-process rate limiting on all OAuth endpoints (token bucket per IP, configurable via `RATE_LIMIT_WINDOW_MS` / `RATE_LIMIT_MAX`)
 - Redirect URIs registered via dynamic client registration are constrained: loopback (`localhost` / `127.0.0.0/8` / `::1`) is always allowed, cleartext `http` to non-loopback hosts is always rejected, and non-loopback `https` hosts require `ALLOWED_REDIRECT_HOSTS` unless `ALLOW_OPEN_REDIRECT_REGISTRATION=true` is explicitly set for unsafe/dev use
 
-## Tools (56)
+## Tools (62)
 
 Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specification/draft/server/tools#tool-annotations) — a human-readable `title` plus behaviour hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) so MCP clients can render them appropriately and apply safety policies.
 
@@ -238,6 +238,14 @@ Each tool exposes MCP [tool annotations](https://modelcontextprotocol.io/specifi
 | `update_schedule` | Update Schedule | Update | Update a schedule |
 | `delete_schedule` | Delete Schedule | Destructive | Delete a schedule |
 | `get_default_schedule` | Get Default Schedule | Read | Get default schedule |
+
+### Out of Office (4)
+| Tool | Title | Hint | Description |
+|---|---|---|---|
+| `get_ooo_entries` | List Out-of-Office Entries | Read | List the authenticated user's day-granular out-of-office entries |
+| `create_ooo_entry` | Create Out-of-Office Entry | Create | Create a day-granular out-of-office entry; use UTC timestamps and discover `toUserId` through membership tools |
+| `update_ooo_entry` | Update Out-of-Office Entry | Update | Update an out-of-office entry; provide both start and end when changing its date range |
+| `delete_ooo_entry` | Delete Out-of-Office Entry | Destructive | Permanently delete an out-of-office entry |
 
 ### Availability / Slots (1)
 | Tool | Title | Hint | Description |

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -4,7 +4,7 @@ A **Model Context Protocol (MCP)** server that wraps the [Cal.com Platform API v
 
 ## Features
 
-- **57 tools** covering Bookings, Event Types, CRM Sync Errors, Schedules, Availability, Calendars, Conferencing, Booking Routing Trace, Routing Forms, Organizations, Teams, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
+- **62 tools** covering Bookings, Event Types, CRM Sync Errors, Schedules, Out of Office, Availability, Calendars, Conferencing, Booking Routing Trace, Routing Forms, Organizations, Teams, and User Profile (each with MCP tool annotations: `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`)
 - **Dual transport** — stdio for local dev tooling, StreamableHTTP for remote/production
 - **Dual auth** — API key for stdio (local dev), OAuth 2.1 Authorization Code + PKCE for HTTP (production)
 - **Per-user token storage** — encrypted at rest with AES-256-GCM in Postgres

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -61,6 +61,17 @@ import {
   updateEventType,
   updateEventTypeSchema,
 } from "./tools/event-types.js";
+// ── Out of Office ──
+import {
+  createOooEntry,
+  createOooEntrySchema,
+  deleteOooEntry,
+  deleteOooEntrySchema,
+  getOooEntries,
+  getOooEntriesSchema,
+  updateOooEntry,
+  updateOooEntrySchema,
+} from "./tools/ooo.js";
 // ── Organizations: Attributes ──
 import {
   assignAttributeToUser,
@@ -495,6 +506,52 @@ export function registerTools(server: McpServer): void {
       annotations: READ_ONLY,
     },
     getDefaultSchedule
+  );
+
+  // ── Out of Office (4) ──
+  server.registerTool(
+    "get_ooo_entries",
+    {
+      title: "List Out-of-Office Entries",
+      description:
+        "List the authenticated user's out-of-office entries. Entries are day-granular: the API normalizes start to 00:00:00.000Z and end to 23:59:59.999Z. Use UTC timestamps matching YYYY-MM-DDTHH:mm:ss(.sss)Z; for partial-day absences, use update_schedule instead.",
+      inputSchema: getOooEntriesSchema,
+      annotations: READ_ONLY,
+    },
+    getOooEntries
+  );
+  server.registerTool(
+    "create_ooo_entry",
+    {
+      title: "Create Out-of-Office Entry",
+      description:
+        "Create a day-granular out-of-office entry. start and end must be UTC timestamps matching YYYY-MM-DDTHH:mm:ss(.sss)Z; the API normalizes them to the start and end of their dates. For partial-day absences, use update_schedule instead. toUserId redirects bookings to a covering user — discover it with get_org_memberships, get_team_memberships, or get_my_teams; never guess an ID.",
+      inputSchema: createOooEntrySchema,
+      annotations: CREATE,
+    },
+    createOooEntry
+  );
+  server.registerTool(
+    "update_ooo_entry",
+    {
+      title: "Update Out-of-Office Entry",
+      description:
+        "Update an out-of-office entry by ID. This is a partial update, but if changing the date range you must provide both start and end; the API rejects exactly one. Use UTC timestamps matching YYYY-MM-DDTHH:mm:ss(.sss)Z. Entries are day-granular; use update_schedule for partial-day absences. Discover toUserId with get_org_memberships, get_team_memberships, or get_my_teams — never guess an ID.",
+      inputSchema: updateOooEntrySchema,
+      annotations: UPDATE,
+    },
+    updateOooEntry
+  );
+  server.registerTool(
+    "delete_ooo_entry",
+    {
+      title: "Delete Out-of-Office Entry",
+      description:
+        "Permanently delete an out-of-office entry by ID. This action is irreversible — confirm with the user before proceeding.",
+      inputSchema: deleteOooEntrySchema,
+      annotations: DESTRUCTIVE,
+    },
+    deleteOooEntry
   );
 
   // ── Availability / Slots (1) ──

--- a/apps/mcp-server/src/server-instructions.ts
+++ b/apps/mcp-server/src/server-instructions.ts
@@ -15,6 +15,7 @@ CAPABILITIES — what you CAN do with the available tools:
 - Manage booking attendees (list, get, add)
 - Mark bookings as absent (no-show)
 - Manage schedules (list, get, create, update, delete)
+- Manage out-of-office entries (list, create, update, delete)
 - Check host availability for booking
 - View connected calendars and busy times
 - List connected conferencing apps
@@ -39,7 +40,7 @@ LIMITATIONS — what you CANNOT do (do NOT attempt to use other tools for these)
 
 RULES:
 1. If a user asks for something not listed under CAPABILITIES, tell them clearly: "The Cal.com integration doesn't support [action] yet." Do NOT call a different tool hoping it might work.
-2. NEVER guess or fabricate IDs, emails, names, phone numbers, app slugs, or time zones. If you don't have a value, either use the appropriate discovery tool (e.g., get_me, get_event_types, get_event_type, get_bookings, get_org_team_bookings, get_org_user_bookings, get_org_memberships, get_team_memberships, get_org_teams, get_my_teams, get_org_attributes, get_attribute_options, get_user_attributes) or ask the user.
+2. NEVER guess or fabricate IDs, emails, names, phone numbers, app slugs, or time zones. If you don't have a value, either use the appropriate discovery tool (e.g., get_me, get_event_types, get_event_type, get_bookings, get_org_team_bookings, get_org_user_bookings, get_org_memberships, get_team_memberships, get_org_teams, get_my_teams, get_org_attributes, get_attribute_options, get_user_attributes, get_ooo_entries) or ask the user.
 3. Before creating or rescheduling a booking, ALWAYS check availability first using get_availability.
-4. For destructive actions (delete event type, cancel booking, delete schedule, delete organization membership, delete team membership, unassign attribute from user), confirm with the user before proceeding.
+4. For destructive actions (delete event type, cancel booking, delete schedule, delete out-of-office entry, delete organization membership, delete team membership, unassign attribute from user), confirm with the user before proceeding.
 5. All date/time values sent to the API must be in UTC ISO 8601 format.`;

--- a/apps/mcp-server/src/tools/ooo.test.ts
+++ b/apps/mcp-server/src/tools/ooo.test.ts
@@ -53,6 +53,10 @@ describe("OOO schemas", () => {
     expect(createOooEntrySchema.start.safeParse("2026-09-01T00:00:00Z").success).toBe(true);
     expect(createOooEntrySchema.start.safeParse("2026-09-01").success).toBe(false);
     expect(createOooEntrySchema.start.safeParse("2026-09-01T00:00:00+02:00").success).toBe(false);
+    expect(createOooEntrySchema.start.safeParse(undefined).success).toBe(false);
+    expect(createOooEntrySchema.end.safeParse(undefined).success).toBe(false);
+    expect(updateOooEntrySchema.start.safeParse(undefined).success).toBe(true);
+    expect(updateOooEntrySchema.end.safeParse(undefined).success).toBe(true);
     expect(updateOooEntrySchema.end.safeParse(end).success).toBe(true);
   });
 

--- a/apps/mcp-server/src/tools/ooo.test.ts
+++ b/apps/mcp-server/src/tools/ooo.test.ts
@@ -51,8 +51,12 @@ describe("OOO schemas", () => {
   it("enforces strict UTC date-time format", () => {
     expect(createOooEntrySchema.start.safeParse(start).success).toBe(true);
     expect(createOooEntrySchema.start.safeParse("2026-09-01T00:00:00Z").success).toBe(true);
+    expect(createOooEntrySchema.start.safeParse("2028-02-29T00:00:00.000Z").success).toBe(true);
     expect(createOooEntrySchema.start.safeParse("2026-09-01").success).toBe(false);
     expect(createOooEntrySchema.start.safeParse("2026-09-01T00:00:00+02:00").success).toBe(false);
+    expect(createOooEntrySchema.start.safeParse("2026-02-31T00:00:00.000Z").success).toBe(false);
+    expect(createOooEntrySchema.start.safeParse("2026-13-01T00:00:00.000Z").success).toBe(false);
+    expect(createOooEntrySchema.start.safeParse("2026-09-01T99:99:99Z").success).toBe(false);
     expect(createOooEntrySchema.start.safeParse(undefined).success).toBe(false);
     expect(createOooEntrySchema.end.safeParse(undefined).success).toBe(false);
     expect(updateOooEntrySchema.start.safeParse(undefined).success).toBe(true);

--- a/apps/mcp-server/src/tools/ooo.test.ts
+++ b/apps/mcp-server/src/tools/ooo.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CalApiError } from "../utils/errors.js";
+
+vi.mock("../utils/api-client.js", () => ({
+  calApi: vi.fn(),
+}));
+
+import { calApi } from "../utils/api-client.js";
+import {
+  createOooEntry,
+  createOooEntrySchema,
+  deleteOooEntry,
+  deleteOooEntrySchema,
+  getOooEntries,
+  getOooEntriesSchema,
+  updateOooEntry,
+  updateOooEntrySchema,
+} from "./ooo.js";
+
+const mockCalApi = vi.mocked(calApi);
+const start = "2026-09-01T00:00:00.000Z";
+const end = "2026-09-03T23:59:59.999Z";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("OOO schemas", () => {
+  it("exports pagination and sorting fields", () => {
+    expect(getOooEntriesSchema.take).toBeDefined();
+    expect(getOooEntriesSchema.skip).toBeDefined();
+    expect(getOooEntriesSchema.sortStart).toBeDefined();
+    expect(getOooEntriesSchema.sortEnd).toBeDefined();
+  });
+
+  it("enforces pagination bounds", () => {
+    expect(getOooEntriesSchema.take.safeParse(0).success).toBe(false);
+    expect(getOooEntriesSchema.take.safeParse(1).success).toBe(true);
+    expect(getOooEntriesSchema.take.safeParse(250).success).toBe(true);
+    expect(getOooEntriesSchema.take.safeParse(251).success).toBe(false);
+    expect(getOooEntriesSchema.skip.safeParse(-1).success).toBe(false);
+    expect(getOooEntriesSchema.skip.safeParse(0).success).toBe(true);
+  });
+
+  it("enforces sort enums", () => {
+    expect(getOooEntriesSchema.sortStart.safeParse("asc").success).toBe(true);
+    expect(getOooEntriesSchema.sortEnd.safeParse("desc").success).toBe(true);
+    expect(getOooEntriesSchema.sortStart.safeParse("up").success).toBe(false);
+  });
+
+  it("enforces strict UTC date-time format", () => {
+    expect(createOooEntrySchema.start.safeParse(start).success).toBe(true);
+    expect(createOooEntrySchema.start.safeParse("2026-09-01T00:00:00Z").success).toBe(true);
+    expect(createOooEntrySchema.start.safeParse("2026-09-01").success).toBe(false);
+    expect(createOooEntrySchema.start.safeParse("2026-09-01T00:00:00+02:00").success).toBe(false);
+    expect(updateOooEntrySchema.end.safeParse(end).success).toBe(true);
+  });
+
+  it("enforces the reason enum", () => {
+    expect(createOooEntrySchema.reason.safeParse("vacation").success).toBe(true);
+    expect(createOooEntrySchema.reason.safeParse("public_holiday").success).toBe(true);
+    expect(createOooEntrySchema.reason.safeParse("holiday").success).toBe(false);
+    expect(updateOooEntrySchema.reason.safeParse("sick").success).toBe(true);
+  });
+
+  it("exports ID schemas", () => {
+    expect(updateOooEntrySchema.oooId).toBeDefined();
+    expect(deleteOooEntrySchema.oooId).toBeDefined();
+  });
+});
+
+describe("getOooEntries", () => {
+  it("sends query params and returns the response", async () => {
+    mockCalApi.mockResolvedValueOnce({ entries: [{ id: 1 }] });
+
+    const result = await getOooEntries({
+      take: 25,
+      skip: 5,
+      sortStart: "asc",
+      sortEnd: "desc",
+    });
+
+    expect(mockCalApi).toHaveBeenCalledWith("me/ooo", {
+      params: { take: 25, skip: 5, sortStart: "asc", sortEnd: "desc" },
+    });
+    expect(JSON.parse(result.content[0].text)).toEqual({ entries: [{ id: 1 }] });
+  });
+
+  it("omits undefined query params", async () => {
+    mockCalApi.mockResolvedValueOnce([]);
+
+    await getOooEntries({});
+
+    expect(mockCalApi).toHaveBeenCalledWith("me/ooo", { params: {} });
+  });
+
+  it("passes API errors through the tool error response", async () => {
+    mockCalApi.mockRejectedValueOnce(new CalApiError(409, "Ooo entry already exists", {}));
+
+    const result = await getOooEntries({});
+
+    expect(result).toHaveProperty("isError", true);
+    expect(result.content[0].text).toContain("409");
+    expect(result.content[0].text).toContain("Ooo entry already exists");
+  });
+});
+
+describe("createOooEntry", () => {
+  it("sends POST with required and optional fields", async () => {
+    mockCalApi.mockResolvedValueOnce({ id: 10 });
+
+    await createOooEntry({
+      start,
+      end,
+      notes: "Vacation",
+      toUserId: 42,
+      reason: "vacation",
+    });
+
+    expect(mockCalApi).toHaveBeenCalledWith("me/ooo", {
+      method: "POST",
+      body: { start, end, notes: "Vacation", toUserId: 42, reason: "vacation" },
+    });
+  });
+
+  it("only sends defined optional fields", async () => {
+    mockCalApi.mockResolvedValueOnce({ id: 11 });
+
+    await createOooEntry({ start, end });
+
+    expect(mockCalApi).toHaveBeenCalledWith("me/ooo", {
+      method: "POST",
+      body: { start, end },
+    });
+  });
+});
+
+describe("updateOooEntry", () => {
+  it("sends PATCH with a partial body", async () => {
+    mockCalApi.mockResolvedValueOnce({});
+
+    await updateOooEntry({ oooId: 5, notes: "Updated notes" });
+
+    expect(mockCalApi).toHaveBeenCalledWith("me/ooo/5", {
+      method: "PATCH",
+      body: { notes: "Updated notes" },
+    });
+  });
+
+  it("sends all defined fields and omits undefined fields", async () => {
+    mockCalApi.mockResolvedValueOnce({});
+
+    await updateOooEntry({
+      oooId: 5,
+      start,
+      end,
+      toUserId: 42,
+      reason: "travel",
+    });
+
+    expect(mockCalApi).toHaveBeenCalledWith("me/ooo/5", {
+      method: "PATCH",
+      body: { start, end, toUserId: 42, reason: "travel" },
+    });
+  });
+});
+
+describe("deleteOooEntry", () => {
+  it("sends DELETE request", async () => {
+    mockCalApi.mockResolvedValueOnce({});
+
+    await deleteOooEntry({ oooId: 5 });
+
+    expect(mockCalApi).toHaveBeenCalledWith("me/ooo/5", { method: "DELETE" });
+  });
+});

--- a/apps/mcp-server/src/tools/ooo.ts
+++ b/apps/mcp-server/src/tools/ooo.ts
@@ -1,0 +1,151 @@
+import { z } from "zod";
+import { calApi } from "../utils/api-client.js";
+import { handleError, ok } from "../utils/tool-helpers.js";
+
+const utcDateTime = z
+  .string()
+  .regex(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d{3})?Z$/,
+    "Must be an ISO 8601 UTC timestamp in YYYY-MM-DDTHH:mm:ss(.sss)Z format."
+  )
+  .describe(
+    "ISO 8601 UTC timestamp in YYYY-MM-DDTHH:mm:ss(.sss)Z format, such as 2026-09-01T00:00:00.000Z. Date-only and offset timestamps are not accepted."
+  );
+
+const reason = z.enum(["unspecified", "vacation", "travel", "sick", "public_holiday"]);
+
+const toUserIdDescription =
+  "Optional numeric ID of the user who should receive redirected bookings. Discover this with get_org_memberships, get_team_memberships, or get_my_teams — never guess an ID.";
+
+export const getOooEntriesSchema = {
+  take: z
+    .number()
+    .int()
+    .min(1)
+    .max(250)
+    .optional()
+    .describe("Maximum entries to return (1-250, defaults to 250)."),
+  skip: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Number of entries to skip (offset, defaults to 0)."),
+  sortStart: z
+    .enum(["asc", "desc"])
+    .optional()
+    .describe("Sort entries by start time in ascending or descending order."),
+  sortEnd: z
+    .enum(["asc", "desc"])
+    .optional()
+    .describe("Sort entries by end time in ascending or descending order."),
+};
+
+export async function getOooEntries(params: {
+  take?: number;
+  skip?: number;
+  sortStart?: "asc" | "desc";
+  sortEnd?: "asc" | "desc";
+}) {
+  try {
+    const qp: Record<string, string | number | undefined> = {};
+    if (params.take !== undefined) qp.take = params.take;
+    if (params.skip !== undefined) qp.skip = params.skip;
+    if (params.sortStart !== undefined) qp.sortStart = params.sortStart;
+    if (params.sortEnd !== undefined) qp.sortEnd = params.sortEnd;
+    const data = await calApi("me/ooo", { params: qp });
+    return ok(data);
+  } catch (err) {
+    return handleError("get_ooo_entries", err);
+  }
+}
+
+export const createOooEntrySchema = {
+  start: utcDateTime.describe(
+    "Start of the day-granular out-of-office period as an ISO 8601 UTC timestamp in YYYY-MM-DDTHH:mm:ss(.sss)Z format, such as 2026-09-01T00:00:00.000Z. The API normalizes this to 00:00:00.000Z. For a partial-day absence, use update_schedule instead."
+  ),
+  end: utcDateTime.describe(
+    "End of the day-granular out-of-office period as an ISO 8601 UTC timestamp in YYYY-MM-DDTHH:mm:ss(.sss)Z format, such as 2026-09-01T23:59:59.999Z. The API normalizes this to 23:59:59.999Z. For a partial-day absence, use update_schedule instead."
+  ),
+  notes: z.string().optional().describe("Optional notes for the out-of-office entry."),
+  toUserId: z.number().int().optional().describe(toUserIdDescription),
+  reason: reason
+    .optional()
+    .describe(
+      "Optional reason: unspecified, vacation, travel, sick, or public_holiday. The API defaults to unspecified when omitted."
+    ),
+};
+
+export async function createOooEntry(params: {
+  start: string;
+  end: string;
+  notes?: string;
+  toUserId?: number;
+  reason?: "unspecified" | "vacation" | "travel" | "sick" | "public_holiday";
+}) {
+  try {
+    const body: Record<string, unknown> = {
+      start: params.start,
+      end: params.end,
+    };
+    if (params.notes !== undefined) body.notes = params.notes;
+    if (params.toUserId !== undefined) body.toUserId = params.toUserId;
+    if (params.reason !== undefined) body.reason = params.reason;
+    const data = await calApi("me/ooo", { method: "POST", body });
+    return ok(data);
+  } catch (err) {
+    return handleError("create_ooo_entry", err);
+  }
+}
+
+export const updateOooEntrySchema = {
+  oooId: z.number().int().describe("Out-of-office entry ID. Use get_ooo_entries to find it."),
+  start: utcDateTime.describe(
+    "Optional new start timestamp in ISO 8601 UTC YYYY-MM-DDTHH:mm:ss(.sss)Z format. If start or end is supplied, supply both; the API rejects exactly one. The API normalizes the date to 00:00:00.000Z. For a partial-day absence, use update_schedule instead."
+  ),
+  end: utcDateTime.describe(
+    "Optional new end timestamp in ISO 8601 UTC YYYY-MM-DDTHH:mm:ss(.sss)Z format. If start or end is supplied, supply both; the API rejects exactly one. The API normalizes the date to 23:59:59.999Z. For a partial-day absence, use update_schedule instead."
+  ),
+  notes: z.string().optional().describe("Optional replacement notes for the out-of-office entry."),
+  toUserId: z.number().int().optional().describe(toUserIdDescription),
+  reason: reason
+    .optional()
+    .describe(
+      "Optional replacement reason: unspecified, vacation, travel, sick, or public_holiday."
+    ),
+};
+
+export async function updateOooEntry(params: {
+  oooId: number;
+  start?: string;
+  end?: string;
+  notes?: string;
+  toUserId?: number;
+  reason?: "unspecified" | "vacation" | "travel" | "sick" | "public_holiday";
+}) {
+  try {
+    const body: Record<string, unknown> = {};
+    if (params.start !== undefined) body.start = params.start;
+    if (params.end !== undefined) body.end = params.end;
+    if (params.notes !== undefined) body.notes = params.notes;
+    if (params.toUserId !== undefined) body.toUserId = params.toUserId;
+    if (params.reason !== undefined) body.reason = params.reason;
+    const data = await calApi(`me/ooo/${params.oooId}`, { method: "PATCH", body });
+    return ok(data);
+  } catch (err) {
+    return handleError("update_ooo_entry", err);
+  }
+}
+
+export const deleteOooEntrySchema = {
+  oooId: z.number().int().describe("Out-of-office entry ID. Use get_ooo_entries to find it."),
+};
+
+export async function deleteOooEntry(params: { oooId: number }) {
+  try {
+    const data = await calApi(`me/ooo/${params.oooId}`, { method: "DELETE" });
+    return ok(data);
+  } catch (err) {
+    return handleError("delete_ooo_entry", err);
+  }
+}

--- a/apps/mcp-server/src/tools/ooo.ts
+++ b/apps/mcp-server/src/tools/ooo.ts
@@ -8,6 +8,12 @@ const utcDateTime = z
     /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d{3})?Z$/,
     "Must be an ISO 8601 UTC timestamp in YYYY-MM-DDTHH:mm:ss(.sss)Z format."
   )
+  .refine((value) => {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return false;
+    const normalizedValue = value.includes(".") ? value : value.replace(/Z$/, ".000Z");
+    return parsed.toISOString() === normalizedValue;
+  }, "Must be a real UTC timestamp with a valid calendar date and time.")
   .describe(
     "ISO 8601 UTC timestamp in YYYY-MM-DDTHH:mm:ss(.sss)Z format, such as 2026-09-01T00:00:00.000Z. Date-only and offset timestamps are not accepted."
   );

--- a/apps/mcp-server/src/tools/ooo.ts
+++ b/apps/mcp-server/src/tools/ooo.ts
@@ -100,12 +100,16 @@ export async function createOooEntry(params: {
 
 export const updateOooEntrySchema = {
   oooId: z.number().int().describe("Out-of-office entry ID. Use get_ooo_entries to find it."),
-  start: utcDateTime.describe(
-    "Optional new start timestamp in ISO 8601 UTC YYYY-MM-DDTHH:mm:ss(.sss)Z format. If start or end is supplied, supply both; the API rejects exactly one. The API normalizes the date to 00:00:00.000Z. For a partial-day absence, use update_schedule instead."
-  ),
-  end: utcDateTime.describe(
-    "Optional new end timestamp in ISO 8601 UTC YYYY-MM-DDTHH:mm:ss(.sss)Z format. If start or end is supplied, supply both; the API rejects exactly one. The API normalizes the date to 23:59:59.999Z. For a partial-day absence, use update_schedule instead."
-  ),
+  start: utcDateTime
+    .optional()
+    .describe(
+      "Optional new start timestamp in ISO 8601 UTC YYYY-MM-DDTHH:mm:ss(.sss)Z format. If start or end is supplied, supply both; the API rejects exactly one. The API normalizes the date to 00:00:00.000Z. For a partial-day absence, use update_schedule instead."
+    ),
+  end: utcDateTime
+    .optional()
+    .describe(
+      "Optional new end timestamp in ISO 8601 UTC YYYY-MM-DDTHH:mm:ss(.sss)Z format. If start or end is supplied, supply both; the API rejects exactly one. The API normalizes the date to 23:59:59.999Z. For a partial-day absence, use update_schedule instead."
+    ),
   notes: z.string().optional().describe("Optional replacement notes for the out-of-office entry."),
   toUserId: z.number().int().optional().describe(toUserIdDescription),
   reason: reason


### PR DESCRIPTION
## Summary

The MCP server had no out-of-office tools, so any OOO request fell through to rule 1 of `server-instructions.ts` ("The Cal.com integration doesn't support [action] yet"), even though API v2 has had `/v2/me/ooo` for a while. Adds `src/tools/ooo.ts` wrapping the four self-service endpoints — `get_ooo_entries`, `create_ooo_entry`, `update_ooo_entry`, `delete_ooo_entry` — plus registration, instructions, README table and tests. Fixes [CON-320](https://linear.app/calcom/issue/CON-320/mcp-ooo-not-supported-yet).

Scoped to `/me` deliberately: the org (`/v2/organizations/{orgId}/users/{userId}/ooo`) and team variants need `ORG_SCHEDULE_READ/WRITE`, which aren't in the default OAuth scope string, so shipping them means a config change and re-consent for existing sessions. Self-service only needs `SCHEDULE_READ`/`SCHEDULE_WRITE`, which we already request. Org/team OOO is a follow-up.

Three contract details drove the schema, all mirrored from `calcom/cal`'s `docs/api-reference/v2/openapi.json` and the `ooo` module:

- The API validates dates with a strict regex, so `2026-09-01` and `2026-09-01T00:00:00+02:00` are 400s. The Zod schema enforces the same shape rather than letting the model find out at request time:
  ```ts
  const utcDateTime = z.string().regex(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(\.\d{3})?Z$/, ...)
  ```
- OOO is **day-granular** — the API normalizes `start` to `00:00:00.000Z` and `end` to `23:59:59.999Z` — so a partial-day absence can't be expressed. Tool descriptions send those requests to `update_schedule` date overrides instead.
- `toUserId` (booking redirect target) is an ID the model must never guess; descriptions point at `get_org_memberships` / `get_team_memberships` / `get_my_teams`, per rule 2.

No `cal-api-version` override was added — the OOO controllers accept `API_VERSIONS_VALUES`, so the `2024-08-13` default is fine.

Note: the README heading said `Tools (56)` but 58 were actually registered; it now says 62.

## Test plan

`ooo.test.ts` follows `schedules.test.ts`: exact path/method/body/params per handler (including that only defined optional fields are sent), the create-vs-update required/optional split, pagination bounds (`take` 0/1/250/251, `skip` -1), the date regex accept/reject cases, the `reason` enum, and a `CalApiError` pass-through.

- `bun --filter @calcom/mcp-server test` — 365 passed
- `bun run typecheck`
- Biome check on the touched files


Link to Devin session: https://app.devin.ai/sessions/d68d5bb5a6ae4b038c7ecfe89c14388d
Requested by: @PeerRich