### PR TITLE
feat(mcp-server): add OpenTelemetry monitoring

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -66,6 +66,25 @@ cp apps/mcp-server/.env.example apps/mcp-server/.env
 | `CORS_ORIGIN` | No | `MCP_SERVER_URL` origin | Browser CORS origin for remote HTTP clients. Set this when the browser client origin differs from the MCP server origin. |
 | `OPENAI_APPS_CHALLENGE_TOKEN` | No | — | Token served at `/.well-known/openai-apps-challenge` for OpenAI Apps domain verification. When unset, the endpoint returns 404. |
 
+### OpenTelemetry
+
+Vercel deployments initialize OpenTelemetry through the project-root
+`instrumentation.ts` hook and `@vercel/otel`. No additional environment variable
+is required for Vercel's built-in collector. MCP tool executions produce custom
+spans under the `cal-mcp-server` service with only the static tool name and
+success/error status; tool arguments, results, credentials, user identifiers, and
+exception messages are not attached.
+
+The stdio and self-hosted HTTP entry points do not initialize an SDK or exporter,
+so telemetry remains a no-op by default and stdout stays reserved for MCP. A
+self-hosted operator may preload their own OpenTelemetry SDK/exporter; the custom
+tool spans will then use that globally registered provider.
+
+To retain production traces in Vercel, enable Always-on Tracing and add sampling
+rules in the Vercel project (with no rules, it collects nothing). Exporting
+traces to Grafana or another backend instead requires a Vercel Trace Drain (or
+provider integration). Both are deployment configuration outside this repository.
+
 ## Transport Modes
 
 The server supports two transport modes selected via the `MCP_TRANSPORT` environment variable.

--- a/apps/mcp-server/instrumentation.ts
+++ b/apps/mcp-server/instrumentation.ts
@@ -1,0 +1,6 @@
+/**
+ * Vercel discovers instrumentation only at the project root. Keep this as a
+ * thin deployment entry point while the implementation lives under src/ so it
+ * is typechecked, linted, built, and included in the published package.
+ */
+import "./src/instrumentation.js";

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -22,13 +22,15 @@
     "start": "node dist/index.js",
     "dev": "node --import tsx src/index.ts",
     "typecheck": "tsc --noEmit -p tsconfig.check.json",
-    "lint": "biome lint src/",
+    "lint": "biome lint src/ instrumentation.ts",
     "format": "biome format --write .",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
+    "@opentelemetry/api": "1.9.0",
+    "@vercel/otel": "2.0.1",
     "@vercel/postgres": "0.10.0",
     "zod": "3.25.76"
   },

--- a/apps/mcp-server/src/http-server.ts
+++ b/apps/mcp-server/src/http-server.ts
@@ -24,6 +24,7 @@ import { cleanupExpired, countRegisteredClients } from "./storage/token-store.js
 import { applyCorsHeaders, resolveCorsOrigin } from "./utils/http-security.js";
 import { logger, withLogContext } from "./utils/logger.js";
 import { getClientIp, RateLimiter, sendRateLimited } from "./utils/rate-limiter.js";
+import { instrumentMcpTransport } from "./utils/telemetry.js";
 
 export interface HttpServerConfig {
   port: number;
@@ -401,7 +402,7 @@ export async function startHttpServer(
           }
         };
 
-        await server.connect(transport);
+        await server.connect(instrumentMcpTransport(transport));
 
         await withLogContext({ requestId }, async () => {
           await authContext.run(calAuthHeaders, async () => {

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -9,6 +9,7 @@ import { startHttpServer } from "./http-server.js";
 import { registerTools } from "./register-tools.js";
 import { SERVER_INSTRUCTIONS } from "./server-instructions.js";
 import { logger, setLogLevel } from "./utils/logger.js";
+import { instrumentMcpTransport } from "./utils/telemetry.js";
 
 async function main(): Promise<void> {
   const config = loadConfig();
@@ -58,7 +59,7 @@ async function main(): Promise<void> {
     registerTools(server);
 
     const stdioTransport = new StdioServerTransport();
-    await server.connect(stdioTransport);
+    await server.connect(instrumentMcpTransport(stdioTransport));
 
     logger.info("Cal.com MCP server running on stdio");
   }

--- a/apps/mcp-server/src/instrumentation.test.ts
+++ b/apps/mcp-server/src/instrumentation.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ registerOTel: vi.fn() }));
+
+vi.mock("@vercel/otel", () => ({ registerOTel: mocks.registerOTel }));
+
+describe("Vercel OpenTelemetry instrumentation", () => {
+  it("registers the MCP service with Vercel's supported setup", async () => {
+    vi.resetModules();
+    mocks.registerOTel.mockClear();
+    await import("../instrumentation.js");
+
+    expect(mocks.registerOTel).toHaveBeenCalledOnce();
+    expect(mocks.registerOTel).toHaveBeenCalledWith({ serviceName: "cal-mcp-server" });
+  });
+});

--- a/apps/mcp-server/src/instrumentation.ts
+++ b/apps/mcp-server/src/instrumentation.ts
@@ -1,0 +1,8 @@
+import { registerOTel } from "@vercel/otel";
+
+/**
+ * Register Vercel's supported OpenTelemetry setup for non-Next.js frameworks.
+ * Self-hosted and stdio entry points do not load the project-root hook, so they
+ * do not initialize an SDK.
+ */
+registerOTel({ serviceName: "cal-mcp-server" });

--- a/apps/mcp-server/src/register-tools.ts
+++ b/apps/mcp-server/src/register-tools.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { instrumentToolHandler } from "./utils/telemetry.js";
 // ── Availability / Slots ──
 import { getAvailability, getAvailabilitySchema } from "./tools/availability.js";
 // ── Booking Routing Trace ──
@@ -205,7 +206,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getMeSchema,
       annotations: READ_ONLY,
     },
-    getMe
+    instrumentToolHandler("get_me", getMe)
   );
   server.registerTool(
     "update_me",
@@ -216,7 +217,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateMeSchema,
       annotations: UPDATE,
     },
-    updateMe
+    instrumentToolHandler("update_me", updateMe)
   );
 
   // ── Event Types (9) ──
@@ -229,7 +230,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getEventTypesSchema,
       annotations: READ_ONLY,
     },
-    getEventTypes
+    instrumentToolHandler("get_event_types", getEventTypes)
   );
   server.registerTool(
     "get_event_type",
@@ -240,7 +241,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getEventTypeSchema,
       annotations: READ_ONLY,
     },
-    getEventType
+    instrumentToolHandler("get_event_type", getEventType)
   );
   server.registerTool(
     "get_crm_sync_errors",
@@ -251,7 +252,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getCrmSyncErrorsSchema,
       annotations: READ_ONLY,
     },
-    getCrmSyncErrors
+    instrumentToolHandler("get_crm_sync_errors", getCrmSyncErrors)
   );
   server.registerTool(
     "create_event_type",
@@ -262,7 +263,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: createEventTypeSchema,
       annotations: CREATE,
     },
-    createEventType
+    instrumentToolHandler("create_event_type", createEventType)
   );
   server.registerTool(
     "update_event_type",
@@ -273,7 +274,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateEventTypeSchema,
       annotations: UPDATE,
     },
-    updateEventType
+    instrumentToolHandler("update_event_type", updateEventType)
   );
   server.registerTool(
     "delete_event_type",
@@ -284,7 +285,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: deleteEventTypeSchema,
       annotations: DESTRUCTIVE,
     },
-    deleteEventType
+    instrumentToolHandler("delete_event_type", deleteEventType)
   );
   server.registerTool(
     "get_scheduling_config",
@@ -295,7 +296,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getSchedulingConfigSchema,
       annotations: READ_ONLY,
     },
-    getSchedulingConfig
+    instrumentToolHandler("get_scheduling_config", getSchedulingConfig)
   );
   server.registerTool(
     "get_event_type_history",
@@ -306,7 +307,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getEventTypeHistorySchema,
       annotations: READ_ONLY,
     },
-    getEventTypeHistory
+    instrumentToolHandler("get_event_type_history", getEventTypeHistory)
   );
   server.registerTool(
     "get_event_type_settings",
@@ -317,7 +318,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getEventTypeSettingsSchema,
       annotations: READ_ONLY,
     },
-    getEventTypeSettings
+    instrumentToolHandler("get_event_type_settings", getEventTypeSettings)
   );
 
   // ── Bookings (10) ──
@@ -330,7 +331,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingsSchema,
       annotations: READ_ONLY,
     },
-    getBookings
+    instrumentToolHandler("get_bookings", getBookings)
   );
   server.registerTool(
     "get_booking",
@@ -341,7 +342,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingSchema,
       annotations: READ_ONLY,
     },
-    getBooking
+    instrumentToolHandler("get_booking", getBooking)
   );
   server.registerTool(
     "create_booking",
@@ -352,7 +353,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: createBookingSchema,
       annotations: CREATE,
     },
-    createBooking
+    instrumentToolHandler("create_booking", createBooking)
   );
   server.registerTool(
     "reschedule_booking",
@@ -363,7 +364,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: rescheduleBookingSchema,
       annotations: UPDATE,
     },
-    rescheduleBooking
+    instrumentToolHandler("reschedule_booking", rescheduleBooking)
   );
   server.registerTool(
     "cancel_booking",
@@ -374,7 +375,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: cancelBookingSchema,
       annotations: DESTRUCTIVE,
     },
-    cancelBooking
+    instrumentToolHandler("cancel_booking", cancelBooking)
   );
   server.registerTool(
     "confirm_booking",
@@ -385,7 +386,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: confirmBookingSchema,
       annotations: UPDATE,
     },
-    confirmBooking
+    instrumentToolHandler("confirm_booking", confirmBooking)
   );
   server.registerTool(
     "mark_booking_absent",
@@ -396,7 +397,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: markBookingAbsentSchema,
       annotations: UPDATE,
     },
-    markBookingAbsent
+    instrumentToolHandler("mark_booking_absent", markBookingAbsent)
   );
   server.registerTool(
     "get_booking_attendees",
@@ -406,7 +407,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingAttendeesSchema,
       annotations: READ_ONLY,
     },
-    getBookingAttendees
+    instrumentToolHandler("get_booking_attendees", getBookingAttendees)
   );
   server.registerTool(
     "add_booking_attendee",
@@ -417,7 +418,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: addBookingAttendeeSchema,
       annotations: CREATE,
     },
-    addBookingAttendee
+    instrumentToolHandler("add_booking_attendee", addBookingAttendee)
   );
   server.registerTool(
     "get_booking_attendee",
@@ -428,7 +429,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingAttendeeSchema,
       annotations: READ_ONLY,
     },
-    getBookingAttendee
+    instrumentToolHandler("get_booking_attendee", getBookingAttendee)
   );
 
   // ── Schedules (6) ──
@@ -440,7 +441,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getSchedulesSchema,
       annotations: READ_ONLY,
     },
-    getSchedules
+    instrumentToolHandler("get_schedules", getSchedules)
   );
   server.registerTool(
     "get_schedule",
@@ -451,7 +452,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getScheduleSchema,
       annotations: READ_ONLY,
     },
-    getSchedule
+    instrumentToolHandler("get_schedule", getSchedule)
   );
   server.registerTool(
     "create_schedule",
@@ -462,7 +463,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: createScheduleSchema,
       annotations: CREATE,
     },
-    createSchedule
+    instrumentToolHandler("create_schedule", createSchedule)
   );
   server.registerTool(
     "update_schedule",
@@ -473,7 +474,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateScheduleSchema,
       annotations: UPDATE,
     },
-    updateSchedule
+    instrumentToolHandler("update_schedule", updateSchedule)
   );
   server.registerTool(
     "delete_schedule",
@@ -484,7 +485,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: deleteScheduleSchema,
       annotations: DESTRUCTIVE,
     },
-    deleteSchedule
+    instrumentToolHandler("delete_schedule", deleteSchedule)
   );
   server.registerTool(
     "get_default_schedule",
@@ -494,7 +495,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getDefaultScheduleSchema,
       annotations: READ_ONLY,
     },
-    getDefaultSchedule
+    instrumentToolHandler("get_default_schedule", getDefaultSchedule)
   );
 
   // ── Availability / Slots (1) ──
@@ -507,7 +508,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getAvailabilitySchema,
       annotations: READ_ONLY,
     },
-    getAvailability
+    instrumentToolHandler("get_availability", getAvailability)
   );
 
   // ── Calendars (2) ──
@@ -520,7 +521,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getConnectedCalendarsSchema,
       annotations: READ_ONLY,
     },
-    getConnectedCalendars
+    instrumentToolHandler("get_connected_calendars", getConnectedCalendars)
   );
   server.registerTool(
     "get_busy_times",
@@ -531,7 +532,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBusyTimesSchema,
       annotations: READ_ONLY,
     },
-    getBusyTimes
+    instrumentToolHandler("get_busy_times", getBusyTimes)
   );
 
   // ── Conferencing (1) ──
@@ -544,7 +545,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getConferencingAppsSchema,
       annotations: READ_ONLY,
     },
-    getConferencingApps
+    instrumentToolHandler("get_conferencing_apps", getConferencingApps)
   );
 
   // ── Booking Routing Trace (1) ──
@@ -557,7 +558,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getBookingRoutingTraceSchema,
       annotations: READ_ONLY,
     },
-    getBookingRoutingTrace
+    instrumentToolHandler("get_booking_routing_trace", getBookingRoutingTrace)
   );
 
   // ── Routing Forms (1) ──
@@ -570,7 +571,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: calculateRoutingFormSlotsSchema,
       annotations: CREATE,
     },
-    calculateRoutingFormSlots
+    instrumentToolHandler("calculate_routing_form_slots", calculateRoutingFormSlots)
   );
 
   // ── Organizations: Attributes (8) ──
@@ -583,7 +584,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgAttributesSchema,
       annotations: READ_ONLY,
     },
-    getOrgAttributes
+    instrumentToolHandler("get_org_attributes", getOrgAttributes)
   );
   server.registerTool(
     "get_org_attribute",
@@ -594,7 +595,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgAttributeSchema,
       annotations: READ_ONLY,
     },
-    getOrgAttribute
+    instrumentToolHandler("get_org_attribute", getOrgAttribute)
   );
   server.registerTool(
     "get_attribute_options",
@@ -605,7 +606,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getAttributeOptionsSchema,
       annotations: READ_ONLY,
     },
-    getAttributeOptions
+    instrumentToolHandler("get_attribute_options", getAttributeOptions)
   );
   server.registerTool(
     "get_user_attributes",
@@ -616,7 +617,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getUserAttributesSchema,
       annotations: READ_ONLY,
     },
-    getUserAttributes
+    instrumentToolHandler("get_user_attributes", getUserAttributes)
   );
   server.registerTool(
     "get_user_attribute_history",
@@ -627,7 +628,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getUserAttributeHistorySchema,
       annotations: READ_ONLY,
     },
-    getUserAttributeHistory
+    instrumentToolHandler("get_user_attribute_history", getUserAttributeHistory)
   );
   server.registerTool(
     "assign_attribute_to_user",
@@ -638,7 +639,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: assignAttributeToUserSchema,
       annotations: CREATE,
     },
-    assignAttributeToUser
+    instrumentToolHandler("assign_attribute_to_user", assignAttributeToUser)
   );
   server.registerTool(
     "update_user_attribute",
@@ -649,7 +650,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateUserAttributeSchema,
       annotations: UPDATE,
     },
-    updateUserAttribute
+    instrumentToolHandler("update_user_attribute", updateUserAttribute)
   );
   server.registerTool(
     "unassign_attribute_from_user",
@@ -660,7 +661,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: unassignAttributeFromUserSchema,
       annotations: DESTRUCTIVE,
     },
-    unassignAttributeFromUser
+    instrumentToolHandler("unassign_attribute_from_user", unassignAttributeFromUser)
   );
 
   // ── Organizations: Bookings (2) ──
@@ -673,7 +674,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgTeamBookingsSchema,
       annotations: READ_ONLY,
     },
-    getOrgTeamBookings
+    instrumentToolHandler("get_org_team_bookings", getOrgTeamBookings)
   );
   server.registerTool(
     "get_org_user_bookings",
@@ -684,7 +685,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgUserBookingsSchema,
       annotations: READ_ONLY,
     },
-    getOrgUserBookings
+    instrumentToolHandler("get_org_user_bookings", getOrgUserBookings)
   );
 
   // ── Organizations: Memberships (5) ──
@@ -697,7 +698,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgMembershipsSchema,
       annotations: READ_ONLY,
     },
-    getOrgMemberships
+    instrumentToolHandler("get_org_memberships", getOrgMemberships)
   );
   server.registerTool(
     "create_org_membership",
@@ -708,7 +709,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: createOrgMembershipSchema,
       annotations: CREATE,
     },
-    createOrgMembership
+    instrumentToolHandler("create_org_membership", createOrgMembership)
   );
   server.registerTool(
     "get_org_membership",
@@ -718,7 +719,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgMembershipSchema,
       annotations: READ_ONLY,
     },
-    getOrgMembership
+    instrumentToolHandler("get_org_membership", getOrgMembership)
   );
   server.registerTool(
     "delete_org_membership",
@@ -729,7 +730,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: deleteOrgMembershipSchema,
       annotations: DESTRUCTIVE,
     },
-    deleteOrgMembership
+    instrumentToolHandler("delete_org_membership", deleteOrgMembership)
   );
   server.registerTool(
     "update_org_membership",
@@ -740,7 +741,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateOrgMembershipSchema,
       annotations: UPDATE,
     },
-    updateOrgMembership
+    instrumentToolHandler("update_org_membership", updateOrgMembership)
   );
 
   // ── Organizations: Teams (2) ──
@@ -753,7 +754,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgTeamsSchema,
       annotations: READ_ONLY,
     },
-    getOrgTeams
+    instrumentToolHandler("get_org_teams", getOrgTeams)
   );
   server.registerTool(
     "get_my_teams",
@@ -764,7 +765,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getMyTeamsSchema,
       annotations: READ_ONLY,
     },
-    getMyTeams
+    instrumentToolHandler("get_my_teams", getMyTeams)
   );
 
   // ── Organizations: Routing Forms (2) ──
@@ -777,7 +778,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgRoutingFormsSchema,
       annotations: READ_ONLY,
     },
-    getOrgRoutingForms
+    instrumentToolHandler("get_org_routing_forms", getOrgRoutingForms)
   );
   server.registerTool(
     "get_org_routing_form_responses",
@@ -788,7 +789,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getOrgRoutingFormResponsesSchema,
       annotations: READ_ONLY,
     },
-    getOrgRoutingFormResponses
+    instrumentToolHandler("get_org_routing_form_responses", getOrgRoutingFormResponses)
   );
 
   // ── Teams: Memberships (6) ──
@@ -801,7 +802,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getTeamMembershipsSchema,
       annotations: READ_ONLY,
     },
-    getTeamMemberships
+    instrumentToolHandler("get_team_memberships", getTeamMemberships)
   );
   server.registerTool(
     "get_team_membership",
@@ -812,7 +813,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: getTeamMembershipSchema,
       annotations: READ_ONLY,
     },
-    getTeamMembership
+    instrumentToolHandler("get_team_membership", getTeamMembership)
   );
   server.registerTool(
     "create_team_membership",
@@ -823,7 +824,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: createTeamMembershipSchema,
       annotations: CREATE,
     },
-    createTeamMembership
+    instrumentToolHandler("create_team_membership", createTeamMembership)
   );
   server.registerTool(
     "update_team_membership",
@@ -834,7 +835,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: updateTeamMembershipSchema,
       annotations: UPDATE,
     },
-    updateTeamMembership
+    instrumentToolHandler("update_team_membership", updateTeamMembership)
   );
   server.registerTool(
     "delete_team_membership",
@@ -845,7 +846,7 @@ export function registerTools(server: McpServer): void {
       inputSchema: deleteTeamMembershipSchema,
       annotations: DESTRUCTIVE,
     },
-    deleteTeamMembership
+    instrumentToolHandler("delete_team_membership", deleteTeamMembership)
   );
   server.registerTool(
     "create_team_invite",
@@ -856,6 +857,6 @@ export function registerTools(server: McpServer): void {
       inputSchema: createTeamInviteSchema,
       annotations: CREATE,
     },
-    createTeamInvite
+    instrumentToolHandler("create_team_invite", createTeamInvite)
   );
 }

--- a/apps/mcp-server/src/utils/telemetry.test.ts
+++ b/apps/mcp-server/src/utils/telemetry.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const span = {
+    end: vi.fn(),
+    recordException: vi.fn(),
+    setAttribute: vi.fn(),
+    setStatus: vi.fn(),
+  };
+  const startActiveSpan = vi.fn(
+    async (
+      _name: string,
+      _options: unknown,
+      callback: (activeSpan: typeof span) => Promise<unknown>
+    ) => callback(span)
+  );
+  return { span, startActiveSpan };
+});
+
+vi.mock("@opentelemetry/api", () => ({
+  SpanKind: { SERVER: 1 },
+  SpanStatusCode: { ERROR: 2 },
+  trace: {
+    getTracer: () => ({ startActiveSpan: mocks.startActiveSpan }),
+  },
+}));
+
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import { instrumentMcpTransport, instrumentToolHandler } from "./telemetry.js";
+
+function createTransport(): Transport {
+  return {
+    start: vi.fn(async () => {}),
+    send: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+  };
+}
+
+describe("instrumentMcpTransport", () => {
+  beforeEach(() => {
+    mocks.span.end.mockClear();
+    mocks.span.recordException.mockClear();
+    mocks.span.setAttribute.mockClear();
+    mocks.span.setStatus.mockClear();
+    mocks.startActiveSpan.mockClear();
+  });
+
+  it.each([
+    "initialize",
+    "tools/list",
+  ])("traces %s until its JSON-RPC response is sent", async (method) => {
+    const transport = createTransport();
+    const instrumented = instrumentMcpTransport(transport);
+    const forwarded: JSONRPCMessage[] = [];
+    instrumented.onmessage = (message) => forwarded.push(message);
+    await instrumented.start();
+
+    const request = { jsonrpc: "2.0" as const, id: 42, method };
+    transport.onmessage?.(request, {});
+
+    expect(forwarded).toEqual([request]);
+    expect(mocks.startActiveSpan).toHaveBeenCalledWith(
+      method,
+      {
+        kind: 1,
+        attributes: { "mcp.method.name": method },
+      },
+      expect.any(Function)
+    );
+    expect(mocks.span.end).not.toHaveBeenCalled();
+
+    await instrumented.send({ jsonrpc: "2.0", id: 42, result: {} });
+
+    expect(transport.send).toHaveBeenCalledOnce();
+    expect(mocks.span.end).toHaveBeenCalledOnce();
+  });
+
+  it("records the negotiated protocol version on initialize and later operations", async () => {
+    const transport = createTransport();
+    const instrumented = instrumentMcpTransport(transport);
+    instrumented.onmessage = vi.fn();
+    await instrumented.start();
+
+    transport.onmessage?.({ jsonrpc: "2.0", id: 1, method: "initialize" }, {});
+    await instrumented.send({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { protocolVersion: "2025-11-25" },
+    });
+    transport.onmessage?.({ jsonrpc: "2.0", id: 2, method: "tools/list" }, {});
+
+    expect(mocks.span.setAttribute).toHaveBeenCalledWith("mcp.protocol.version", "2025-11-25");
+    expect(mocks.startActiveSpan).toHaveBeenLastCalledWith(
+      "tools/list",
+      {
+        kind: 1,
+        attributes: {
+          "mcp.method.name": "tools/list",
+          "mcp.protocol.version": "2025-11-25",
+        },
+      },
+      expect.any(Function)
+    );
+  });
+
+  it("marks JSON-RPC errors without recording their message", async () => {
+    const transport = createTransport();
+    const instrumented = instrumentMcpTransport(transport);
+    instrumented.onmessage = vi.fn();
+    await instrumented.start();
+
+    transport.onmessage?.({ jsonrpc: "2.0", id: "list-1", method: "tools/list" }, {});
+    await instrumented.send({
+      jsonrpc: "2.0",
+      id: "list-1",
+      error: { code: -32603, message: "sensitive internal detail" },
+    });
+
+    expect(mocks.span.setAttribute.mock.calls).toEqual([["error.type", "-32603"]]);
+    expect(mocks.span.setStatus).toHaveBeenCalledWith({ code: 2 });
+    expect(mocks.span.recordException).not.toHaveBeenCalled();
+    expect(mocks.span.end).toHaveBeenCalledOnce();
+  });
+
+  it("forwards other MCP messages without creating a span", async () => {
+    const transport = createTransport();
+    const instrumented = instrumentMcpTransport(transport);
+    instrumented.onmessage = vi.fn();
+    await instrumented.start();
+
+    transport.onmessage?.(
+      { jsonrpc: "2.0", id: 7, method: "tools/call", params: { name: "get_me" } },
+      {}
+    );
+
+    expect(instrumented.onmessage).toHaveBeenCalledOnce();
+    expect(mocks.startActiveSpan).not.toHaveBeenCalled();
+  });
+});
+
+describe("instrumentToolHandler", () => {
+  beforeEach(() => {
+    mocks.span.end.mockClear();
+    mocks.span.recordException.mockClear();
+    mocks.span.setAttribute.mockClear();
+    mocks.span.setStatus.mockClear();
+    mocks.startActiveSpan.mockClear();
+  });
+
+  it("records only bounded tool metadata and successful completion", async () => {
+    const handler = vi.fn(async (input: { email: string }) => ({ content: input.email }));
+    const instrumented = instrumentToolHandler("get_me", handler);
+
+    await expect(instrumented({ email: "private@example.com" })).resolves.toEqual({
+      content: "private@example.com",
+    });
+
+    expect(mocks.startActiveSpan).toHaveBeenCalledWith(
+      "tools/call get_me",
+      {
+        kind: 1,
+        attributes: {
+          "mcp.method.name": "tools/call",
+          "gen_ai.operation.name": "execute_tool",
+          "gen_ai.tool.name": "get_me",
+        },
+      },
+      expect.any(Function)
+    );
+    expect(mocks.span.setStatus).not.toHaveBeenCalled();
+    expect(mocks.span.setAttribute).not.toHaveBeenCalled();
+    expect(mocks.span.recordException).not.toHaveBeenCalled();
+    expect(mocks.span.end).toHaveBeenCalledOnce();
+  });
+
+  it("marks failures without attaching exception details", async () => {
+    const failure = new Error("secret upstream response");
+    const instrumented = instrumentToolHandler("create_booking", async () => {
+      throw failure;
+    });
+
+    await expect(instrumented()).rejects.toBe(failure);
+
+    expect(mocks.span.setAttribute.mock.calls).toEqual([["error.type", "Error"]]);
+    expect(mocks.span.setStatus).toHaveBeenCalledWith({ code: 2 });
+    expect(mocks.span.recordException).not.toHaveBeenCalled();
+    expect(mocks.span.end).toHaveBeenCalledOnce();
+  });
+
+  it("marks MCP error results as failures", async () => {
+    const instrumented = instrumentToolHandler("get_me", async () => ({
+      content: [{ type: "text", text: "safe client-facing error" }],
+      isError: true,
+    }));
+
+    await instrumented();
+
+    expect(mocks.span.setAttribute).toHaveBeenCalledWith("error.type", "tool_error");
+    expect(mocks.span.setStatus).toHaveBeenCalledWith({ code: 2 });
+    expect(mocks.span.end).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mcp-server/src/utils/telemetry.ts
+++ b/apps/mcp-server/src/utils/telemetry.ts
@@ -1,0 +1,172 @@
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { RequestId } from "@modelcontextprotocol/sdk/types.js";
+import { type Span, SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
+
+const tracer = trace.getTracer("@calcom/mcp-server", "0.1.0");
+const TRACED_MCP_METHODS = new Set(["initialize", "tools/list"]);
+
+function errorType(error: unknown): string {
+  return error instanceof Error && error.constructor.name ? error.constructor.name : "_OTHER";
+}
+
+function markSpanError(span: Span, type: string): void {
+  span.setAttribute("error.type", type);
+  span.setStatus({ code: SpanStatusCode.ERROR });
+}
+
+/**
+ * Add MCP server spans for protocol operations handled internally by the SDK.
+ *
+ * The SDK owns its request handlers and its message callback does not return the
+ * handler promise. Wrapping the transport lets each span start when a request is
+ * received and end after the matching JSON-RPC response has been sent.
+ */
+export function instrumentMcpTransport(transport: Transport): Transport {
+  const activeRequests = new Map<RequestId, Span>();
+  let protocolVersion: string | undefined;
+
+  const wrappedTransport: Transport = {
+    get sessionId() {
+      return transport.sessionId;
+    },
+    setProtocolVersion: transport.setProtocolVersion
+      ? (version: string) => transport.setProtocolVersion?.(version)
+      : undefined,
+    async start(): Promise<void> {
+      const previousOnClose = transport.onclose;
+      const previousOnError = transport.onerror;
+
+      transport.onclose = () => {
+        for (const span of activeRequests.values()) {
+          markSpanError(span, "connection_closed");
+          span.end();
+        }
+        activeRequests.clear();
+        previousOnClose?.();
+        wrappedTransport.onclose?.();
+      };
+      transport.onerror = (error) => {
+        previousOnError?.(error);
+        wrappedTransport.onerror?.(error);
+      };
+      transport.onmessage = (message, extra) => {
+        if (
+          !("method" in message) ||
+          !("id" in message) ||
+          message.id == null ||
+          !TRACED_MCP_METHODS.has(message.method)
+        ) {
+          wrappedTransport.onmessage?.(message, extra);
+          return;
+        }
+
+        const attributes: Record<string, string> = {
+          "mcp.method.name": message.method,
+        };
+        if (protocolVersion) attributes["mcp.protocol.version"] = protocolVersion;
+
+        tracer.startActiveSpan(
+          message.method,
+          { kind: SpanKind.SERVER, attributes },
+          (span: Span) => {
+            activeRequests.set(message.id, span);
+            try {
+              wrappedTransport.onmessage?.(message, extra);
+            } catch (error) {
+              activeRequests.delete(message.id);
+              markSpanError(span, errorType(error));
+              span.end();
+              throw error;
+            }
+          }
+        );
+      };
+
+      await transport.start();
+    },
+    async send(message, options): Promise<void> {
+      const span =
+        "id" in message && message.id != null && !("method" in message)
+          ? activeRequests.get(message.id)
+          : undefined;
+
+      try {
+        if (span && "result" in message) {
+          const result = message.result;
+          if (
+            typeof result === "object" &&
+            result !== null &&
+            "protocolVersion" in result &&
+            typeof result.protocolVersion === "string"
+          ) {
+            protocolVersion = result.protocolVersion;
+            span.setAttribute("mcp.protocol.version", protocolVersion);
+          }
+        } else if (span && "error" in message) {
+          markSpanError(span, String(message.error.code));
+        }
+
+        await transport.send(message, options);
+      } catch (error) {
+        if (span) markSpanError(span, errorType(error));
+        throw error;
+      } finally {
+        if (span && "id" in message && message.id != null) {
+          activeRequests.delete(message.id);
+          span.end();
+        }
+      }
+    },
+    async close(): Promise<void> {
+      await transport.close();
+    },
+  };
+
+  return wrappedTransport;
+}
+
+/**
+ * Add a bounded span around an MCP tool handler.
+ *
+ * Tool names come from the server's static registry. Arguments, results, user
+ * identifiers, tokens, and exception details are deliberately not recorded.
+ * Without an initialized OpenTelemetry SDK (the default for stdio and
+ * self-hosted deployments), the API supplies a no-op tracer.
+ */
+export function instrumentToolHandler<TArgs extends unknown[], TResult>(
+  toolName: string,
+  handler: (...args: TArgs) => TResult | Promise<TResult>
+): (...args: TArgs) => Promise<TResult> {
+  return (...args: TArgs): Promise<TResult> =>
+    tracer.startActiveSpan(
+      `tools/call ${toolName}`,
+      {
+        kind: SpanKind.SERVER,
+        attributes: {
+          "mcp.method.name": "tools/call",
+          "gen_ai.operation.name": "execute_tool",
+          "gen_ai.tool.name": toolName,
+        },
+      },
+      async (span: Span): Promise<TResult> => {
+        try {
+          const result = await handler(...args);
+          const isMcpError =
+            typeof result === "object" &&
+            result !== null &&
+            "isError" in result &&
+            result.isError === true;
+          if (isMcpError) {
+            span.setAttribute("error.type", "tool_error");
+            span.setStatus({ code: SpanStatusCode.ERROR });
+          }
+          return result;
+        } catch (error) {
+          markSpanError(span, errorType(error));
+          throw error;
+        } finally {
+          span.end();
+        }
+      }
+    );
+}

--- a/apps/mcp-server/src/vercel-handler.ts
+++ b/apps/mcp-server/src/vercel-handler.ts
@@ -25,6 +25,7 @@ import { SERVER_INSTRUCTIONS } from "./server-instructions.js";
 import { initDb, sql } from "./storage/db.js";
 import { countRegisteredClients } from "./storage/token-store.js";
 import { applyCorsHeaders, resolveCorsOrigin } from "./utils/http-security.js";
+import { instrumentMcpTransport } from "./utils/telemetry.js";
 
 /**
  * Vercel serverless entry point.
@@ -332,7 +333,7 @@ export default async function handler(req: IncomingMessage, res: ServerResponse)
       { instructions: SERVER_INSTRUCTIONS }
     );
     registerTools(server);
-    await server.connect(transport);
+    await server.connect(instrumentMcpTransport(transport));
 
     // 55 s gives a ~5 s buffer before Vercel's 60 s hard limit.
     const timeoutMs = 55_000;

--- a/apps/mcp-server/tsconfig.check.json
+++ b/apps/mcp-server/tsconfig.check.json
@@ -1,7 +1,17 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": ".",
     "skipLibCheck": true
   },
-  "exclude": ["node_modules", "dist", "src/index.ts", "src/register-tools.ts", "src/http-server.ts", "src/vercel-handler.ts", "src/**/*.test.ts"]
+  "include": ["src/**/*", "instrumentation.ts"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/index.ts",
+    "src/register-tools.ts",
+    "src/http-server.ts",
+    "src/vercel-handler.ts",
+    "src/**/*.test.ts"
+  ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
+        "@opentelemetry/api": "1.9.0",
+        "@vercel/otel": "2.0.1",
         "@vercel/postgres": "0.10.0",
         "zod": "3.25.76",
       },
@@ -770,6 +772,24 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.222.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-9mb1If+IF6u0ZVXkHQ6ogEae5HwA6ajIVUgpSDQyRASxft6BSXHvBvPooRle3yFN/fKnCdSOnuu0OC3PLcF6+g=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.11.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.222.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.222.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fhbRDuAgzPKpq1k5+hX3uS+3QAYNca0on0Ngot/R8dDsQtuFaADeZnG2uSgxABuvcI7S2phAaRhbct9jieeKZw=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.11.0", "", { "dependencies": { "@opentelemetry/core": "2.11.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.222.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.222.0", "@opentelemetry/core": "2.11.0", "@opentelemetry/resources": "2.11.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-+19YHODIjaUCArxleaJtuufFZVpz/xvvK+VllQqE+W8hHolxdoRwHfK/s667zezwh1hkx6FFF+oYzetYgqK+Bg=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.11.0", "", { "dependencies": { "@opentelemetry/core": "2.11.0", "@opentelemetry/resources": "2.11.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-7GXXcObyHyDUUSG+L+kJoquty01bzm7ivE7+SSgXXJcHuPzGviptxwARmI2c+bnnxjexGQbJnyNlN8HxBP/Y7A=="],
+
+    "@opentelemetry/sdk-trace": ["@opentelemetry/sdk-trace@2.11.0", "", { "dependencies": { "@opentelemetry/core": "2.11.0", "@opentelemetry/resources": "2.11.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-fFnTqGm8/G73GQVnxYi7LXa1ZVYEUvgL6XI1LpvV0bPC7WQ/ZGgKxCSl8FnlZBKto9JHHEFTO6s6CUpvvtwFrA=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.11.0", "", { "dependencies": { "@opentelemetry/core": "2.11.0", "@opentelemetry/resources": "2.11.0", "@opentelemetry/sdk-trace": "2.11.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-H19x/TX/LZdqiYOjM7fqtSxwlplC5pgelavqbQdHbhdq0q/AI/TGkM2dfGuuynTXmJPeF2HoZVoPDu+TGoW78A=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
+
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@pkgr/core": ["@pkgr/core@0.3.6", "", {}, "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA=="],
@@ -1135,6 +1155,8 @@
     "@vercel/functions": ["@vercel/functions@3.4.3", "", { "dependencies": { "@vercel/oidc": "3.2.0" }, "peerDependencies": { "@aws-sdk/credential-provider-web-identity": "*" }, "optionalPeers": ["@aws-sdk/credential-provider-web-identity"] }, "sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
+
+    "@vercel/otel": ["@vercel/otel@2.0.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <2.0.0", "@opentelemetry/api-logs": ">=0.200.0 <0.300.0", "@opentelemetry/instrumentation": ">=0.200.0 <0.300.0", "@opentelemetry/resources": ">=2.0.0 <3.0.0", "@opentelemetry/sdk-logs": ">=0.200.0 <0.300.0", "@opentelemetry/sdk-metrics": ">=2.0.0 <3.0.0", "@opentelemetry/sdk-trace-base": ">=2.0.0 <3.0.0" } }, "sha512-eC8F8t9Ksn6xPBXBef7w2pMVcgjXoUOMJ3gnTs4Yh/zbKSIKfvX17GjyqCODwF9FdbiiPBxLsF8aQxFOtKyiEA=="],
 
     "@vercel/postgres": ["@vercel/postgres@0.10.0", "", { "dependencies": { "@neondatabase/serverless": "^0.9.3", "bufferutil": "^4.0.8", "ws": "^8.17.1" } }, "sha512-fSD23DxGND40IzSkXjcFcxr53t3Tiym59Is0jSYIFpG4/0f0KO9SGtcp1sXiebvPaGe7N/tU05cH4yt2S6/IPg=="],
 
@@ -1882,6 +1904,8 @@
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
+    "import-in-the-middle": ["import-in-the-middle@3.4.0", "", { "dependencies": { "cjs-module-lexer": "^2.2.0", "es-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-Xfjwfarhe+LGmoaof+sexeNo3sGRysb5x56WrZLwHtmqT0OilSKtVWkv0lrCcMgSKyKP9oBogBAisHZvtJH0aw=="],
+
     "import-local": ["import-local@3.2.0", "", { "dependencies": { "pkg-dir": "^4.2.0", "resolve-cwd": "^3.0.0" }, "bin": { "import-local-fixture": "fixtures/cli.js" } }, "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA=="],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
@@ -2332,6 +2356,8 @@
 
     "mobile": ["mobile@workspace:apps/mobile"],
 
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
+
     "ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
     "multimatch": ["multimatch@6.0.0", "", { "dependencies": { "@types/minimatch": "^3.0.5", "array-differ": "^4.0.0", "array-union": "^3.0.1", "minimatch": "^3.0.4" } }, "sha512-I7tSVxHGPlmPN/enE3mS1aOSo6bWBfls+3HmuEeCUBCE7gWnm3cBXCBkpurzFjVRwC6Kld8lLaZ1Iv5vOcjvcQ=="],
@@ -2685,6 +2711,8 @@
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "requireg": ["requireg@0.2.2", "", { "dependencies": { "nested-error-stacks": "~2.0.1", "rc": "~1.2.7", "resolve": "~1.7.1" } }, "sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg=="],
 
@@ -3528,6 +3556,8 @@
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
+    "import-in-the-middle/es-module-lexer": ["es-module-lexer@2.3.2", "", {}, "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw=="],
+
     "ioredis/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "is-core-module/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
@@ -3763,6 +3793,8 @@
     "react-native-worklets/@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
 
     "react-native-worklets/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "require-in-the-middle/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "requireg/resolve": ["resolve@1.7.1", "", { "dependencies": { "path-parse": "^1.0.5" } }, "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw=="],
 
@@ -4359,6 +4391,8 @@
     "react-native/pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "react-native/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
+
+    "require-in-the-middle/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 


### PR DESCRIPTION
## What & why

Add Vercel's supported OpenTelemetry setup to the MCP server and emit MCP semantic-convention spans for tool execution, initialization, and tool discovery. This gives the service useful traces under the stable `cal-mcp-server` service name without recording tool arguments, results, credentials, user identifiers, or exception messages.

User story: As an MCP operator, I want MCP protocol operations and tool executions traced, so that I can diagnose latency and failures in production.

- Fixes FOUND-518

## Out of scope

Enabling Vercel Always-on Tracing, configuring sampling rules, and adding a Trace Drain or Grafana integration remain deployment configuration. Automatic database instrumentation and changes to Vercel edge-network root-span naming are separate observability follow-ups.

## How to test

No new environment variables are required. A deployed end-to-end check needs the existing MCP OAuth configuration, Vercel tracing enabled with a sampling rule, and a valid Cal.com access token.

1. From `apps/mcp-server`, run `bun run test` → all MCP tests pass, including the Vercel registration and protocol/tool span coverage.
2. From `apps/mcp-server`, run `bun run typecheck` and `bun run lint` → both complete without errors.
3. Deploy the MCP server to a Vercel preview with tracing enabled → invoke MCP `initialize`, `tools/list`, and any registered tool → traces appear under service `cal-mcp-server` with `initialize`, `tools/list`, and `tools/call <tool_name>` server spans.
4. Inspect the emitted span attributes → MCP spans include the recommended bounded method/tool metadata and error status, while request arguments, response bodies, tokens, user identifiers, and exception messages are absent.

## Visual demo

N/A — backend-only observability change.

## Risk & rollback

Blast radius is limited to MCP server telemetry. Vercel deployments initialize the SDK automatically; stdio and self-hosted HTTP remain no-op unless an operator registers an OpenTelemetry provider. There are no migrations, data writes, or feature flags. Roll back by reverting this commit; Vercel sampling and drains can also be disabled independently without a code deployment.

## Reviewer callouts

- New dependency: `@vercel/otel` provides Vercel's supported zero-configuration OpenTelemetry setup for non-Next.js functions; `@opentelemetry/api` provides vendor-neutral custom spans and remains no-op when no SDK is registered.
- Size justification past the ~500-line / ~10-file checkpoint: the functional implementation is small; most changed lines are the mechanical wrapping of every registered MCP tool plus focused tests for successful, failed, initialization, and listing spans.

## Mandatory checks

- [x] I have self-reviewed the code (a decent size PR without self-review might be rejected).
- [x] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). N/A — no public docs change is required; MCP operator behavior is documented in `apps/mcp-server/README.md`.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.
- [x] I have updated the capability spec in the same PR when behaviour changed. N/A — telemetry does not change the MCP capability contract.
