### PR TITLE
feat(mobile): Cal.com custom keyboard for iOS and Android

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,4 @@
+# Cal.com Companion mobile app
+
+See the [custom keyboard guide](./docs/custom-keyboard.md) for installation,
+syncing, and native development instructions.

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -142,6 +142,7 @@
         }
       ],
       "@bacons/apple-targets",
+      "./plugins/withCalKeyboard",
       [
         "react-native-android-widget",
         {

--- a/apps/mobile/app/(tabs)/(more)/index.ios.tsx
+++ b/apps/mobile/app/(tabs)/(more)/index.ios.tsx
@@ -93,6 +93,12 @@ export default function More() {
 
   const menuItems: MoreMenuItem[] = [
     {
+      name: "Cal.com Keyboard",
+      icon: "keypad-outline",
+      isExternal: false,
+      onPress: () => router.push("/keyboard-settings"),
+    },
+    {
       name: "Apps",
       icon: "grid-outline",
       isExternal: false,

--- a/apps/mobile/app/(tabs)/(more)/index.tsx
+++ b/apps/mobile/app/(tabs)/(more)/index.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
 import { useState } from "react";
 import {
   Alert,
@@ -29,6 +30,7 @@ interface MoreMenuItem {
 }
 
 export default function More() {
+  const router = useRouter();
   const { logout } = useAuth();
   const { clearCache } = useQueryContext();
   const { preferences, setLandingPage, landingPageLabel } = useUserPreferences();
@@ -82,6 +84,11 @@ export default function More() {
 
   const calAppUrl = getCalAppUrl();
   const menuItems: MoreMenuItem[] = [
+    {
+      name: "Cal.com Keyboard",
+      icon: "keypad-outline",
+      onPress: () => router.push("/keyboard-settings"),
+    },
     {
       name: "Apps",
       icon: "grid-outline",

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -7,6 +7,7 @@ import { isLiquidGlassAvailable } from "expo-glass-effect";
 import { Stack } from "expo-router";
 import { Platform, StatusBar, useColorScheme, View } from "react-native";
 import { CalComLogo } from "@/components/CalComLogo";
+import { KeyboardSyncProvider } from "@/components/KeyboardSyncProvider";
 import LoginScreenComponent from "@/components/LoginScreen";
 import { NetworkStatusBanner } from "@/components/NetworkStatusBanner";
 import { PushNotificationProvider } from "@/components/PushNotificationProvider";
@@ -80,6 +81,13 @@ function RootLayoutContent() {
               : isDark
                 ? "dark"
                 : "light",
+        }}
+      />
+      <Stack.Screen
+        name="keyboard-settings"
+        options={{
+          headerShown: true,
+          title: "Cal.com Keyboard",
         }}
       />
       <Stack.Screen
@@ -458,7 +466,9 @@ export default function RootLayout() {
         <ToastProvider>
           <PushNotificationProvider>
             <WidgetSyncProvider>
-              <RootLayoutContent />
+              <KeyboardSyncProvider>
+                <RootLayoutContent />
+              </KeyboardSyncProvider>
             </WidgetSyncProvider>
           </PushNotificationProvider>
           <GlobalToast />

--- a/apps/mobile/app/keyboard-settings.tsx
+++ b/apps/mobile/app/keyboard-settings.tsx
@@ -1,9 +1,22 @@
+import { Ionicons } from "@expo/vector-icons";
 import { Stack } from "expo-router";
 import { useEffect, useState } from "react";
 import { Linking, Platform, Pressable, ScrollView, Text, useColorScheme, View } from "react-native";
 import { getColors } from "@/constants/colors";
 import { getKeyboardData } from "@/utils/keyboardStorage";
 import { composeKeyboardInsertion } from "@/utils/keyboardStorage.shared";
+
+const IOS_STEPS = [
+  "Open Settings → General → Keyboard → Keyboards.",
+  "Tap Add New Keyboard and choose Cal.com.",
+  "In any text field, hold the globe key and pick Cal.com.",
+];
+
+const ANDROID_STEPS = [
+  "Open Settings → System → Languages & input → On-screen keyboard.",
+  "Tap Manage keyboards and enable Cal.com.",
+  "In any text field, tap the keyboard-switch key and pick Cal.com.",
+];
 
 export default function KeyboardSettings() {
   const [keyboardData, setKeyboardData] =
@@ -23,6 +36,7 @@ export default function KeyboardSettings() {
     }
   };
 
+  const steps = Platform.OS === "ios" ? IOS_STEPS : ANDROID_STEPS;
   const exampleLink = keyboardData?.links[0];
   const exampleSelections =
     exampleLink?.days.flatMap((day) => day.slots.map((slot) => ({ day, slot }))).slice(0, 2) ?? [];
@@ -30,73 +44,137 @@ export default function KeyboardSettings() {
     exampleLink && exampleSelections.length > 0
       ? composeKeyboardInsertion(exampleLink, exampleSelections, keyboardData.timeZone)
       : null;
+  const linkCount = keyboardData?.links.length ?? 0;
+  const isSynced = linkCount > 0;
 
   return (
     <View className="flex-1" style={{ backgroundColor: colors.background }}>
       <Stack.Screen options={{ title: "Cal.com Keyboard" }} />
-      <ScrollView contentContainerStyle={{ padding: 20 }}>
-        <Text className="mb-2 text-2xl font-bold" style={{ color: colors.text }}>
-          Cal.com Keyboard
-        </Text>
-        <Text className="mb-6 text-base" style={{ color: colors.textSecondary }}>
-          Insert booking links and prefilled times into any app.
-        </Text>
-        <Text className="mb-2 text-lg font-semibold" style={{ color: colors.text }}>
-          {Platform.OS === "ios" ? "iPhone and iPad" : "Android"}
-        </Text>
-        {(Platform.OS === "ios"
-          ? [
-              "Open Settings → General → Keyboard → Keyboards.",
-              "Tap Add New Keyboard and choose Cal.com.",
-              "Switch to Cal.com from any text field using the globe key.",
-            ]
-          : [
-              "Open Settings → System → Languages & input → On-screen keyboard.",
-              "Tap Manage keyboards and enable Cal.com.",
-              "Switch to Cal.com using the keyboard-switch key.",
-            ]
-        ).map((step, index) => (
-          <Text key={step} className="mb-3 text-base" style={{ color: colors.text }}>
-            {index + 1}. {step}
+      <ScrollView contentContainerStyle={{ padding: 20, paddingBottom: 40 }}>
+        <View className="mb-8 items-center">
+          <View
+            className="mb-4 h-14 w-14 items-center justify-center rounded-2xl"
+            style={{ backgroundColor: colors.backgroundMuted }}
+          >
+            <Ionicons name="keypad-outline" size={26} color={colors.text} />
+          </View>
+          <Text className="mb-2 text-center text-2xl font-bold" style={{ color: colors.text }}>
+            Cal.com Keyboard
           </Text>
-        ))}
-        {Platform.OS === "ios" && (
-          <Text className="mb-6 text-sm" style={{ color: colors.textSecondary }}>
-            Allow Full Access is not required.
+          <Text className="text-center text-base leading-6" style={{ color: colors.textSecondary }}>
+            Share a booking link with times already picked, without leaving the app you're typing
+            in.
           </Text>
-        )}
+        </View>
+
+        <Text
+          className="mb-2 text-xs font-semibold uppercase tracking-wide"
+          style={{ color: colors.textMuted }}
+        >
+          {Platform.OS === "ios" ? "Set up on iPhone and iPad" : "Set up on Android"}
+        </Text>
+        <View
+          className="mb-4 overflow-hidden rounded-2xl border"
+          style={{ borderColor: colors.border, backgroundColor: colors.backgroundSecondary }}
+        >
+          {steps.map((step, index) => (
+            <View
+              key={step}
+              className="flex-row items-start px-4 py-4"
+              style={
+                index === 0 ? undefined : { borderTopWidth: 1, borderTopColor: colors.borderSubtle }
+              }
+            >
+              <View
+                className="mr-3 h-6 w-6 items-center justify-center rounded-full"
+                style={{ backgroundColor: colors.backgroundEmphasis }}
+              >
+                <Text className="text-xs font-semibold" style={{ color: colors.text }}>
+                  {index + 1}
+                </Text>
+              </View>
+              <Text className="flex-1 text-base leading-6" style={{ color: colors.text }}>
+                {step}
+              </Text>
+            </View>
+          ))}
+        </View>
+
         <Pressable
-          className="mb-6 rounded-lg px-4 py-3"
+          className="mb-3 flex-row items-center justify-center rounded-xl px-4 py-3.5"
           style={{ backgroundColor: colors.accent }}
           onPress={openKeyboardSettings}
         >
-          <Text className="text-center font-semibold" style={{ color: "#FFFFFF" }}>
+          <Ionicons name="settings-outline" size={18} color="#FFFFFF" />
+          <Text className="ml-2 text-base font-semibold" style={{ color: "#FFFFFF" }}>
             Open keyboard settings
           </Text>
         </Pressable>
-        {exampleText && (
-          <View
-            className="mb-4 rounded-lg border p-4"
-            style={{ borderColor: colors.border, backgroundColor: colors.backgroundSecondary }}
-          >
-            <Text className="mb-2 text-sm font-semibold" style={{ color: colors.text }}>
-              Example of what gets inserted
-            </Text>
-            <Text className="text-sm" style={{ color: colors.textSecondary }}>
-              {exampleText}
+        {Platform.OS === "ios" && (
+          <View className="mb-8 flex-row items-center justify-center">
+            <Ionicons name="lock-closed-outline" size={13} color={colors.textMuted} />
+            <Text className="ml-1.5 text-xs" style={{ color: colors.textMuted }}>
+              Allow Full Access is not required
             </Text>
           </View>
         )}
-        <Text className="text-sm" style={{ color: colors.textSecondary }}>
-          Last synced:{" "}
-          {keyboardData?.lastUpdated
-            ? new Date(keyboardData.lastUpdated).toLocaleString()
-            : "Not yet"}
+
+        {exampleText && (
+          <>
+            <Text
+              className="mb-2 text-xs font-semibold uppercase tracking-wide"
+              style={{ color: colors.textMuted }}
+            >
+              What gets inserted
+            </Text>
+            <View
+              className="mb-8 rounded-2xl px-4 py-3"
+              style={{ backgroundColor: colors.backgroundMuted }}
+            >
+              <Text
+                className="text-[13px] leading-5"
+                style={{
+                  color: colors.text,
+                  fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace",
+                }}
+              >
+                {exampleText}
+              </Text>
+            </View>
+          </>
+        )}
+
+        <Text
+          className="mb-2 text-xs font-semibold uppercase tracking-wide"
+          style={{ color: colors.textMuted }}
+        >
+          Sync
         </Text>
-        <Text className="mt-4 text-sm" style={{ color: colors.textSecondary }}>
-          Open the Cal.com app to refresh your keyboard data. The keyboard never fetches network
-          data itself.
-        </Text>
+        <View
+          className="rounded-2xl border px-4 py-4"
+          style={{ borderColor: colors.border, backgroundColor: colors.backgroundSecondary }}
+        >
+          <View className="mb-1 flex-row items-center">
+            <View
+              className="mr-2 h-2 w-2 rounded-full"
+              style={{ backgroundColor: isSynced ? colors.success : colors.warning }}
+            />
+            <Text className="flex-1 text-base font-medium" style={{ color: colors.text }}>
+              {isSynced
+                ? `${linkCount} ${linkCount === 1 ? "link" : "links"} ready`
+                : "No links synced yet"}
+            </Text>
+            <Text className="text-sm" style={{ color: colors.textSecondary }}>
+              {keyboardData?.lastUpdated
+                ? new Date(keyboardData.lastUpdated).toLocaleString()
+                : "—"}
+            </Text>
+          </View>
+          <Text className="text-sm leading-5" style={{ color: colors.textSecondary }}>
+            Your links and available times refresh whenever you open this app. The keyboard reads
+            them from your device and never fetches anything itself.
+          </Text>
+        </View>
       </ScrollView>
     </View>
   );

--- a/apps/mobile/app/keyboard-settings.tsx
+++ b/apps/mobile/app/keyboard-settings.tsx
@@ -3,14 +3,16 @@ import { useEffect, useState } from "react";
 import { Linking, Platform, Pressable, ScrollView, Text, useColorScheme, View } from "react-native";
 import { getColors } from "@/constants/colors";
 import { getKeyboardData } from "@/utils/keyboardStorage";
+import { composeKeyboardInsertion } from "@/utils/keyboardStorage.shared";
 
 export default function KeyboardSettings() {
-  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
+  const [keyboardData, setKeyboardData] =
+    useState<Awaited<ReturnType<typeof getKeyboardData>>>(null);
   const isDark = useColorScheme() === "dark";
   const colors = getColors(isDark);
 
   useEffect(() => {
-    getKeyboardData().then((data) => setLastUpdated(data?.lastUpdated ?? null));
+    getKeyboardData().then(setKeyboardData);
   }, []);
 
   const openKeyboardSettings = () => {
@@ -20,6 +22,14 @@ export default function KeyboardSettings() {
       Linking.sendIntent("android.settings.INPUT_METHOD_SETTINGS");
     }
   };
+
+  const exampleLink = keyboardData?.links[0];
+  const exampleSelections =
+    exampleLink?.days.flatMap((day) => day.slots.map((slot) => ({ day, slot }))).slice(0, 2) ?? [];
+  const exampleText =
+    exampleLink && exampleSelections.length > 0
+      ? composeKeyboardInsertion(exampleLink, exampleSelections, keyboardData.timeZone)
+      : null;
 
   return (
     <View className="flex-1" style={{ backgroundColor: colors.background }}>
@@ -64,8 +74,24 @@ export default function KeyboardSettings() {
             Open keyboard settings
           </Text>
         </Pressable>
+        {exampleText && (
+          <View
+            className="mb-4 rounded-lg border p-4"
+            style={{ borderColor: colors.border, backgroundColor: colors.backgroundSecondary }}
+          >
+            <Text className="mb-2 text-sm font-semibold" style={{ color: colors.text }}>
+              Example of what gets inserted
+            </Text>
+            <Text className="text-sm" style={{ color: colors.textSecondary }}>
+              {exampleText}
+            </Text>
+          </View>
+        )}
         <Text className="text-sm" style={{ color: colors.textSecondary }}>
-          Last synced: {lastUpdated ? new Date(lastUpdated).toLocaleString() : "Not yet"}
+          Last synced:{" "}
+          {keyboardData?.lastUpdated
+            ? new Date(keyboardData.lastUpdated).toLocaleString()
+            : "Not yet"}
         </Text>
         <Text className="mt-4 text-sm" style={{ color: colors.textSecondary }}>
           Open the Cal.com app to refresh your keyboard data. The keyboard never fetches network

--- a/apps/mobile/app/keyboard-settings.tsx
+++ b/apps/mobile/app/keyboard-settings.tsx
@@ -1,0 +1,77 @@
+import { Stack } from "expo-router";
+import { useEffect, useState } from "react";
+import { Linking, Platform, Pressable, ScrollView, Text, useColorScheme, View } from "react-native";
+import { getColors } from "@/constants/colors";
+import { getKeyboardData } from "@/utils/keyboardStorage";
+
+export default function KeyboardSettings() {
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
+  const isDark = useColorScheme() === "dark";
+  const colors = getColors(isDark);
+
+  useEffect(() => {
+    getKeyboardData().then((data) => setLastUpdated(data?.lastUpdated ?? null));
+  }, []);
+
+  const openKeyboardSettings = () => {
+    if (Platform.OS === "ios") {
+      Linking.openSettings();
+    } else {
+      Linking.sendIntent("android.settings.INPUT_METHOD_SETTINGS");
+    }
+  };
+
+  return (
+    <View className="flex-1" style={{ backgroundColor: colors.background }}>
+      <Stack.Screen options={{ title: "Cal.com Keyboard" }} />
+      <ScrollView contentContainerStyle={{ padding: 20 }}>
+        <Text className="mb-2 text-2xl font-bold" style={{ color: colors.text }}>
+          Cal.com Keyboard
+        </Text>
+        <Text className="mb-6 text-base" style={{ color: colors.textSecondary }}>
+          Insert booking links and prefilled times into any app.
+        </Text>
+        <Text className="mb-2 text-lg font-semibold" style={{ color: colors.text }}>
+          {Platform.OS === "ios" ? "iPhone and iPad" : "Android"}
+        </Text>
+        {(Platform.OS === "ios"
+          ? [
+              "Open Settings → General → Keyboard → Keyboards.",
+              "Tap Add New Keyboard and choose Cal.com.",
+              "Switch to Cal.com from any text field using the globe key.",
+            ]
+          : [
+              "Open Settings → System → Languages & input → On-screen keyboard.",
+              "Tap Manage keyboards and enable Cal.com.",
+              "Switch to Cal.com using the keyboard-switch key.",
+            ]
+        ).map((step, index) => (
+          <Text key={step} className="mb-3 text-base" style={{ color: colors.text }}>
+            {index + 1}. {step}
+          </Text>
+        ))}
+        {Platform.OS === "ios" && (
+          <Text className="mb-6 text-sm" style={{ color: colors.textSecondary }}>
+            Allow Full Access is not required.
+          </Text>
+        )}
+        <Pressable
+          className="mb-6 rounded-lg px-4 py-3"
+          style={{ backgroundColor: colors.accent }}
+          onPress={openKeyboardSettings}
+        >
+          <Text className="text-center font-semibold" style={{ color: "#FFFFFF" }}>
+            Open keyboard settings
+          </Text>
+        </Pressable>
+        <Text className="text-sm" style={{ color: colors.textSecondary }}>
+          Last synced: {lastUpdated ? new Date(lastUpdated).toLocaleString() : "Not yet"}
+        </Text>
+        <Text className="mt-4 text-sm" style={{ color: colors.textSecondary }}>
+          Open the Cal.com app to refresh your keyboard data. The keyboard never fetches network
+          data itself.
+        </Text>
+      </ScrollView>
+    </View>
+  );
+}

--- a/apps/mobile/components/KeyboardSyncProvider.tsx
+++ b/apps/mobile/components/KeyboardSyncProvider.tsx
@@ -1,0 +1,6 @@
+import { useKeyboardSync } from "@/hooks/useKeyboardSync";
+
+export function KeyboardSyncProvider({ children }: { children: React.ReactNode }) {
+  useKeyboardSync();
+  return <>{children}</>;
+}

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/services/oauthService";
 import type { UserProfile } from "@/services/types/users.types";
 import { WebAuthService } from "@/services/webAuth";
+import { clearKeyboardData } from "@/utils/keyboardStorage";
 import { clearQueryCache } from "@/utils/queryPersister";
 import { clearRegion, getRegion, preloadRegion, subscribeRegion } from "@/utils/region";
 import { safeLogWarn } from "@/utils/safeLogger";
@@ -375,6 +376,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
       await clearWidgetBookings();
     } catch (widgetError) {
       console.warn("Failed to clear widget bookings during logout:", widgetError);
+    }
+    try {
+      await clearKeyboardData();
+    } catch (keyboardError) {
+      console.warn("Failed to clear keyboard data during logout:", keyboardError);
     }
     resetAuthState();
   }, [clearAuth, resetAuthState, queryClient]);

--- a/apps/mobile/docs/custom-keyboard.md
+++ b/apps/mobile/docs/custom-keyboard.md
@@ -1,0 +1,40 @@
+# Cal.com custom keyboard
+
+The Cal.com keyboard lets you insert a booking link and one or more available
+times into any app's text field. Open the Companion app to sync your links and
+available times before switching to the keyboard.
+
+## iOS installation
+
+1. Open **Settings → General → Keyboard → Keyboards**.
+2. Tap **Add New Keyboard** and choose **Cal.com**.
+3. In any text field, use the globe key to switch to Cal.com.
+
+Allow Full Access is not required. The keyboard does not fetch network data.
+
+## Android installation
+
+1. Open **Settings → System → Languages & input → On-screen keyboard**.
+2. Tap **Manage keyboards** and enable **Cal.com**.
+3. In any text field, switch to Cal.com with the keyboard-switch key.
+
+## Data syncing
+
+The Companion app owns authentication, time-zone formatting, and availability
+requests. Open the app to refresh the keyboard data. The keyboard itself never
+fetches network data.
+
+## Development and builds
+
+Custom keyboard extensions are not available in Expo Go. Generate native
+projects and install a development build:
+
+```sh
+cd apps/mobile
+npx expo prebuild
+eas build --profile development --platform ios
+eas build --profile development --platform android
+```
+
+The iOS keyboard extension and Android IME are included by the native
+configuration during prebuild.

--- a/apps/mobile/hooks/useKeyboardSync.ts
+++ b/apps/mobile/hooks/useKeyboardSync.ts
@@ -1,0 +1,99 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect } from "react";
+import { AppState, Platform } from "react-native";
+import { queryKeys } from "@/config/cache.config";
+import { useAuth } from "@/contexts/AuthContext";
+import { CalComAPIService, type EventType } from "@/services/calcom";
+import {
+  clearKeyboardData,
+  transformToKeyboardData,
+  updateKeyboardData,
+} from "@/utils/keyboardStorage";
+import { getCalAppUrl } from "@/utils/region";
+
+const SYNC_INTERVAL_MS = 15 * 60 * 1000;
+let lastSuccessfulSyncAt = 0;
+
+export function useKeyboardSync() {
+  const queryClient = useQueryClient();
+  const { isAuthenticated, userInfo } = useAuth();
+
+  const syncKeyboardData = useCallback(async () => {
+    if (
+      Platform.OS === "web" ||
+      !isAuthenticated ||
+      Date.now() - lastSuccessfulSyncAt < SYNC_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    const cachedEventTypes = queryClient.getQueryData<EventType[]>(queryKeys.eventTypes.lists());
+    const eventTypes =
+      cachedEventTypes ??
+      (await CalComAPIService.getEventTypes()).filter((eventType) => !eventType.hidden);
+    const visibleEventTypes = eventTypes.filter((eventType) => !eventType.hidden).slice(0, 10);
+    if (visibleEventTypes.length === 0) {
+      await updateKeyboardData({
+        links: [],
+        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        lastUpdated: new Date().toISOString(),
+      });
+      lastSuccessfulSyncAt = Date.now();
+      return;
+    }
+
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const start = new Date();
+    const end = new Date(start.getTime() + 14 * 24 * 60 * 60 * 1000);
+    const slotsByEventType: Record<string, Array<{ start: string }>> = {};
+
+    for (const eventType of visibleEventTypes) {
+      slotsByEventType[String(eventType.id)] = Object.values(
+        await CalComAPIService.getAvailableSlots({
+          eventTypeId: eventType.id,
+          start: start.toISOString(),
+          end: end.toISOString(),
+          timeZone,
+        })
+      ).flat();
+    }
+
+    const username = userInfo?.username ?? (await CalComAPIService.getUserProfile()).username;
+    const data = transformToKeyboardData({
+      eventTypes: visibleEventTypes,
+      slotsByEventType,
+      timeZone,
+      bookingUrlForEventType: (eventType) => `${getCalAppUrl()}/${username}/${eventType.slug}`,
+    });
+    await updateKeyboardData(data);
+    lastSuccessfulSyncAt = Date.now();
+  }, [isAuthenticated, queryClient, userInfo?.username]);
+
+  useEffect(() => {
+    if (Platform.OS === "web") {
+      return;
+    }
+    if (!isAuthenticated) {
+      clearKeyboardData().catch((error) => {
+        console.warn("Failed to clear keyboard data:", error);
+      });
+      lastSuccessfulSyncAt = 0;
+      return;
+    }
+
+    syncKeyboardData().catch((error) => {
+      console.warn("Failed to sync keyboard data:", error);
+    });
+    const subscription = AppState.addEventListener("change", (nextAppState) => {
+      if (nextAppState === "active") {
+        syncKeyboardData().catch((error) => {
+          console.warn("Failed to sync keyboard data on foreground:", error);
+        });
+      }
+    });
+
+    return () => subscription.remove();
+  }, [isAuthenticated, syncKeyboardData]);
+
+  return { syncKeyboardData, clearKeyboardData };
+}

--- a/apps/mobile/hooks/useKeyboardSync.ts
+++ b/apps/mobile/hooks/useKeyboardSync.ts
@@ -27,43 +27,42 @@ export function useKeyboardSync() {
       return;
     }
 
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const cachedEventTypes = queryClient.getQueryData<EventType[]>(queryKeys.eventTypes.lists());
-    const eventTypes =
-      cachedEventTypes ??
-      (await CalComAPIService.getEventTypes()).filter((eventType) => !eventType.hidden);
+    const eventTypes = cachedEventTypes ?? (await CalComAPIService.getEventTypes());
     const visibleEventTypes = eventTypes.filter((eventType) => !eventType.hidden).slice(0, 10);
     if (visibleEventTypes.length === 0) {
       await updateKeyboardData({
         links: [],
-        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        timeZone,
         lastUpdated: new Date().toISOString(),
       });
       lastSuccessfulSyncAt = Date.now();
       return;
     }
 
-    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const start = new Date();
     const end = new Date(start.getTime() + 14 * 24 * 60 * 60 * 1000);
     const slotsByEventType: Record<string, Array<{ start: string }>> = {};
 
     for (const eventType of visibleEventTypes) {
-      slotsByEventType[String(eventType.id)] = Object.values(
-        await CalComAPIService.getAvailableSlots({
-          eventTypeId: eventType.id,
-          start: start.toISOString(),
-          end: end.toISOString(),
-          timeZone,
-        })
-      ).flat();
+      slotsByEventType[String(eventType.id)] = await CalComAPIService.getAvailableSlots({
+        eventTypeId: eventType.id,
+        start: start.toISOString(),
+        end: end.toISOString(),
+        timeZone,
+      });
     }
 
-    const username = userInfo?.username ?? (await CalComAPIService.getUserProfile()).username;
+    const fallbackUsername = visibleEventTypes.some((eventType) => !eventType.bookingUrl)
+      ? (userInfo?.username ?? (await CalComAPIService.getUserProfile()).username)
+      : null;
     const data = transformToKeyboardData({
       eventTypes: visibleEventTypes,
       slotsByEventType,
       timeZone,
-      bookingUrlForEventType: (eventType) => `${getCalAppUrl()}/${username}/${eventType.slug}`,
+      bookingUrlForEventType: (eventType) =>
+        eventType.bookingUrl ?? `${getCalAppUrl()}/${fallbackUsername}/${eventType.slug}`,
     });
     await updateKeyboardData(data);
     lastSuccessfulSyncAt = Date.now();

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -50,6 +50,7 @@
     "expo-crypto": "15.0.9-canary-20251230-fc48ddc",
     "expo-dev-client": "6.1.0-canary-20251230-fc48ddc",
     "expo-device": "8.0.11-canary-20251230-fc48ddc",
+    "expo-file-system": "19.0.22-canary-20251230-fc48ddc",
     "expo-glass-effect": "0.2.0-canary-20251230-fc48ddc",
     "expo-haptics": "15.0.9-canary-20251230-fc48ddc",
     "expo-image": "3.1.0-canary-20251230-fc48ddc",

--- a/apps/mobile/plugins/android/CalKeyboardService.kt
+++ b/apps/mobile/plugins/android/CalKeyboardService.kt
@@ -1,0 +1,230 @@
+package com.calcom.companion.keyboard
+
+import android.graphics.Color
+import android.inputmethodservice.InputMethodService
+import android.view.Gravity
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import org.json.JSONObject
+import java.io.File
+
+private data class KeyboardSlot(val start: String, val label: String, val url: String)
+private data class KeyboardDay(val date: String, val label: String, val slots: List<KeyboardSlot>)
+private data class KeyboardLink(
+    val id: String,
+    val title: String,
+    val url: String,
+    val durationLabel: String?,
+    val days: List<KeyboardDay>
+)
+private data class KeyboardData(
+    val links: List<KeyboardLink>,
+    val timeZone: String
+)
+
+class CalKeyboardService : InputMethodService() {
+    private var data: KeyboardData? = null
+    private var selectedLink: KeyboardLink? = null
+    private val selectedSlots = linkedSetOf<String>()
+
+    override fun onStartInputView(info: android.view.inputmethod.EditorInfo?, restarting: Boolean) {
+        super.onStartInputView(info, restarting)
+        data = readData()
+        selectedLink = null
+        selectedSlots.clear()
+        showLinks()
+    }
+
+    private fun readData(): KeyboardData? {
+        return try {
+            val root = JSONObject(File(filesDir, "cal-keyboard.json").readText())
+            val links = root.optJSONArray("links") ?: return null
+            val parsedLinks = buildList {
+                for (index in 0 until links.length()) {
+                    val link = links.getJSONObject(index)
+                    val days = link.optJSONArray("days") ?: continue
+                    val parsedDays = buildList {
+                        for (dayIndex in 0 until days.length()) {
+                            val day = days.getJSONObject(dayIndex)
+                            val slots = day.optJSONArray("slots") ?: continue
+                            val parsedSlots = buildList {
+                                for (slotIndex in 0 until slots.length()) {
+                                    val slot = slots.getJSONObject(slotIndex)
+                                    add(
+                                        KeyboardSlot(
+                                            slot.getString("start"),
+                                            slot.getString("label"),
+                                            slot.getString("url")
+                                        )
+                                    )
+                                }
+                            }
+                            add(
+                                KeyboardDay(
+                                    day.getString("date"),
+                                    day.getString("label"),
+                                    parsedSlots
+                                )
+                            )
+                        }
+                    }
+                    add(
+                        KeyboardLink(
+                            link.getString("id"),
+                            link.getString("title"),
+                            link.getString("url"),
+                            link.optString("durationLabel").takeUnless { it == "null" || it.isEmpty() },
+                            parsedDays
+                        )
+                    )
+                }
+            }
+            KeyboardData(parsedLinks, root.optString("timeZone"))
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun baseLayout(): LinearLayout {
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(8), dp(8), dp(8), dp(8))
+            setBackgroundColor(Color.rgb(245, 245, 245))
+        }
+    }
+
+    private fun showLinks() {
+        val layout = baseLayout()
+        val title = TextView(this).apply {
+            text = "Cal.com links"
+            textSize = 18f
+            setTextColor(Color.BLACK)
+        }
+        layout.addView(title)
+        val links = data?.links.orEmpty()
+        if (links.isEmpty()) {
+            layout.addView(message("Open the Cal.com app to sync your links"))
+        } else {
+            val scroll = ScrollView(this)
+            val list = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+            links.forEach { link ->
+                val button = Button(this).apply {
+                    text = link.durationLabel?.let { "${link.title} ($it)" } ?: link.title
+                    setOnClickListener {
+                        selectedLink = link
+                        selectedSlots.clear()
+                        showSlots()
+                    }
+                }
+                list.addView(button)
+            }
+            scroll.addView(list)
+            layout.addView(scroll, LinearLayout.LayoutParams(-1, 0, 1f))
+        }
+        addFooter(layout)
+        setInputView(layout)
+    }
+
+    private fun showSlots() {
+        val link = selectedLink ?: return
+        val layout = baseLayout()
+        val header = LinearLayout(this).apply {
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        header.addView(Button(this).apply {
+            text = "Back"
+            setOnClickListener { showLinks() }
+        })
+        header.addView(TextView(this).apply {
+            text = link.title
+            textSize = 18f
+            setTextColor(Color.BLACK)
+            setPadding(dp(8), 0, 0, 0)
+        }, LinearLayout.LayoutParams(0, -2, 1f))
+        header.addView(Button(this).apply {
+            text = "Insert"
+            isEnabled = false
+            tag = "insert"
+            setOnClickListener {
+                currentInputConnection?.commitText(composeInsertion(link), 1)
+                selectedSlots.clear()
+                showLinks()
+            }
+        })
+        layout.addView(header)
+
+        val scroll = ScrollView(this)
+        val list = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        link.days.forEach { day ->
+            list.addView(TextView(this).apply {
+                text = day.label
+                textSize = 15f
+                setTextColor(Color.DKGRAY)
+                setPadding(0, dp(8), 0, dp(2))
+            })
+            day.slots.forEach { slot ->
+                val checkBox = CheckBox(this).apply {
+                    text = slot.label
+                    isChecked = selectedSlots.contains(slot.start)
+                    setOnCheckedChangeListener { _, checked ->
+                        if (checked) selectedSlots.add(slot.start) else selectedSlots.remove(slot.start)
+                        header.findViewWithTag<Button>("insert").isEnabled = selectedSlots.isNotEmpty()
+                    }
+                }
+                list.addView(checkBox)
+            }
+        }
+        scroll.addView(list)
+        layout.addView(scroll, LinearLayout.LayoutParams(-1, 0, 1f))
+        addFooter(layout)
+        setInputView(layout)
+    }
+
+    private fun addFooter(layout: LinearLayout) {
+        val footer = LinearLayout(this).apply {
+            gravity = Gravity.RIGHT
+        }
+        val switchButton = Button(this).apply {
+            text = "🌐"
+            setOnClickListener {
+                if (!switchToNextInputMethod(false)) {
+                    (getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager)
+                        .showInputMethodPicker()
+                }
+            }
+        }
+        footer.addView(switchButton)
+        footer.addView(Button(this).apply {
+            text = "⌫"
+            setOnClickListener { currentInputConnection?.deleteSurroundingText(1, 0) }
+        })
+        layout.addView(footer)
+    }
+
+    private fun composeInsertion(link: KeyboardLink): String {
+        val selections = link.days.flatMap { day ->
+            day.slots.filter { selectedSlots.contains(it.start) }.map { day to it }
+        }
+        val lines = selections.map { (day, slot) -> "${day.label} at ${slot.label} — ${slot.url}" }
+        if (lines.size == 1) return lines[0]
+        return (listOf("${link.title} — pick a time:") + lines + listOf("", "(times in ${data?.timeZone.orEmpty()})"))
+            .joinToString("\n")
+    }
+
+    private fun message(text: String): TextView {
+        return TextView(this).apply {
+            this.text = text
+            textSize = 15f
+            gravity = Gravity.CENTER
+            setTextColor(Color.DKGRAY)
+            setPadding(dp(8), dp(16), dp(8), dp(16))
+        }
+    }
+
+    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
+}

--- a/apps/mobile/plugins/android/CalKeyboardService.kt
+++ b/apps/mobile/plugins/android/CalKeyboardService.kt
@@ -2,6 +2,7 @@ package com.calcom.companion.keyboard
 
 import android.graphics.Color
 import android.inputmethodservice.InputMethodService
+import android.view.KeyEvent
 import android.view.Gravity
 import android.view.View
 import android.view.inputmethod.InputMethodManager
@@ -78,7 +79,7 @@ class CalKeyboardService : InputMethodService() {
                             link.getString("id"),
                             link.getString("title"),
                             link.getString("url"),
-                            link.optString("durationLabel").takeUnless { it == "null" || it.isEmpty() },
+                            if (link.isNull("durationLabel")) null else link.optString("durationLabel"),
                             parsedDays
                         )
                     )
@@ -187,7 +188,7 @@ class CalKeyboardService : InputMethodService() {
 
     private fun addFooter(layout: LinearLayout) {
         val footer = LinearLayout(this).apply {
-            gravity = Gravity.RIGHT
+            gravity = Gravity.END
         }
         val switchButton = Button(this).apply {
             text = "🌐"
@@ -201,7 +202,7 @@ class CalKeyboardService : InputMethodService() {
         footer.addView(switchButton)
         footer.addView(Button(this).apply {
             text = "⌫"
-            setOnClickListener { currentInputConnection?.deleteSurroundingText(1, 0) }
+            setOnClickListener { sendDownUpKeyEvents(KeyEvent.KEYCODE_DEL) }
         })
         layout.addView(footer)
     }

--- a/apps/mobile/plugins/android/cal_keyboard_method.xml
+++ b/apps/mobile/plugins/android/cal_keyboard_method.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<input-method xmlns:android="http://schemas.android.com/apk/res/android">
+  <subtype
+    android:label="@string/app_name"
+    android:imeSubtypeLocale="en_US"
+    android:imeSubtypeMode="keyboard" />
+</input-method>

--- a/apps/mobile/plugins/withCalKeyboard.js
+++ b/apps/mobile/plugins/withCalKeyboard.js
@@ -1,0 +1,65 @@
+const { withAndroidManifest, withDangerousMod } = require("@expo/config-plugins");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const sourceRoot = path.join(__dirname, "android");
+
+function copyFile(projectRoot, source, destination) {
+  const destinationPath = path.join(projectRoot, destination);
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+  fs.copyFileSync(path.join(sourceRoot, source), destinationPath);
+}
+
+module.exports = function withCalKeyboard(config) {
+  config = withDangerousMod(config, [
+    "android",
+    (config) => {
+      copyFile(
+        config.modRequest.projectRoot,
+        "CalKeyboardService.kt",
+        "android/app/src/main/java/com/calcom/companion/keyboard/CalKeyboardService.kt"
+      );
+      copyFile(
+        config.modRequest.projectRoot,
+        "cal_keyboard_method.xml",
+        "android/app/src/main/res/xml/cal_keyboard_method.xml"
+      );
+      return config;
+    },
+  ]);
+
+  return withAndroidManifest(config, (config) => {
+    const application = config.modResults.manifest.application?.[0];
+    if (!application) {
+      return config;
+    }
+
+    const service = {
+      $: {
+        "android:name": ".keyboard.CalKeyboardService",
+        "android:label": "Cal.com Keyboard",
+        "android:permission": "android.permission.BIND_INPUT_METHOD",
+        "android:exported": "true",
+      },
+      "intent-filter": [
+        {
+          action: [{ $: { "android:name": "android.view.InputMethod" } }],
+        },
+      ],
+      "meta-data": [
+        {
+          $: {
+            "android:name": "android.view.im",
+            "android:resource": "@xml/cal_keyboard_method",
+          },
+        },
+      ],
+    };
+    const services = application.service ?? [];
+    application.service = services.filter(
+      (item) => item.$?.["android:name"] !== service.$["android:name"]
+    );
+    application.service.push(service);
+    return config;
+  });
+};

--- a/apps/mobile/services/calcom/index.ts
+++ b/apps/mobile/services/calcom/index.ts
@@ -89,6 +89,7 @@ import {
   getSchedules,
   updateSchedule,
 } from "./schedules";
+import { getAvailableSlots } from "./slots";
 import {
   clearUserProfile,
   getCurrentUser,
@@ -163,6 +164,9 @@ export const CalComAPIService = {
   updateSchedule,
   duplicateSchedule,
   deleteSchedule,
+
+  // Availability
+  getAvailableSlots,
 
   // Conferencing
   getConferencingOptions,

--- a/apps/mobile/services/calcom/slots.ts
+++ b/apps/mobile/services/calcom/slots.ts
@@ -15,7 +15,7 @@ export async function getAvailableSlots({
   start: string;
   end: string;
   timeZone: string;
-}): Promise<Record<string, Array<{ start: string }>>> {
+}): Promise<Array<{ start: string }>> {
   const params = new URLSearchParams({
     eventTypeId: String(eventTypeId),
     start,
@@ -33,13 +33,13 @@ export async function getAvailableSlots({
   );
 
   if (Array.isArray(response)) {
-    return { slots: response };
+    return response;
   }
   if (response?.data && !Array.isArray(response.data)) {
-    return response.data;
+    return Object.values(response.data).flat();
   }
   if (response?.data && Array.isArray(response.data)) {
-    return { slots: response.data };
+    return response.data;
   }
-  return {};
+  return [];
 }

--- a/apps/mobile/services/calcom/slots.ts
+++ b/apps/mobile/services/calcom/slots.ts
@@ -1,0 +1,45 @@
+import { makeRequest } from "./request";
+
+interface SlotsResponse {
+  status?: string;
+  data?: Record<string, Array<{ start: string }>> | Array<{ start: string }>;
+}
+
+export async function getAvailableSlots({
+  eventTypeId,
+  start,
+  end,
+  timeZone,
+}: {
+  eventTypeId: number;
+  start: string;
+  end: string;
+  timeZone: string;
+}): Promise<Record<string, Array<{ start: string }>>> {
+  const params = new URLSearchParams({
+    eventTypeId: String(eventTypeId),
+    start,
+    end,
+    timeZone,
+  });
+  const response = await makeRequest<SlotsResponse | Array<{ start: string }>>(
+    `/slots?${params.toString()}`,
+    {
+      headers: {
+        "cal-api-version": "2024-09-04",
+      },
+    },
+    "2024-09-04"
+  );
+
+  if (Array.isArray(response)) {
+    return { slots: response };
+  }
+  if (response?.data && !Array.isArray(response.data)) {
+    return response.data;
+  }
+  if (response?.data && Array.isArray(response.data)) {
+    return { slots: response.data };
+  }
+  return {};
+}

--- a/apps/mobile/targets/keyboard/Info.plist
+++ b/apps/mobile/targets/keyboard/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSExtension</key>
+    <dict>
+      <key>NSExtensionPointIdentifier</key>
+      <string>com.apple.keyboard-service</string>
+      <key>NSExtensionPrincipalClass</key>
+      <string>$(PRODUCT_MODULE_NAME).KeyboardViewController</string>
+      <key>NSExtensionAttributes</key>
+      <dict>
+        <key>RequestsOpenAccess</key>
+        <false/>
+        <key>IsASCIICapable</key>
+        <false/>
+        <key>PrefersRightToLeft</key>
+        <false/>
+        <key>PrimaryLanguage</key>
+        <string>en-US</string>
+      </dict>
+    </dict>
+  </dict>
+</plist>

--- a/apps/mobile/targets/keyboard/KeyboardViewController.swift
+++ b/apps/mobile/targets/keyboard/KeyboardViewController.swift
@@ -1,0 +1,217 @@
+import SwiftUI
+import UIKit
+
+struct KeyboardData: Codable {
+    let links: [KeyboardLink]
+    let timeZone: String
+    let lastUpdated: String
+}
+
+struct KeyboardLink: Codable, Identifiable {
+    let id: String
+    let title: String
+    let url: String
+    let durationLabel: String?
+    let days: [KeyboardDay]
+}
+
+struct KeyboardDay: Codable, Identifiable {
+    let date: String
+    let label: String
+    let slots: [KeyboardSlot]
+
+    var id: String { date }
+}
+
+struct KeyboardSlot: Codable, Identifiable {
+    let start: String
+    let label: String
+    let url: String
+
+    var id: String { start }
+}
+
+final class KeyboardViewController: UIInputViewController {
+    private var hostingController: UIHostingController<KeyboardRootView>?
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        let data = loadKeyboardData()
+        let rootView = KeyboardRootView(
+            data: data,
+            showsInputModeSwitchKey: needsInputModeSwitchKey,
+            onSwitchInputMode: { [weak self] in self?.advanceToNextInputMode() },
+            onBackspace: { [weak self] in self?.textDocumentProxy.deleteBackward() },
+            onInsert: { [weak self] text in self?.textDocumentProxy.insertText(text) }
+        )
+
+        if let hostingController {
+            hostingController.rootView = rootView
+        } else {
+            let controller = UIHostingController(rootView: rootView)
+            hostingController = controller
+            addChild(controller)
+            view.addSubview(controller.view)
+            controller.view.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                controller.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                controller.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                controller.view.topAnchor.constraint(equalTo: view.topAnchor),
+                controller.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                view.heightAnchor.constraint(equalToConstant: 300),
+            ])
+            controller.didMove(toParent: self)
+        }
+    }
+
+    private func loadKeyboardData() -> KeyboardData? {
+        guard let defaults = UserDefaults(suiteName: "group.com.cal.companion") else {
+            return nil
+        }
+
+        if let jsonString = defaults.string(forKey: "keyboardLinks"),
+           let data = jsonString.data(using: .utf8) {
+            return try? JSONDecoder().decode(KeyboardData.self, from: data)
+        }
+        if let data = defaults.data(forKey: "keyboardLinks") {
+            return try? JSONDecoder().decode(KeyboardData.self, from: data)
+        }
+        return nil
+    }
+}
+
+struct KeyboardRootView: View {
+    let data: KeyboardData?
+    let showsInputModeSwitchKey: Bool
+    let onSwitchInputMode: () -> Void
+    let onBackspace: () -> Void
+    let onInsert: (String) -> Void
+    @State private var selectedLink: KeyboardLink?
+    @State private var selectedSlots: Set<String> = []
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if let data {
+                if let selectedLink {
+                    slotPicker(link: selectedLink, timeZone: data.timeZone)
+                } else {
+                    linkPicker(data.links)
+                }
+            } else {
+                Text("Open the Cal.com app to sync your links")
+                    .font(.system(size: 15, weight: .medium))
+                    .multilineTextAlignment(.center)
+                    .padding()
+            }
+            Spacer(minLength: 0)
+            HStack(spacing: 8) {
+                if showsInputModeSwitchKey {
+                    Button(action: onSwitchInputMode) {
+                        Image(systemName: "globe")
+                    }
+                }
+                Spacer()
+                Button(action: onBackspace) {
+                    Image(systemName: "delete.left")
+                }
+            }
+            .buttonStyle(.bordered)
+            .padding(.horizontal, 8)
+        }
+        .padding(8)
+        .background(Color(uiColor: .systemGray6))
+    }
+
+    private func linkPicker(_ links: [KeyboardLink]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Cal.com links")
+                .font(.headline)
+            if links.isEmpty {
+                Text("Open the Cal.com app to sync your links")
+                    .foregroundStyle(.secondary)
+            } else {
+                ScrollView {
+                    ForEach(links) { link in
+                        Button {
+                            selectedLink = link
+                            selectedSlots = []
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading) {
+                                    Text(link.title).fontWeight(.semibold)
+                                    if let duration = link.durationLabel {
+                                        Text(duration).font(.caption).foregroundStyle(.secondary)
+                                    }
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        Divider()
+                    }
+                }
+            }
+        }
+    }
+
+    private func slotPicker(link: KeyboardLink, timeZone: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Button {
+                    selectedLink = nil
+                    selectedSlots = []
+                } label: {
+                    Image(systemName: "chevron.left")
+                }
+                Text(link.title).font(.headline).lineLimit(1)
+                Spacer()
+                Button("Insert") {
+                    let selections = link.days.flatMap { day in
+                        day.slots.filter { selectedSlots.contains($0.id) }.map { (day, $0) }
+                    }
+                    onInsert(composeInsertion(link: link, selections: selections, timeZone: timeZone))
+                    selectedSlots = []
+                }
+                .disabled(selectedSlots.isEmpty)
+            }
+            ScrollView {
+                ForEach(link.days) { day in
+                    Section(day.label) {
+                        ForEach(day.slots) { slot in
+                            Button {
+                                if selectedSlots.contains(slot.id) {
+                                    selectedSlots.remove(slot.id)
+                                } else {
+                                    selectedSlots.insert(slot.id)
+                                }
+                            } label: {
+                                HStack {
+                                    Text(slot.label)
+                                    Spacer()
+                                    if selectedSlots.contains(slot.id) {
+                                        Image(systemName: "checkmark")
+                                    }
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func composeInsertion(
+        link: KeyboardLink,
+        selections: [(KeyboardDay, KeyboardSlot)],
+        timeZone: String
+    ) -> String {
+        let lines = selections.map { "\($0.0.label) at \($0.1.label) — \($0.1.url)" }
+        if lines.count == 1 {
+            return lines[0]
+        }
+        return ([ "\(link.title) — pick a time:" ] + lines + ["", "(times in \(timeZone))"]).joined(separator: "\n")
+    }
+}

--- a/apps/mobile/targets/keyboard/KeyboardViewController.swift
+++ b/apps/mobile/targets/keyboard/KeyboardViewController.swift
@@ -32,18 +32,18 @@ struct KeyboardSlot: Codable, Identifiable {
 }
 
 final class KeyboardViewController: UIInputViewController {
-    private var hostingController: UIHostingController<KeyboardRootView>?
+    private var hostingController: UIHostingController<AnyView>?
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         let data = loadKeyboardData()
-        let rootView = KeyboardRootView(
+        let rootView = AnyView(KeyboardRootView(
             data: data,
             showsInputModeSwitchKey: needsInputModeSwitchKey,
             onSwitchInputMode: { [weak self] in self?.advanceToNextInputMode() },
             onBackspace: { [weak self] in self?.textDocumentProxy.deleteBackward() },
             onInsert: { [weak self] text in self?.textDocumentProxy.insertText(text) }
-        )
+        ).id(data?.lastUpdated ?? ""))
 
         if let hostingController {
             hostingController.rootView = rootView
@@ -53,12 +53,14 @@ final class KeyboardViewController: UIInputViewController {
             addChild(controller)
             view.addSubview(controller.view)
             controller.view.translatesAutoresizingMaskIntoConstraints = false
+            let heightConstraint = view.heightAnchor.constraint(equalToConstant: 300)
+            heightConstraint.priority = UILayoutPriority(999)
             NSLayoutConstraint.activate([
                 controller.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 controller.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 controller.view.topAnchor.constraint(equalTo: view.topAnchor),
                 controller.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-                view.heightAnchor.constraint(equalToConstant: 300),
+                heightConstraint,
             ])
             controller.didMove(toParent: self)
         }
@@ -178,7 +180,11 @@ struct KeyboardRootView: View {
             }
             ScrollView {
                 ForEach(link.days) { day in
-                    Section(day.label) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(day.label)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .padding(.top, 8)
                         ForEach(day.slots) { slot in
                             Button {
                                 if selectedSlots.contains(slot.id) {

--- a/apps/mobile/targets/keyboard/expo-target.config.js
+++ b/apps/mobile/targets/keyboard/expo-target.config.js
@@ -1,0 +1,9 @@
+/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = () => ({
+  type: "keyboard",
+  name: "CalKeyboard",
+  icon: "../../assets/icon.png",
+  entitlements: {
+    "com.apple.security.application-groups": ["group.com.cal.companion"],
+  },
+});

--- a/apps/mobile/utils/keyboardStorage.android.ts
+++ b/apps/mobile/utils/keyboardStorage.android.ts
@@ -1,0 +1,27 @@
+import { File, Paths } from "expo-file-system";
+
+import { ANDROID_KEYBOARD_FILE, type KeyboardData } from "./keyboardStorage.shared";
+
+const keyboardFile = new File(Paths.document, ANDROID_KEYBOARD_FILE);
+
+export async function updateKeyboardData(data: KeyboardData): Promise<void> {
+  keyboardFile.write(JSON.stringify(data));
+}
+
+export async function getKeyboardData(): Promise<KeyboardData | null> {
+  try {
+    return JSON.parse(await keyboardFile.text()) as KeyboardData;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearKeyboardData(): Promise<void> {
+  try {
+    keyboardFile.delete();
+  } catch {
+    // The file may not exist yet.
+  }
+}
+
+export * from "./keyboardStorage.shared";

--- a/apps/mobile/utils/keyboardStorage.ios.ts
+++ b/apps/mobile/utils/keyboardStorage.ios.ts
@@ -1,0 +1,32 @@
+import { ExtensionStorage } from "@bacons/apple-targets";
+
+import {
+  APP_GROUP_IDENTIFIER,
+  KEYBOARD_DATA_KEY,
+  type KeyboardData,
+} from "./keyboardStorage.shared";
+
+const iosStorage = new ExtensionStorage(APP_GROUP_IDENTIFIER);
+
+export async function updateKeyboardData(data: KeyboardData): Promise<void> {
+  iosStorage.set(KEYBOARD_DATA_KEY, data as unknown as Record<string, string | number>);
+}
+
+export async function getKeyboardData(): Promise<KeyboardData | null> {
+  const value = iosStorage.get(KEYBOARD_DATA_KEY);
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return (typeof value === "string" ? JSON.parse(value) : value) as KeyboardData;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearKeyboardData(): Promise<void> {
+  iosStorage.remove(KEYBOARD_DATA_KEY);
+}
+
+export * from "./keyboardStorage.shared";

--- a/apps/mobile/utils/keyboardStorage.shared.test.js
+++ b/apps/mobile/utils/keyboardStorage.shared.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  buildSlotUrl,
+  composeKeyboardInsertion,
+  transformToKeyboardData,
+} from "./keyboardStorage.shared";
+
+const eventType = (id) => ({
+  id,
+  title: `Event ${id}`,
+  slug: `event-${id}`,
+  length: 30,
+});
+
+describe("keyboard storage data", () => {
+  it("adds slot query parameters while preserving an existing query", () => {
+    expect(
+      buildSlotUrl(
+        "https://app.cal.com/alex/meeting?theme=dark",
+        "2026-09-01T17:00:00.000Z",
+        "America/New_York"
+      )
+    ).toBe(
+      "https://app.cal.com/alex/meeting?theme=dark&date=2026-09-01&month=2026-09&slot=2026-09-01T17%3A00%3A00.000Z"
+    );
+  });
+
+  it("caps links, days, and slots", () => {
+    const slotsByEventType = {};
+    for (let eventId = 1; eventId <= 11; eventId += 1) {
+      slotsByEventType[eventId] = Array.from({ length: 64 }, (_, index) => ({
+        start: new Date(Date.UTC(2026, 8, 1 + Math.floor(index / 8), index % 8)).toISOString(),
+      }));
+    }
+    const result = transformToKeyboardData({
+      eventTypes: Array.from({ length: 11 }, (_, index) => eventType(index + 1)),
+      slotsByEventType,
+      timeZone: "UTC",
+      bookingUrlForEventType: (event) => `https://app.cal.com/alex/${event.slug}`,
+    });
+
+    expect(result.links).toHaveLength(10);
+    expect(result.links[0].days).toHaveLength(7);
+    expect(result.links[0].days.every((day) => day.slots.length <= 8)).toBe(true);
+  });
+
+  it("composes single and multiple slot insertions", () => {
+    const data = transformToKeyboardData({
+      eventTypes: [eventType(1)],
+      slotsByEventType: {
+        1: [{ start: "2026-09-01T10:00:00.000Z" }, { start: "2026-09-01T11:00:00.000Z" }],
+      },
+      timeZone: "UTC",
+      bookingUrlForEventType: () => "https://app.cal.com/alex/event-1",
+    });
+    const [link] = data.links;
+    const [day] = link.days;
+    const [slot] = day.slots;
+
+    expect(composeKeyboardInsertion(link, [{ day, slot }], "UTC")).toBe(
+      `${day.label} at ${slot.label} — ${slot.url}`
+    );
+    const secondSlot = day.slots[1];
+    expect(
+      composeKeyboardInsertion(
+        link,
+        [
+          { day, slot },
+          { day, slot: secondSlot },
+        ],
+        "UTC"
+      )
+    ).toContain("(times in UTC)");
+  });
+});

--- a/apps/mobile/utils/keyboardStorage.shared.test.js
+++ b/apps/mobile/utils/keyboardStorage.shared.test.js
@@ -70,6 +70,14 @@ describe("keyboard storage data", () => {
         ],
         "UTC"
       )
-    ).toContain("(times in UTC)");
+    ).toBe(
+      [
+        `${link.title} — pick a time:`,
+        `${day.label} at ${slot.label} — ${slot.url}`,
+        `${day.label} at ${secondSlot.label} — ${secondSlot.url}`,
+        "",
+        "(times in UTC)",
+      ].join("\n")
+    );
   });
 });

--- a/apps/mobile/utils/keyboardStorage.shared.ts
+++ b/apps/mobile/utils/keyboardStorage.shared.ts
@@ -1,0 +1,155 @@
+import type { EventType } from "@/services/types";
+
+import { APP_GROUP_IDENTIFIER } from "./widgetStorage.shared";
+
+export const KEYBOARD_DATA_KEY = "keyboardLinks";
+export const ANDROID_KEYBOARD_FILE = "cal-keyboard.json";
+
+export interface KeyboardSlot {
+  start: string;
+  label: string;
+  url: string;
+}
+
+export interface KeyboardDay {
+  date: string;
+  label: string;
+  slots: KeyboardSlot[];
+}
+
+export interface KeyboardLink {
+  id: string;
+  title: string;
+  url: string;
+  durationLabel: string | null;
+  days: KeyboardDay[];
+}
+
+export interface KeyboardData {
+  links: KeyboardLink[];
+  timeZone: string;
+  lastUpdated: string;
+}
+
+export interface KeyboardSlotInput {
+  start: string;
+}
+
+export interface KeyboardDataInput {
+  eventTypes: EventType[];
+  slotsByEventType: Record<string, KeyboardSlotInput[]>;
+  timeZone: string;
+  bookingUrlForEventType: (eventType: EventType) => string;
+}
+
+function getDateParts(start: string, timeZone: string): Record<string, string> {
+  return Object.fromEntries(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    })
+      .formatToParts(new Date(start))
+      .filter(({ type }) => type !== "literal")
+      .map(({ type, value }) => [type, value])
+  );
+}
+
+function formatDate(start: string, timeZone: string): string {
+  const parts = getDateParts(start, timeZone);
+  return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+function formatDateLabel(start: string, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  }).format(new Date(start));
+}
+
+function formatTimeLabel(start: string, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(new Date(start));
+}
+
+export function buildSlotUrl(bookingUrl: string, isoStart: string, timeZone: string): string {
+  const url = new URL(bookingUrl);
+  const date = formatDate(isoStart, timeZone);
+  url.searchParams.set("date", date);
+  url.searchParams.set("month", date.slice(0, 7));
+  url.searchParams.set("slot", isoStart);
+  return url.toString();
+}
+
+export function transformToKeyboardData(input: KeyboardDataInput): KeyboardData {
+  const links = input.eventTypes.slice(0, 10).map((eventType) => {
+    const slots = input.slotsByEventType[String(eventType.id)] ?? [];
+    const daysByDate = new Map<string, KeyboardDay>();
+
+    for (const slot of slots) {
+      const date = formatDate(slot.start, input.timeZone);
+      const day = daysByDate.get(date) ?? {
+        date,
+        label: formatDateLabel(slot.start, input.timeZone),
+        slots: [],
+      };
+
+      if (day.slots.length < 8) {
+        day.slots.push({
+          start: slot.start,
+          label: formatTimeLabel(slot.start, input.timeZone),
+          url: buildSlotUrl(input.bookingUrlForEventType(eventType), slot.start, input.timeZone),
+        });
+        daysByDate.set(date, day);
+      }
+    }
+
+    const days = [...daysByDate.values()]
+      .filter((day) => day.slots.length > 0)
+      .sort((a, b) => a.date.localeCompare(b.date))
+      .slice(0, 7);
+
+    return {
+      id: String(eventType.id),
+      title: eventType.title,
+      url: input.bookingUrlForEventType(eventType),
+      durationLabel:
+        eventType.lengthInMinutes !== undefined || eventType.length !== undefined
+          ? `${eventType.lengthInMinutes ?? eventType.length} min`
+          : null,
+      days,
+    };
+  });
+
+  return {
+    links,
+    timeZone: input.timeZone,
+    lastUpdated: new Date().toISOString(),
+  };
+}
+
+export function composeKeyboardInsertion(
+  link: KeyboardLink,
+  selections: Array<{ day: KeyboardDay; slot: KeyboardSlot }>,
+  timeZone: string
+): string {
+  if (selections.length === 0) {
+    return "";
+  }
+
+  const lines = selections.map(({ day, slot }) => `${day.label} at ${slot.label} — ${slot.url}`);
+  if (selections.length === 1) {
+    return lines[0];
+  }
+
+  return [`${link.title} — pick a time:`, ...lines, "", `(times in ${timeZone})`].join("\n");
+}
+
+export { APP_GROUP_IDENTIFIER };

--- a/apps/mobile/utils/keyboardStorage.ts
+++ b/apps/mobile/utils/keyboardStorage.ts
@@ -1,0 +1,16 @@
+import type { KeyboardData } from "./keyboardStorage.shared";
+
+export * from "./keyboardStorage.shared";
+
+export async function updateKeyboardData(_data: KeyboardData): Promise<void> {
+  console.warn("Keyboard updates are not supported on this platform");
+}
+
+export async function getKeyboardData(): Promise<KeyboardData | null> {
+  console.warn("Keyboard reads are not supported on this platform");
+  return null;
+}
+
+export async function clearKeyboardData(): Promise<void> {
+  console.warn("Keyboard clearing is not supported on this platform");
+}

--- a/bun.lock
+++ b/bun.lock
@@ -96,6 +96,7 @@
         "expo-crypto": "15.0.9-canary-20251230-fc48ddc",
         "expo-dev-client": "6.1.0-canary-20251230-fc48ddc",
         "expo-device": "8.0.11-canary-20251230-fc48ddc",
+        "expo-file-system": "19.0.22-canary-20251230-fc48ddc",
         "expo-glass-effect": "0.2.0-canary-20251230-fc48ddc",
         "expo-haptics": "15.0.9-canary-20251230-fc48ddc",
         "expo-image": "3.1.0-canary-20251230-fc48ddc",


### PR DESCRIPTION
## Summary

Adds an installable Cal.com system keyboard so you can drop booking links with pre-selected times into any app's text field: pick a link → tick one or more available slots → **Insert**.

A keyboard is a separate OS-owned process (iOS app extension / Android `InputMethodService`), so it can't be React Native and it does no networking. The split is:

- **Expo app** (auth, API, formatting) syncs a small JSON payload to a place the keyboard can read: iOS App Group `group.com.cal.companion` (key `keyboardLinks`, via `ExtensionStorage`, same channel as the existing widget), Android `filesDir/cal-keyboard.json`.
- **Keyboard** (SwiftUI in `targets/keyboard`, Kotlin views in `plugins/android`) only renders that payload and commits text via `textDocumentProxy.insertText` / `commitText`.

Sync runs on login + foreground, throttled to 15 min, capped at 10 links × 7 days × 8 slots so the extension stays inside its memory budget. Cleared on logout. `RequestsOpenAccess` stays `false`.

Slot URLs reuse the event type's canonical `bookingUrl` (falls back to `${calAppUrl}/${username}/${slug}`) and set the booker's own params, preserving anything already on the URL:

```ts
buildSlotUrl("https://app.cal.com/alex/meeting?theme=dark", "2026-09-01T17:00:00.000Z", "America/New_York")
// → ...?theme=dark&date=2026-09-01&month=2026-09&slot=2026-09-01T17%3A00%3A00.000Z
```

Insertion format lives in `composeKeyboardInsertion` (TS, reimplemented identically in Swift/Kotlin) — one slot inserts a single line, several insert a block:

```
Intro call — pick a time:
Mon, Sep 1 at 10:00 AM — <url>
Mon, Sep 1 at 2:00 PM — <url>

(times in America/New_York)
```

Android is wired through a new config plugin (`plugins/withCalKeyboard.js`) that copies the Kotlin service + IME XML and registers the service with `BIND_INPUT_METHOD` during prebuild.

Setup instructions ship both in-app (More → Cal.com Keyboard, with a button into system keyboard settings and a live preview of the inserted text) and in `apps/mobile/docs/custom-keyboard.md`. Requires a dev build — keyboards don't exist in Expo Go.

## Verification

`bun run typecheck`, Biome on changed files, and Jest for the URL/cap/format helpers pass; `expo prebuild` was run for both platforms to confirm the generated manifest, IME XML, Kotlin source and iOS keyboard target (generated dirs removed after).

Not verified: this box is Linux, so the Swift and Kotlin were never compiled and the keyboard UI was never rendered — both need a device pass before merge.


Link to Devin session: https://app.devin.ai/sessions/7eb5fa8ae38c4609816cf2081a83bc5c
Open in Devin Desktop: https://app.devin.ai/desktop/session/7eb5fa8ae38c4609816cf2081a83bc5c?variant=devin
Requested by: @PeerRich