### PR TITLE
fix(extension): keep host page interactive during toast

### DIFF
--- a/apps/extension/entrypoints/content.ts
+++ b/apps/extension/entrypoints/content.ts
@@ -1,7 +1,7 @@
 /// <reference types="chrome" />
 import { initGoogleCalendarIntegration } from "../lib/google-calendar";
 import { initLinkedInIntegration } from "../lib/linkedin";
-import { setSidebarIframeExpanded } from "../lib/sidebar-iframe";
+import { getSidebarIframeMode, setSidebarIframeExpanded } from "../lib/sidebar-iframe";
 import { escapeHtml } from "../lib/utils";
 
 /**
@@ -89,6 +89,17 @@ export default defineContentScript({
 
     iframeContainer.appendChild(iframe);
 
+    let isFullScreenModalOpen = false;
+    let isToastVisible = false;
+
+    function updateSidebarIframeMode() {
+      setSidebarIframeExpanded(
+        iframe,
+        iframeContainer,
+        getSidebarIframeMode({ isFullScreenModalOpen, isToastVisible })
+      );
+    }
+
     // Listen for messages from iframe to control width and handle OAuth
     window.addEventListener("message", (event) => {
       if (!iframeLoaded) return;
@@ -125,9 +136,19 @@ export default defineContentScript({
       };
 
       if (event.data.type === "cal-companion-expand") {
-        setSidebarIframeExpanded(iframe, iframeContainer, true);
+        if (event.data.source === "toast") {
+          isToastVisible = true;
+        } else {
+          isFullScreenModalOpen = true;
+        }
+        updateSidebarIframeMode();
       } else if (event.data.type === "cal-companion-collapse") {
-        setSidebarIframeExpanded(iframe, iframeContainer, false);
+        if (event.data.source === "toast") {
+          isToastVisible = false;
+        } else {
+          isFullScreenModalOpen = false;
+        }
+        updateSidebarIframeMode();
       } else if (event.data.type === "cal-extension-oauth-request") {
         // Handle OAuth request from iframe
         handleOAuthRequest(event.data.authUrl, iframe.contentWindow);

--- a/apps/extension/entrypoints/content.ts
+++ b/apps/extension/entrypoints/content.ts
@@ -1,7 +1,7 @@
 /// <reference types="chrome" />
 import { initGoogleCalendarIntegration } from "../lib/google-calendar";
 import { initLinkedInIntegration } from "../lib/linkedin";
-import { getSidebarIframeMode, setSidebarIframeExpanded } from "../lib/sidebar-iframe";
+import { createSidebarIframeState, setSidebarIframeExpanded } from "../lib/sidebar-iframe";
 import { escapeHtml } from "../lib/utils";
 
 /**
@@ -89,15 +89,10 @@ export default defineContentScript({
 
     iframeContainer.appendChild(iframe);
 
-    let isFullScreenModalOpen = false;
-    let isToastVisible = false;
+    const sidebarIframeState = createSidebarIframeState();
 
     function updateSidebarIframeMode() {
-      setSidebarIframeExpanded(
-        iframe,
-        iframeContainer,
-        getSidebarIframeMode({ isFullScreenModalOpen, isToastVisible })
-      );
+      setSidebarIframeExpanded(iframe, iframeContainer, sidebarIframeState.getMode());
     }
 
     // Listen for messages from iframe to control width and handle OAuth
@@ -135,19 +130,11 @@ export default defineContentScript({
         return true;
       };
 
-      if (event.data.type === "cal-companion-expand") {
-        if (event.data.source === "toast") {
-          isToastVisible = true;
-        } else {
-          isFullScreenModalOpen = true;
-        }
-        updateSidebarIframeMode();
-      } else if (event.data.type === "cal-companion-collapse") {
-        if (event.data.source === "toast") {
-          isToastVisible = false;
-        } else {
-          isFullScreenModalOpen = false;
-        }
+      if (
+        event.data.type === "cal-companion-expand" ||
+        event.data.type === "cal-companion-collapse"
+      ) {
+        sidebarIframeState.handleMessage(event.data);
         updateSidebarIframeMode();
       } else if (event.data.type === "cal-extension-oauth-request") {
         // Handle OAuth request from iframe

--- a/apps/extension/entrypoints/content.ts
+++ b/apps/extension/entrypoints/content.ts
@@ -1,6 +1,7 @@
 /// <reference types="chrome" />
 import { initGoogleCalendarIntegration } from "../lib/google-calendar";
 import { initLinkedInIntegration } from "../lib/linkedin";
+import { setSidebarIframeExpanded } from "../lib/sidebar-iframe";
 import { escapeHtml } from "../lib/utils";
 
 /**
@@ -124,19 +125,9 @@ export default defineContentScript({
       };
 
       if (event.data.type === "cal-companion-expand") {
-        // Disable transition for instant expansion
-        iframe.style.transition = "none";
-        iframe.style.width = "100vw";
-        iframeContainer.style.width = "100%";
-        iframeContainer.style.left = "0";
-        iframeContainer.style.right = "0";
+        setSidebarIframeExpanded(iframe, iframeContainer, true);
       } else if (event.data.type === "cal-companion-collapse") {
-        // Disable transition for instant collapse
-        iframe.style.transition = "none";
-        iframe.style.width = "400px";
-        iframeContainer.style.width = "400px";
-        iframeContainer.style.left = "auto";
-        iframeContainer.style.right = "0";
+        setSidebarIframeExpanded(iframe, iframeContainer, false);
       } else if (event.data.type === "cal-extension-oauth-request") {
         // Handle OAuth request from iframe
         handleOAuthRequest(event.data.authUrl, iframe.contentWindow);

--- a/apps/extension/lib/sidebar-iframe.test.js
+++ b/apps/extension/lib/sidebar-iframe.test.js
@@ -1,0 +1,43 @@
+import { setSidebarIframeExpanded } from "./sidebar-iframe";
+
+function createStyledElement() {
+  return {
+    style: {
+      left: "",
+      pointerEvents: "",
+      right: "",
+      transition: "",
+      width: "",
+    },
+  };
+}
+
+describe("setSidebarIframeExpanded", () => {
+  test("makes the full-screen notification iframe click-through", () => {
+    const iframe = createStyledElement();
+    const container = createStyledElement();
+
+    setSidebarIframeExpanded(iframe, container, true);
+
+    expect(iframe.style).toMatchObject({
+      pointerEvents: "none",
+      transition: "none",
+      width: "100vw",
+    });
+    expect(container.style).toMatchObject({ left: "0", right: "0", width: "100%" });
+  });
+
+  test("restores sidebar interaction after the notification collapses", () => {
+    const iframe = createStyledElement();
+    const container = createStyledElement();
+
+    setSidebarIframeExpanded(iframe, container, false);
+
+    expect(iframe.style).toMatchObject({
+      pointerEvents: "auto",
+      transition: "none",
+      width: "400px",
+    });
+    expect(container.style).toMatchObject({ left: "auto", right: "0", width: "400px" });
+  });
+});

--- a/apps/extension/lib/sidebar-iframe.test.js
+++ b/apps/extension/lib/sidebar-iframe.test.js
@@ -1,4 +1,8 @@
-import { getSidebarIframeMode, setSidebarIframeExpanded } from "./sidebar-iframe";
+import {
+  createSidebarIframeState,
+  getSidebarIframeMode,
+  setSidebarIframeExpanded,
+} from "./sidebar-iframe";
 
 function createStyledElement() {
   return {
@@ -56,5 +60,22 @@ describe("setSidebarIframeExpanded", () => {
         expanded: true,
       });
     }
+  });
+
+  test("keeps a later modal expanded when an earlier modal cleanup arrives", () => {
+    const state = createSidebarIframeState();
+
+    state.handleMessage({ type: "cal-companion-expand", source: "modal", modalId: "first-modal" });
+    state.handleMessage({ type: "cal-companion-expand", source: "modal", modalId: "second-modal" });
+    state.handleMessage({
+      type: "cal-companion-collapse",
+      source: "modal",
+      modalId: "first-modal",
+    });
+
+    expect(state.getMode()).toEqual({
+      clickThrough: false,
+      expanded: true,
+    });
   });
 });

--- a/apps/extension/lib/sidebar-iframe.test.js
+++ b/apps/extension/lib/sidebar-iframe.test.js
@@ -1,4 +1,4 @@
-import { setSidebarIframeExpanded } from "./sidebar-iframe";
+import { getSidebarIframeMode, setSidebarIframeExpanded } from "./sidebar-iframe";
 
 function createStyledElement() {
   return {
@@ -17,7 +17,11 @@ describe("setSidebarIframeExpanded", () => {
     const iframe = createStyledElement();
     const container = createStyledElement();
 
-    setSidebarIframeExpanded(iframe, container, true);
+    setSidebarIframeExpanded(
+      iframe,
+      container,
+      getSidebarIframeMode({ isFullScreenModalOpen: false, isToastVisible: true })
+    );
 
     expect(iframe.style).toMatchObject({
       pointerEvents: "none",
@@ -31,7 +35,11 @@ describe("setSidebarIframeExpanded", () => {
     const iframe = createStyledElement();
     const container = createStyledElement();
 
-    setSidebarIframeExpanded(iframe, container, false);
+    setSidebarIframeExpanded(
+      iframe,
+      container,
+      getSidebarIframeMode({ isFullScreenModalOpen: false, isToastVisible: false })
+    );
 
     expect(iframe.style).toMatchObject({
       pointerEvents: "auto",
@@ -39,5 +47,14 @@ describe("setSidebarIframeExpanded", () => {
       width: "400px",
     });
     expect(container.style).toMatchObject({ left: "auto", right: "0", width: "400px" });
+  });
+
+  test("keeps interactive full-screen modals interactive", () => {
+    for (const isToastVisible of [false, true]) {
+      expect(getSidebarIframeMode({ isFullScreenModalOpen: true, isToastVisible })).toEqual({
+        clickThrough: false,
+        expanded: true,
+      });
+    }
   });
 });

--- a/apps/extension/lib/sidebar-iframe.ts
+++ b/apps/extension/lib/sidebar-iframe.ts
@@ -1,0 +1,16 @@
+type SidebarElement = {
+  style: Pick<CSSStyleDeclaration, "left" | "pointerEvents" | "right" | "transition" | "width">;
+};
+
+export function setSidebarIframeExpanded(
+  iframe: SidebarElement,
+  iframeContainer: SidebarElement,
+  expanded: boolean
+) {
+  iframe.style.transition = "none";
+  iframe.style.width = expanded ? "100vw" : "400px";
+  iframe.style.pointerEvents = expanded ? "none" : "auto";
+  iframeContainer.style.width = expanded ? "100%" : "400px";
+  iframeContainer.style.left = expanded ? "0" : "auto";
+  iframeContainer.style.right = "0";
+}

--- a/apps/extension/lib/sidebar-iframe.ts
+++ b/apps/extension/lib/sidebar-iframe.ts
@@ -2,14 +2,32 @@ type SidebarElement = {
   style: Pick<CSSStyleDeclaration, "left" | "pointerEvents" | "right" | "transition" | "width">;
 };
 
+interface SidebarIframeMode {
+  clickThrough: boolean;
+  expanded: boolean;
+}
+
+export function getSidebarIframeMode({
+  isFullScreenModalOpen,
+  isToastVisible,
+}: {
+  isFullScreenModalOpen: boolean;
+  isToastVisible: boolean;
+}): SidebarIframeMode {
+  return {
+    expanded: isFullScreenModalOpen || isToastVisible,
+    clickThrough: isToastVisible && !isFullScreenModalOpen,
+  };
+}
+
 export function setSidebarIframeExpanded(
   iframe: SidebarElement,
   iframeContainer: SidebarElement,
-  expanded: boolean
+  { clickThrough, expanded }: SidebarIframeMode
 ) {
   iframe.style.transition = "none";
   iframe.style.width = expanded ? "100vw" : "400px";
-  iframe.style.pointerEvents = expanded ? "none" : "auto";
+  iframe.style.pointerEvents = clickThrough ? "none" : "auto";
   iframeContainer.style.width = expanded ? "100%" : "400px";
   iframeContainer.style.left = expanded ? "0" : "auto";
   iframeContainer.style.right = "0";

--- a/apps/extension/lib/sidebar-iframe.ts
+++ b/apps/extension/lib/sidebar-iframe.ts
@@ -7,6 +7,42 @@ interface SidebarIframeMode {
   expanded: boolean;
 }
 
+interface SidebarIframeMessage {
+  modalId?: string;
+  source?: string;
+  type: "cal-companion-collapse" | "cal-companion-expand";
+}
+
+export function createSidebarIframeState() {
+  const activeModalIds = new Set<string>();
+  let isLegacyFullScreenModalOpen = false;
+  let isToastVisible = false;
+
+  return {
+    getMode() {
+      return getSidebarIframeMode({
+        isFullScreenModalOpen: isLegacyFullScreenModalOpen || activeModalIds.size > 0,
+        isToastVisible,
+      });
+    },
+    handleMessage({ modalId, source, type }: SidebarIframeMessage) {
+      const isExpanding = type === "cal-companion-expand";
+
+      if (source === "toast") {
+        isToastVisible = isExpanding;
+      } else if (source === "modal" && modalId) {
+        if (isExpanding) {
+          activeModalIds.add(modalId);
+        } else {
+          activeModalIds.delete(modalId);
+        }
+      } else {
+        isLegacyFullScreenModalOpen = isExpanding;
+      }
+    },
+  };
+}
+
 export function getSidebarIframeMode({
   isFullScreenModalOpen,
   isToastVisible,

--- a/apps/mobile/components/FullScreenModal.tsx
+++ b/apps/mobile/components/FullScreenModal.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useEffect } from "react";
+import { useEffect, useId } from "react";
 import { Modal, type ModalProps, Platform } from "react-native";
 
 interface FullScreenModalProps extends ModalProps {
@@ -20,6 +20,8 @@ export function FullScreenModal({
   children,
   ...modalProps
 }: FullScreenModalProps) {
+  const modalId = useId();
+
   useEffect(() => {
     // Only send expand/collapse messages on web platform (browser extension)
     if (Platform.OS !== "web") {
@@ -28,19 +30,22 @@ export function FullScreenModal({
 
     if (visible) {
       // Expand the iframe to full width when modal opens
-      window.parent.postMessage({ type: "cal-companion-expand", source: "modal" }, "*");
+      window.parent.postMessage({ type: "cal-companion-expand", source: "modal", modalId }, "*");
     } else {
       // Collapse the iframe back to 400px when modal closes
-      window.parent.postMessage({ type: "cal-companion-collapse", source: "modal" }, "*");
+      window.parent.postMessage({ type: "cal-companion-collapse", source: "modal", modalId }, "*");
     }
 
     // Cleanup: collapse on unmount if still visible
     return () => {
       if (visible && Platform.OS === "web") {
-        window.parent.postMessage({ type: "cal-companion-collapse", source: "modal" }, "*");
+        window.parent.postMessage(
+          { type: "cal-companion-collapse", source: "modal", modalId },
+          "*"
+        );
       }
     };
-  }, [visible]);
+  }, [modalId, visible]);
 
   // For non-web platforms, just use the regular Modal
   if (Platform.OS !== "web") {

--- a/apps/mobile/components/FullScreenModal.tsx
+++ b/apps/mobile/components/FullScreenModal.tsx
@@ -28,16 +28,16 @@ export function FullScreenModal({
 
     if (visible) {
       // Expand the iframe to full width when modal opens
-      window.parent.postMessage({ type: "cal-companion-expand" }, "*");
+      window.parent.postMessage({ type: "cal-companion-expand", source: "modal" }, "*");
     } else {
       // Collapse the iframe back to 400px when modal closes
-      window.parent.postMessage({ type: "cal-companion-collapse" }, "*");
+      window.parent.postMessage({ type: "cal-companion-collapse", source: "modal" }, "*");
     }
 
     // Cleanup: collapse on unmount if still visible
     return () => {
       if (visible && Platform.OS === "web") {
-        window.parent.postMessage({ type: "cal-companion-collapse" }, "*");
+        window.parent.postMessage({ type: "cal-companion-collapse", source: "modal" }, "*");
       }
     };
   }, [visible]);

--- a/apps/mobile/components/ui/GlobalToast.tsx
+++ b/apps/mobile/components/ui/GlobalToast.tsx
@@ -66,16 +66,16 @@ export function GlobalToast() {
   useEffect(() => {
     if (Platform.OS === "web") {
       if (toast.visible) {
-        window.parent.postMessage({ type: "cal-companion-expand" }, "*");
+        window.parent.postMessage({ type: "cal-companion-expand", source: "toast" }, "*");
       } else {
-        window.parent.postMessage({ type: "cal-companion-collapse" }, "*");
+        window.parent.postMessage({ type: "cal-companion-collapse", source: "toast" }, "*");
       }
     }
 
     return () => {
       // Cleanup: collapse on unmount if we expanded
       if (Platform.OS === "web" && toast.visible) {
-        window.parent.postMessage({ type: "cal-companion-collapse" }, "*");
+        window.parent.postMessage({ type: "cal-companion-collapse", source: "toast" }, "*");
       }
     };
   }, [toast.visible]);
@@ -94,17 +94,20 @@ export function GlobalToast() {
   return (
     <View style={styles.overlay} pointerEvents="none">
       <Animated.View
-        style={[
-          styles.container,
-          isDark && dynamicStyles.darkContainer,
-          { opacity: fadeAnim },
-        ]}
+        style={[styles.container, isDark && dynamicStyles.darkContainer, { opacity: fadeAnim }]}
       >
-        <Ionicons name={iconConfig.name} size={24} color={isDark ? "#FFFFFF" : "#000000"} style={styles.icon} />
+        <Ionicons
+          name={iconConfig.name}
+          size={24}
+          color={isDark ? "#FFFFFF" : "#000000"}
+          style={styles.icon}
+        />
         <View style={styles.textContainer}>
           <Text style={[styles.title, isDark && dynamicStyles.darkTitle]}>{toast.title}</Text>
           {toast.message ? (
-            <Text style={[styles.message, isDark && dynamicStyles.darkMessage]}>{toast.message}</Text>
+            <Text style={[styles.message, isDark && dynamicStyles.darkMessage]}>
+              {toast.message}
+            </Text>
           ) : null}
         </View>
       </Animated.View>


### PR DESCRIPTION
Fixes [CON-420](https://linear.app/calcom/issue/CON-420/fix-extension-copy-toast-blocking-host-page-interaction)

## Summary
- make the expanded companion iframe click-through while a transient toast is visible
- restore normal sidebar pointer handling when the toast collapses
- cover both iframe states with an extension regression test

## Root cause
A centered web toast asks the content script to expand the cross-origin iframe to the viewport. Although the toast view itself is non-interactive, the expanded iframe remained interactive and captured all host-page clicks until auto-dismiss.

## Verification
- `bun test apps/extension/lib/sidebar-iframe.test.js`
- `bun run --filter extension typecheck`
- `bunx biome check apps/extension/entrypoints/content.ts apps/extension/lib/sidebar-iframe.ts apps/extension/lib/sidebar-iframe.test.js`
- `bun run --filter extension build`
- `bun run --filter mobile test -- --runInBand` (32 tests)